### PR TITLE
Allow for configuration of session id generation and format.

### DIFF
--- a/spring-session/build.gradle
+++ b/spring-session/build.gradle
@@ -28,7 +28,8 @@ dependencies {
 			'org.mockito:mockito-core:1.9.5',
 			"org.springframework:spring-test:$springVersion",
 			'org.easytesting:fest-assert:1.4',
-			"org.springframework.security:spring-security-core:$springSecurityVersion"
+			"org.springframework.security:spring-security-core:$springSecurityVersion",
+			'com.google.guava:guava:18.0'
 
 	jacoco "org.jacoco:org.jacoco.agent:0.7.2.201409121644:runtime"
 

--- a/spring-session/src/main/java/org/springframework/session/MapSession.java
+++ b/spring-session/src/main/java/org/springframework/session/MapSession.java
@@ -46,7 +46,7 @@ public final class MapSession implements ExpiringSession, Serializable {
 	 */
 	public static final int DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS = 1800;
 
-	private String id = UUID.randomUUID().toString();
+	private String id;
 	private Map<String, Object> sessionAttrs = new HashMap<String, Object>();
 	private long creationTime = System.currentTimeMillis();
 	private long lastAccessedTime = creationTime;
@@ -57,9 +57,15 @@ public final class MapSession implements ExpiringSession, Serializable {
 	private int maxInactiveInterval = DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS;
 
 	/**
-	 * Creates a new instance
+	 * Creates a new instance.
+	 * 
+	 * @param id the session id. Can not be null.
 	 */
-	public MapSession() {
+	public MapSession(String id) {
+		if(id == null) {
+			throw new IllegalArgumentException("id cannot be null");
+		}
+		this.id = id;
 	}
 
 	/**
@@ -80,6 +86,17 @@ public final class MapSession implements ExpiringSession, Serializable {
 		this.lastAccessedTime = session.getLastAccessedTime();
 		this.creationTime = session.getCreationTime();
 		this.maxInactiveInterval = session.getMaxInactiveIntervalInSeconds();
+	}
+	
+	/**
+	 * Creates a new instance creating the session id using a random UUID.
+	 * This is here for compatibility with older implementations of {@link SessionRepository}.
+	 * 
+	 * @deprecated - {@link SessionRepository} classes should now use the constructor that passes an id. 
+	 */
+	@Deprecated
+	public MapSession() {
+		this.id = UUID.randomUUID().toString();
 	}
 
 	public void setLastAccessedTime(long lastAccessedTime) {

--- a/spring-session/src/main/java/org/springframework/session/MapSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/MapSessionRepository.java
@@ -16,6 +16,7 @@
 package org.springframework.session;
 
 import org.springframework.session.events.SessionDestroyedEvent;
+import org.springframework.session.id.UUIDSessionIdStrategy;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,6 +38,11 @@ public class MapSessionRepository implements SessionRepository<ExpiringSession> 
 	 * If non-null, this value is used to override {@link ExpiringSession#setMaxInactiveIntervalInSeconds(int)}.
 	 */
 	private Integer defaultMaxInactiveInterval;
+	
+	/**
+	 * The strategy for generating the session id.  Defaults to using a UUID.
+	 */
+	private SessionIdStrategy sessionIdStrategy = new UUIDSessionIdStrategy();
 
 	private final Map<String,ExpiringSession> sessions;
 
@@ -66,6 +72,17 @@ public class MapSessionRepository implements SessionRepository<ExpiringSession> 
 	public void setDefaultMaxInactiveInterval(int defaultMaxInactiveInterval) {
 		this.defaultMaxInactiveInterval = Integer.valueOf(defaultMaxInactiveInterval);
 	}
+	
+	/**
+	 * Set the strategy for generating new session ids. 
+	 * @param sessionIdStrategy The session id strategy. Can not be null.
+	 */
+	public void setSessionIdStrategy(SessionIdStrategy sessionIdStrategy) {
+		if (sessionIdStrategy == null) {
+			throw new IllegalArgumentException("sessionIdStrategy can not be null");
+		}
+		this.sessionIdStrategy = sessionIdStrategy;
+	}
 
 	public void save(ExpiringSession session) {
 		sessions.put(session.getId(), new MapSession(session));
@@ -90,10 +107,11 @@ public class MapSessionRepository implements SessionRepository<ExpiringSession> 
 	}
 
 	public ExpiringSession createSession() {
-		ExpiringSession result = new MapSession();
+		ExpiringSession result = new MapSession(sessionIdStrategy.createSessionId());
 		if(defaultMaxInactiveInterval != null) {
 			result.setMaxInactiveIntervalInSeconds(defaultMaxInactiveInterval);
 		}
 		return result;
 	}
+
 }

--- a/spring-session/src/main/java/org/springframework/session/SessionIdStrategy.java
+++ b/spring-session/src/main/java/org/springframework/session/SessionIdStrategy.java
@@ -1,0 +1,17 @@
+package org.springframework.session;
+
+/**
+ * An interface 
+ * 
+ * @author Art Gramlich
+ */
+public interface SessionIdStrategy {
+
+	/**
+	 * Creates a new session id.
+	 * 
+	 * @return the new session id
+	 */
+	String createSessionId();
+	
+}

--- a/spring-session/src/main/java/org/springframework/session/id/Base32HexSessionIdEncoder.java
+++ b/spring-session/src/main/java/org/springframework/session/id/Base32HexSessionIdEncoder.java
@@ -1,0 +1,70 @@
+package org.springframework.session.id;
+
+/**
+ * {@link SessionIdEncoder} that encodes as a base32 extended hex with no padding.
+ * 
+ * @author Art Gramlich
+ */
+public class Base32HexSessionIdEncoder implements SessionIdEncoder {
+	
+	private static final char[] UPPER_DIGITS = "0123456789ABCDEFGHIJKLMNOPQRSTUV".toCharArray();
+	private static final char[] LOWER_DIGITS = "0123456789abcdefghijklmnopqrstuv".toCharArray();
+	
+	private char[] digits; 
+	
+	/**
+	 * Creates a new encoder with lower case digits.
+	 *
+	 */
+	public Base32HexSessionIdEncoder() {
+		this(false);
+	}
+	
+	/**
+	 * Creates a new encoder.
+	 * 
+	 * @param lowerCaseDigits - If true, lower case digits are used.
+	 */
+	public Base32HexSessionIdEncoder(boolean lowerCaseDigits) {
+		setLowerCaseDigits(lowerCaseDigits);
+	}
+	
+	/**
+	 * Indicates if upper or lower case digits should be used.
+	 * 
+	 * @param lowerCaseDigits - If true, lower case digits are used.
+	 */
+	public void setLowerCaseDigits(boolean lowerCaseDigits) {
+		digits = lowerCaseDigits ? LOWER_DIGITS : UPPER_DIGITS;
+	}
+		
+	/**
+	 * Encode the session id in a base32hex format.
+	 *  
+	 * @param bytes the bytes representing a session id.
+	 * @return The session id as a string.
+	 */
+	public String encode(byte[] bytes) {
+		int numberOfBytes = bytes.length;
+		int numberOfTotalBits = (numberOfBytes * 8);
+		int numberOfTotalDigits = (numberOfTotalBits / 5) + (numberOfTotalBits % 5 == 0 ? 0 : 1);
+		StringBuilder id = new StringBuilder(numberOfTotalDigits);
+		long fiveByteGroup;
+		for (int i=0; i< numberOfBytes; i+=5) {
+			int bytesInGroup = Math.min(numberOfBytes - i, 5);
+			int digitsInGroup = ((bytesInGroup * 8) / 5) + (bytesInGroup == 5 ? 0 : 1);
+			fiveByteGroup = 0;
+			for (int j=0; j<5; j++) {
+				byte b = (j >= bytesInGroup ? (byte)0 : bytes[i+j]);  
+				long bits = (b & 0xffL) << (8*(4-j));
+				fiveByteGroup = fiveByteGroup | bits;
+			}
+			for (int j=0; j<digitsInGroup; j++) {
+				int digit = (int)(0x1fL & (fiveByteGroup >>> (5*(7-j))));
+				id.append(digits[digit]);
+			}
+		}
+		return id.toString();
+	}
+		
+}

--- a/spring-session/src/main/java/org/springframework/session/id/HexSessionIdEncoder.java
+++ b/spring-session/src/main/java/org/springframework/session/id/HexSessionIdEncoder.java
@@ -1,0 +1,61 @@
+package org.springframework.session.id;
+
+/**
+ * {@link SessionIdEncoder} that encodes as hexidecimal digits.
+ * 
+ * @author Art Gramlich
+ */
+public class HexSessionIdEncoder implements SessionIdEncoder {
+	
+	private static final char[] LOWER_DIGITS = {
+		'0', '1', '2', '3', '4', '5', '6', '7',
+		'8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+	
+	private static final char[] UPPER_DIGITS = {
+		'0', '1', '2', '3', '4', '5', '6', '7',
+		'8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+	
+	private char[] digits;
+	
+	
+	/**
+	 * Creates a new encoder with lower case digits.
+	 *
+	 */
+	public HexSessionIdEncoder() {
+		this(false);
+	}
+	
+	/**
+	 * Creates a new encoder.
+	 * 
+	 * @param lowerCaseDigits - If true, lower case digits are used.
+	 */
+	public HexSessionIdEncoder(boolean lowerCaseDigits) {
+		setLowerCaseDigits(lowerCaseDigits);
+	}
+	
+	/**
+	 * Indicates if upper or lower case digits should be used.
+	 * 
+	 * @param lowerCaseDigits - If true, lower case digits are used.
+	 */
+	public void setLowerCaseDigits(boolean lowerCaseDigits) {
+		digits = lowerCaseDigits ? LOWER_DIGITS : UPPER_DIGITS;
+	}
+	
+	/**
+	 * Encode the session id as hex digits.
+	 *  
+	 * @param bytes the bytes representing a session id.
+	 * @return The bytes as hexidecimal digits.
+	 */
+	public String encode(byte[] bytes) {
+		StringBuilder id = new StringBuilder(bytes.length * 2);
+		for (int i=0; i < bytes.length; i++) {
+			id.append(digits[(0xF0 & bytes[i]) >>> 4]);
+			id.append(digits[(0x0F & bytes[i])]);
+		}
+		return id.toString();
+	}
+}

--- a/spring-session/src/main/java/org/springframework/session/id/SecureRandomSessionIdStrategy.java
+++ b/spring-session/src/main/java/org/springframework/session/id/SecureRandomSessionIdStrategy.java
@@ -1,0 +1,56 @@
+package org.springframework.session.id;
+
+import java.security.SecureRandom;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.springframework.session.SessionIdStrategy;
+
+public class SecureRandomSessionIdStrategy implements SessionIdStrategy {
+	
+    private final Queue<SecureRandomGenerator> randomGenerators = new ConcurrentLinkedQueue<SecureRandomGenerator>();
+
+    private int maxIterations = 100000;
+    private int byteLength = 32;
+    private SessionIdEncoder encoder = new HexSessionIdEncoder(true);
+    
+	public String createSessionId() {
+		SecureRandomGenerator generator = randomGenerators.poll();
+		if (generator == null) {
+			generator = new SecureRandomGenerator();
+		}
+		byte[] bytes = new byte[byteLength];
+		generator.generate(bytes);
+		randomGenerators.add(generator);
+		String id = encoder.encode(bytes);
+		return id;
+	}
+	
+	public void setByteLength(int byteLength) {
+		this.byteLength = byteLength;
+	}
+	
+	public void setEncoder(SessionIdEncoder encoder) {
+		this.encoder = encoder;
+	}
+
+	private class SecureRandomGenerator {
+		private SecureRandom secureRandom;
+		private int iteration;
+		
+		private SecureRandomGenerator() {
+			secureRandom = new SecureRandom();
+			secureRandom.nextInt();
+		}
+		
+		public void generate(byte[] bytes) {
+			secureRandom.nextBytes(bytes);
+			iteration++;
+			if (iteration == maxIterations) {
+				secureRandom.setSeed(secureRandom.nextLong());
+				iteration = 0;
+			}
+		}
+	}
+
+}

--- a/spring-session/src/main/java/org/springframework/session/id/SessionIdEncoder.java
+++ b/spring-session/src/main/java/org/springframework/session/id/SessionIdEncoder.java
@@ -1,0 +1,19 @@
+package org.springframework.session.id;
+
+import org.springframework.session.Session;
+
+/**
+ * An interface to allow a choice of how a byte array-based id is encoded into a {@link String}. 
+ * 
+ * @author Art Gramlich
+ */
+public interface SessionIdEncoder {
+	
+	/**
+	 * Encode the bytes into a {@link String} for use as a {@link Session} id.
+	 * @param bytes the session id as a byte array
+	 * @return the encoded session id.
+	 */
+	String encode(byte[] bytes);;
+	
+}

--- a/spring-session/src/main/java/org/springframework/session/id/UUIDSessionIdStrategy.java
+++ b/spring-session/src/main/java/org/springframework/session/id/UUIDSessionIdStrategy.java
@@ -1,0 +1,22 @@
+package org.springframework.session.id;
+
+import java.util.UUID;
+
+import org.springframework.session.SessionIdStrategy;
+
+/**
+ * A {@link SessionIdStrategy} that uses a random {@link UUID}.
+ * 
+ * @author Art Gramlich
+ *
+ */
+public class UUIDSessionIdStrategy implements SessionIdStrategy {
+
+	/**
+	 * Create a session id using a random UUID.
+	 */
+	public String createSessionId() {
+		return UUID.randomUUID().toString();
+	}
+
+}

--- a/spring-session/src/test/java/org/springframework/session/MapSessionRepositoryTests.java
+++ b/spring-session/src/test/java/org/springframework/session/MapSessionRepositoryTests.java
@@ -17,6 +17,7 @@ package org.springframework.session;
 
 import static org.fest.assertions.Assertions.assertThat;
 
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
@@ -26,11 +27,15 @@ public class MapSessionRepositoryTests {
 	MapSessionRepository repository;
 
 	MapSession session;
+	
+	private static String createUUIDSessionId() {
+		return UUID.randomUUID().toString();
+	}
 
 	@Before
 	public void setup() {
 		repository = new MapSessionRepository();
-		session = new MapSession();
+		session = new MapSession(createUUIDSessionId());
 	}
 
 	@Test
@@ -47,16 +52,30 @@ public class MapSessionRepositoryTests {
 		ExpiringSession session = repository.createSession();
 
 		assertThat(session).isInstanceOf(MapSession.class);
-		assertThat(session.getMaxInactiveIntervalInSeconds()).isEqualTo(new MapSession().getMaxInactiveIntervalInSeconds());
+		assertThat(session.getMaxInactiveIntervalInSeconds()).isEqualTo(new MapSession(createUUIDSessionId()).getMaxInactiveIntervalInSeconds());
 	}
 
 	@Test
 	public void createSessionCustomDefaultExpiration() {
-		final int expectedMaxInterval = new MapSession().getMaxInactiveIntervalInSeconds() + 10;
+		final int expectedMaxInterval = new MapSession(createUUIDSessionId()).getMaxInactiveIntervalInSeconds() + 10;
 		repository.setDefaultMaxInactiveInterval(expectedMaxInterval);
 
 		ExpiringSession session = repository.createSession();
 
 		assertThat(session.getMaxInactiveIntervalInSeconds()).isEqualTo(expectedMaxInterval);
+	}
+	
+	@Test
+	public void setSessionIdStrategy() {
+		MapSessionRepository repoCustomizedId = new MapSessionRepository();
+		repoCustomizedId.setSessionIdStrategy(
+			new SessionIdStrategy() {
+				public String createSessionId() {
+					return "ABC";
+				}
+			}
+		);
+		ExpiringSession sessionCustomizedId = repoCustomizedId.createSession();
+		assertThat(sessionCustomizedId.getId()).isEqualTo("ABC");
 	}
 }

--- a/spring-session/src/test/java/org/springframework/session/MapSessionTests.java
+++ b/spring-session/src/test/java/org/springframework/session/MapSessionTests.java
@@ -23,18 +23,20 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class MapSessionTests {
+	
+	private static final String SESSION_ID="826653e3-8220-48d5-8f2c-e4e2f3c78e99";
 
 	private MapSession session;
 
 	@Before
 	public void setup() {
-		session = new MapSession();
+		session = new MapSession(SESSION_ID);
 		session.setLastAccessedTime(1413258262962L);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void constructorNullSession() {
-		new MapSession(null);
+		new MapSession((ExpiringSession) null);
 	}
 
 	/**

--- a/spring-session/src/test/java/org/springframework/session/data/redis/RedisSessionExpirationPolicyTests.java
+++ b/spring-session/src/test/java/org/springframework/session/data/redis/RedisSessionExpirationPolicyTests.java
@@ -55,9 +55,8 @@ public class RedisSessionExpirationPolicyTests {
 	@Before
 	public void setup() {
 		policy = new RedisSessionExpirationPolicy(sessionRedisOperations);
-		session = new MapSession();
+		session = new MapSession("12345");
 		session.setLastAccessedTime(1429116694665L);
-		session.setId("12345");
 
 		when(sessionRedisOperations.boundSetOps(anyString())).thenReturn(setOperations);
 		when(sessionRedisOperations.boundHashOps(anyString())).thenReturn(hashOperations);

--- a/spring-session/src/test/java/org/springframework/session/id/Base32HexSessionIdEncoderTests.java
+++ b/spring-session/src/test/java/org/springframework/session/id/Base32HexSessionIdEncoderTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.session.id;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.io.BaseEncoding;
+
+public class Base32HexSessionIdEncoderTests {
+	
+	private Base32HexSessionIdEncoder encoder;
+	private BaseEncoding guavaEncoder;
+
+	@Before
+	public void setup() {
+		encoder = new Base32HexSessionIdEncoder();
+		guavaEncoder = BaseEncoding.base32Hex().omitPadding();
+	}
+	
+	@Test
+	public void encode() {
+		for (int i=20; i<30; i+=1) {
+			byte[] bytes = new byte[i];
+			Arrays.fill(bytes, (byte)0x00);
+			assertThat(encoder.encode(bytes)).isEqualTo(guavaEncoder.encode(bytes));
+			Arrays.fill(bytes, (byte)0xff);
+			assertThat(encoder.encode(bytes)).isEqualTo(guavaEncoder.encode(bytes));
+			for (int j=0; j<i; j++) {
+				bytes[j] = (byte) (i+j);
+			}
+			assertThat(encoder.encode(bytes)).isEqualTo(guavaEncoder.encode(bytes));
+		}
+	}
+	
+	@Test
+	public void lowerEncode() {
+		Base32HexSessionIdEncoder lowerEncoder = new Base32HexSessionIdEncoder(true);
+		byte[] bytes = new byte[]{'A','B','C','D'};
+		assertThat(lowerEncoder.encode(bytes)).isEqualTo(guavaEncoder.encode(bytes).toLowerCase(Locale.US));
+	}
+
+
+
+}

--- a/spring-session/src/test/java/org/springframework/session/id/HexSessionIdEncoderTests.java
+++ b/spring-session/src/test/java/org/springframework/session/id/HexSessionIdEncoderTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.session.id;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.springframework.session.id.HexSessionIdEncoder;
+
+public class HexSessionIdEncoderTests {
+
+	@Test
+	public void lowerEncode() {
+		HexSessionIdEncoder lowerEncoder = new HexSessionIdEncoder(true);
+		assertThat(lowerEncoder.encode(new byte[]{-1,0,10,-86})).isEqualTo("ff000aaa");
+	}
+	
+	@Test
+	public void upperEncode() {
+		HexSessionIdEncoder lowerEncoder = new HexSessionIdEncoder(false);
+		assertThat(lowerEncoder.encode(new byte[]{-1,0,10,-86})).isEqualTo("FF000AAA");
+	}
+
+
+}

--- a/spring-session/src/test/java/org/springframework/session/id/SecureRandomSessionIdStrategyTests.java
+++ b/spring-session/src/test/java/org/springframework/session/id/SecureRandomSessionIdStrategyTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.session.id;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.Locale;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class SecureRandomSessionIdStrategyTests {
+	
+	private SecureRandomSessionIdStrategy strategy;
+
+	@Before
+	public void setup() {
+		strategy = new SecureRandomSessionIdStrategy();
+		strategy.setByteLength(20);
+		strategy.setEncoder(new HexSessionIdEncoder(true));
+	}
+
+	@Test
+	public void createSessionId() {
+		String id = strategy.createSessionId();
+		assertThat(id.length()).isEqualTo(40);
+		assertThat(id).isEqualTo(id.toLowerCase(Locale.US));
+	}
+	
+
+}

--- a/spring-session/src/test/java/org/springframework/session/id/UUIDSessionIdStrategyTests.java
+++ b/spring-session/src/test/java/org/springframework/session/id/UUIDSessionIdStrategyTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.session.id;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class UUIDSessionIdStrategyTests {
+	
+	private UUIDSessionIdStrategy strategy;
+
+	@Before
+	public void setup() {
+		strategy = new UUIDSessionIdStrategy();
+	}
+
+	@Test
+	public void createSessionId() {
+		String id = strategy.createSessionId();
+		UUID uuid = UUID.fromString(id);
+		assertThat(uuid.version()).isEqualTo(4);
+	}
+	
+
+}

--- a/spring-session/src/test/java/org/springframework/session/web/http/CookieHttpSessionStrategyTests.java
+++ b/spring-session/src/test/java/org/springframework/session/web/http/CookieHttpSessionStrategyTests.java
@@ -28,6 +28,9 @@ import javax.servlet.http.Cookie;
 import java.util.Map;
 
 public class CookieHttpSessionStrategyTests {
+	
+	private static final String SESSION_ID="54067AC8-E653-4F49-B06F-132582D91DA1";
+	
 	private MockHttpServletRequest request;
 	private MockHttpServletResponse response;
 
@@ -38,7 +41,7 @@ public class CookieHttpSessionStrategyTests {
 	@Before
 	public void setup() throws Exception {
 		cookieName = "SESSION";
-		session = new MapSession();
+		session = new MapSession(SESSION_ID);
 		request = new MockHttpServletRequest();
 		response = new MockHttpServletResponse();
 		strategy = new CookieHttpSessionStrategy();
@@ -70,7 +73,7 @@ public class CookieHttpSessionStrategyTests {
 
 	@Test
 	public void onNewSessionExistingSessionSameAlias() throws Exception {
-		Session existing = new MapSession();
+		Session existing = new MapSession(SESSION_ID);
 		setSessionCookie(existing.getId());
 		strategy.onNewSession(session, request, response);
 		assertThat(getSessionId()).isEqualTo(session.getId());
@@ -78,7 +81,7 @@ public class CookieHttpSessionStrategyTests {
 
 	@Test
 	public void onNewSessionExistingSessionNewAlias() throws Exception {
-		Session existing = new MapSession();
+		Session existing = new MapSession(SESSION_ID);
 		setSessionCookie(existing.getId());
 		request.setParameter(CookieHttpSessionStrategy.DEFAULT_SESSION_ALIAS_PARAM_NAME, "new");
 		strategy.onNewSession(session, request, response);
@@ -125,7 +128,7 @@ public class CookieHttpSessionStrategyTests {
 
 	@Test
 	public void onDeleteSessionExistingSessionSameAlias() throws Exception {
-		Session existing = new MapSession();
+		Session existing = new MapSession(SESSION_ID);
 		setSessionCookie("0 " + existing.getId() + " new " + session.getId());
 		strategy.onInvalidateSession(request, response);
 		assertThat(getSessionId()).isEqualTo(session.getId());
@@ -133,7 +136,7 @@ public class CookieHttpSessionStrategyTests {
 
 	@Test
 	public void onDeleteSessionExistingSessionNewAlias() throws Exception {
-		Session existing = new MapSession();
+		Session existing = new MapSession(SESSION_ID);
 		setSessionCookie("0 " + existing.getId() + " new " + session.getId());
 		request.setParameter(CookieHttpSessionStrategy.DEFAULT_SESSION_ALIAS_PARAM_NAME, "new");
 		strategy.onInvalidateSession(request, response);

--- a/spring-session/src/test/java/org/springframework/session/web/http/HeaderSessionStrategyTests.java
+++ b/spring-session/src/test/java/org/springframework/session/web/http/HeaderSessionStrategyTests.java
@@ -26,6 +26,9 @@ import org.springframework.session.web.http.HeaderHttpSessionStrategy;
 import static org.fest.assertions.Assertions.assertThat;
 
 public class HeaderSessionStrategyTests {
+	
+	private static final String SESSION_ID="54067AC8-E653-4F49-B06F-132582D91DA1";
+	
 	private MockHttpServletRequest request;
 	private MockHttpServletResponse response;
 
@@ -36,7 +39,7 @@ public class HeaderSessionStrategyTests {
 	@Before
 	public void setup() throws Exception {
 		headerName = "x-auth-token";
-		session = new MapSession();
+		session = new MapSession(SESSION_ID);
 		request = new MockHttpServletRequest();
 		response = new MockHttpServletResponse();
 		strategy = new HeaderHttpSessionStrategy();


### PR DESCRIPTION
This patch allows a configurable strategy for how session ids are generated and allows configurable encoding when it makes sense.  It defaults to the existing uuid generation and format. 

It also tries to follow the best practices for SecureRandom mentioned in the issue #11 and borrows some ideas from how Tomcat and Jetty generate ids.
