### PR TITLE
Small improvement to WebSocket guide

### DIFF
--- a/docs/src/docs/asciidoc/guides/websocket.adoc
+++ b/docs/src/docs/asciidoc/guides/websocket.adoc
@@ -32,7 +32,20 @@ For example, the configuration might look something like the following:
 include::{websocketdoc-test-dir}WebSocketConfig.java[tags=class]
 ----
 
-To hook in the Spring Session support, we need to ensure
+To hook in the Spring Session support we only need to change two things:
+
+<1> Instead of extending `AbstractWebSocketMessageBrokerConfigurer` we extend `AbstractSessionWebSocketMessageBrokerConfigurer`
+<2> We rename the `registerStompEndpoints` method to `configureStompEndpoints`
+
+For example:
+
+.src/main/java/samples/config/WebSocketConfig.java
+[source,java]
+----
+include::{samples-dir}websocket/src/main/java/sample/config/WebSocketConfig.java[tags=class]
+----
+
+If interested in more details, here are the things the base class does:
 
 * `WebSocketConnectHandlerDecoratorFactory` is added as a `WebSocketHandlerDecoratorFactory` to `WebSocketTransportRegistration`.
 This ensures a custom `SessionConnectEvent` is fired that contains the `WebSocketSession`.
@@ -45,20 +58,6 @@ This ensures that every time an inbound message is received, that the last acces
 This ensures that we have a mapping of all of the Session id to the corresponding WebSocket connections.
 By maintaining this mapping, we can close all the WebSocket connections when a Spring Session (HttpSession) is terminated.
 
-This is quite a bit of work to get things working.
-Fortunately, Spring Session provides a convenience class named `AbstractSessionWebSocketMessageBrokerConfigurer` that hides the complexity of the configuration.
-An example is provided below:
-
-.src/main/java/samples/config/WebSocketConfig.java
-[source,java]
-----
-include::{samples-dir}websocket/src/main/java/sample/config/WebSocketConfig.java[tags=class]
-----
-
-We only need to change two things to use Spring Session:
-
-<1> Instead of extending `AbstractWebSocketMessageBrokerConfigurer` we extend `AbstractSessionWebSocketMessageBrokerConfigurer`
-<2> We rename the `registerStompEndpoints` method to `configureStompEndpoints`
 
 // end::config[]
 


### PR DESCRIPTION
Simply move content around so that we first show what needs to be
done and then explain what is done internally. Arguably this is an
easier way to digest since the former is required knowledge while
the latter is optional.
