### PR TITLE
Force initialization of default values after creation of the default RedisTemplate

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
@@ -298,6 +298,7 @@ public class RedisOperationsSessionRepository implements SessionRepository<Redis
         template.setKeySerializer(new StringRedisSerializer());
         template.setHashKeySerializer(new StringRedisSerializer());
         template.setConnectionFactory(connectionFactory);
+        template.afterPropertiesSet(); //Force initialization of default values
         return template;
     }
 


### PR DESCRIPTION
There's a small bug within the createDefaultTemplate logic when passing only a connectionFactory to the constructor - it doesn't call afterPropertiesSet() which would normally be called in order to set the various default values - in particular the hashValueSerializer. Without this, you get an NPE when trying to save the session within AbstractRawOperations:146 as the hashValueSerializer is null.
