### PR TITLE
Ensure SessionRepositoryFilter always sends cookie if its value changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ bin
 .settings
 .project
 target
+pom.xml
 out
 .springBeans

--- a/spring-session/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
+++ b/spring-session/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
@@ -182,7 +182,7 @@ public class SessionRepositoryFilter<S extends ExpiringSession> extends OncePerR
             } else {
                 S session = wrappedSession.session;
                 sessionRepository.save(session);
-                if(!requestedValidSession || alwaysSendCookie) {
+                if(!requestedValidSession || alwaysSendCookie || !session.getId().equals(getRequestedSessionId())) {
                     httpSessionStrategy.onNewSession(session, this, response);
                 }
             }

--- a/spring-session/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
+++ b/spring-session/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
@@ -62,6 +62,8 @@ public class SessionRepositoryFilter<S extends ExpiringSession> extends OncePerR
 
     private MultiHttpSessionStrategy httpSessionStrategy = new CookieHttpSessionStrategy();
 
+	public boolean alwaysSendCookie;
+	
     /**
      * Creates a new instance
      *
@@ -97,6 +99,16 @@ public class SessionRepositoryFilter<S extends ExpiringSession> extends OncePerR
         }
         this.httpSessionStrategy = httpSessionStrategy;
     }
+
+	/**
+	 * Flag to indicate that the filter should always send a cookie with the session id,
+	 * even if the caller sent a valid value in the incoming request.
+	 *  
+	 * @param alwaysSendCookie flag value (default false)
+	 */
+	public void setAlwaysSendCookie(boolean alwaysSendCookie) {
+		this.alwaysSendCookie = alwaysSendCookie;
+	}
 
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         request.setAttribute(SESSION_REPOSITORY_ATTR, sessionRepository);
@@ -170,7 +182,7 @@ public class SessionRepositoryFilter<S extends ExpiringSession> extends OncePerR
             } else {
                 S session = wrappedSession.session;
                 sessionRepository.save(session);
-                if(!requestedValidSession) {
+                if(!requestedValidSession || alwaysSendCookie) {
                     httpSessionStrategy.onNewSession(session, this, response);
                 }
             }

--- a/spring-session/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
+++ b/spring-session/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
@@ -317,12 +317,38 @@ public class SessionRepositoryFilterTests<S extends ExpiringSession> {
 
         setupSession();
 
+        response.reset();
         doFilter(new DoInFilter() {
             @Override
             public void doFilter(HttpServletRequest wrappedRequest) {
                 assertThat(wrappedRequest.getSession().isNew()).isFalse();
             }
         });
+        assertThat(response.getCookie("SESSION")).isNull();
+    }
+
+    @Test
+    public void doFilterIsNewTrueWithFlag() throws Exception {
+    	filter.setAlwaysSendCookie(true);
+        doFilter(new DoInFilter() {
+            @Override
+            public void doFilter(HttpServletRequest wrappedRequest) {
+                wrappedRequest.getSession();
+            }
+        });
+        assertThat(response.getCookie("SESSION")).isNotNull();
+        
+        setupSession();
+
+        response.reset();        
+        doFilter(new DoInFilter() {
+            @Override
+            public void doFilter(HttpServletRequest wrappedRequest) {
+                assertThat(wrappedRequest.getSession().isNew()).isFalse();
+            }
+        });
+        
+        assertThat(response.getCookie("SESSION")).isNotNull();
     }
 
     @Test

--- a/spring-session/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
+++ b/spring-session/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
@@ -328,8 +328,14 @@ public class SessionRepositoryFilterTests<S extends ExpiringSession> {
     }
 
     @Test
-    public void doFilterIsNewTrueWithFlag() throws Exception {
-    	filter.setAlwaysSendCookie(true);
+    public void doFilterSetsCookieIfChanged() throws Exception {
+        sessionRepository = new MapSessionRepository() {
+        	@Override
+        	public ExpiringSession getSession(String id) {
+				return createSession();
+        	}
+        };
+        filter = new SessionRepositoryFilter<ExpiringSession>(sessionRepository);
         doFilter(new DoInFilter() {
             @Override
             public void doFilter(HttpServletRequest wrappedRequest) {


### PR DESCRIPTION
In some cases clients might also like to or need to get a Set-Cookie header on
every request. This is really useful if you want to implement a stateless
repository, for instance, because the session ID can change every time the
session is mutated.