### PR TITLE
Change gradlew run command to bootRun

### DIFF
--- a/docs/src/docs/asciidoc/guides/boot.adoc
+++ b/docs/src/docs/asciidoc/guides/boot.adoc
@@ -111,7 +111,7 @@ The boot Sample Application demonstrates how to use Spring Session to transparen
 
 You can run the sample by obtaining the {download-url}[source code] and invoking the following command:
 
-  $ ./gradlew :samples:boot:tomcatRun
+  $ ./gradlew :samples:boot:bootRun
 
 You should now be able to access the application at http://localhost:8080/
 


### PR DESCRIPTION
In contrast to :tomcatRun :bootRun works for me.

For :tomcatRun I was getting: Task 'tomcatRun' not found in project ':samples:boot'.