### PR TITLE
pump spring-data-redis version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,6 @@ jstlVersion=1.2.1
 seleniumVersion=2.44.0
 servletApiVersion=3.0.1
 spockVersion=0.7-groovy-2.0
-springDataRedisVersion=1.3.0.RELEASE
+springDataRedisVersion=1.4.1.RELEASE
 springSecurityVersion=4.0.0.RC1
 springVersion=4.1.3.RELEASE


### PR DESCRIPTION
App fails to start when specifying `@EnableRedisHttpSession` with a `ClassNotFoundException` looking for `RedisSentinelConfiguration`. Confirmed that pumping the spring-data-redis version resolves this issue.

Workaround:
> build.gradle
```groovy
  compile('org.springframework.session:spring-session-data-redis:1.0.0.RELEASE') {
    exclude module: 'spring-data-redis'
  }
  compile 'org.springframework.data:spring-data-redis:1.4.1.RELEASE'
```