### PR TITLE
Fix <type> to </type> in Maven section of guides

### DIFF
--- a/docs/src/docs/asciidoc/guides/httpsession-xml.adoc
+++ b/docs/src/docs/asciidoc/guides/httpsession-xml.adoc
@@ -21,7 +21,7 @@ If you are using Maven, ensure to add the following dependencies:
 		<groupId>org.springframework.session</groupId>
 		<artifactId>spring-session-data-redis</artifactId>
 		<version>{spring-session-version}</version>
-		<type>pom<type>
+		<type>pom</type>
 	</dependency>
 	<dependency>
 		<groupId>org.springframework</groupId>

--- a/docs/src/docs/asciidoc/guides/httpsession.adoc
+++ b/docs/src/docs/asciidoc/guides/httpsession.adoc
@@ -21,7 +21,7 @@ If you are using Maven, ensure to add the following dependencies:
 		<groupId>org.springframework.session</groupId>
 		<artifactId>spring-session-data-redis</artifactId>
 		<version>{spring-session-version}</version>
-		<type>pom<type>
+		<type>pom</type>
 	</dependency>
 	<dependency>
 		<groupId>org.springframework</groupId>

--- a/docs/src/docs/asciidoc/guides/rest.adoc
+++ b/docs/src/docs/asciidoc/guides/rest.adoc
@@ -21,7 +21,7 @@ If you are using Maven, ensure to add the following dependencies:
 		<groupId>org.springframework.session</groupId>
 		<artifactId>spring-session-data-redis</artifactId>
 		<version>{spring-session-version}</version>
-		<type>pom<type>
+		<type>pom</type>
 	</dependency>
 	<dependency>
 		<groupId>org.springframework</groupId>

--- a/docs/src/docs/asciidoc/guides/security.adoc
+++ b/docs/src/docs/asciidoc/guides/security.adoc
@@ -22,7 +22,7 @@ If you are using Maven, ensure to add the following dependencies:
 	<groupId>org.springframework.session</groupId>
 	<artifactId>spring-session-data-redis</artifactId>
 	<version>{spring-session-version}</version>
-	<type>pom<type>
+	<type>pom</type>
 	</dependency>
 	<dependency>
 	<groupId>org.springframework</groupId>


### PR DESCRIPTION
Cutting and pasting the maven dependencies from the guides was failing
due to an xml element that was not closed.