### PR TITLE
Add the Spring IO plugin to spring-session and spring-session-data-redis

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -20,6 +20,7 @@ ext.jedisVersion = '2.4.1'
 ext.commonsPoolVersion = '2.2'
 ext.embeddedRedisVersion = '0.2'
 ext.springDataRedisVersion = '1.3.0.RELEASE'
+ext.springIoVersion = project.hasProperty('platformVersion') ? platformVersion : '1.1.0.BUILD-SNAPSHOT'
 
 ext.spockDependencies = [
         dependencies.create("org.spockframework:spock-core:$spockVersion") {

--- a/spring-session-data-redis/build.gradle
+++ b/spring-session-data-redis/build.gradle
@@ -1,9 +1,13 @@
 apply from: JAVA_GRADLE
 apply from: MAVEN_GRADLE
 
+apply plugin: 'spring-io'
+
 dependencies {
     compile project(':spring-session'),
             "org.springframework.data:spring-data-redis:$springDataRedisVersion",
             "redis.clients:jedis:$jedisVersion",
             "org.apache.commons:commons-pool2:$commonsPoolVersion"
+
+    springIoVersions "io.spring.platform:platform-versions:${springIoVersion}@properties"
 }

--- a/spring-session/build.gradle
+++ b/spring-session/build.gradle
@@ -1,6 +1,8 @@
 apply from: JAVA_GRADLE
 apply from: MAVEN_GRADLE
 
+apply plugin: 'spring-io'
+
 project.conf2ScopeMappings.addMapping(MavenPlugin.TEST_COMPILE_PRIORITY + 1, project.configurations.getByName("integrationTestCompile"), Conf2ScopeMappingContainer.TEST)
 project.conf2ScopeMappings.addMapping(MavenPlugin.TEST_COMPILE_PRIORITY + 2, project.configurations.getByName("integrationTestRuntime"), Conf2ScopeMappingContainer.TEST)
 check.dependsOn integrationTest
@@ -26,6 +28,8 @@ dependencies {
             "org.springframework.security:spring-security-core:$springSecurityVersion"
 
     jacoco "org.jacoco:org.jacoco.agent:0.6.2.201302030002:runtime"
+
+    springIoVersions "io.spring.platform:platform-versions:${springIoVersion}@properties"
 }
 
 ext.javadocLinks = [


### PR DESCRIPTION
This change paves the way for Spring Session's inclusion in Spring IO 1.1 (see spring-io/platform#58). 

Note that I've added the plugin to `spring-session-data-rest` which does not yet contain any code. I'm not sure what the plans are for this module, but validating its dependencies and checking that they're covered by the Platform seemed like the right thing to do.