### PR TITLE
KeepAliveCondition for SessionRepository implementations

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/MapSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/MapSessionRepository.java
@@ -16,6 +16,7 @@
 package org.springframework.session;
 
 import org.springframework.session.events.SessionDestroyedEvent;
+import org.springframework.session.keepalive.KeepAliveCondition;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -39,6 +40,8 @@ public class MapSessionRepository implements SessionRepository<ExpiringSession> 
 	private Integer defaultMaxInactiveInterval;
 
 	private final Map<String,ExpiringSession> sessions;
+
+	private KeepAliveCondition keepAliveCondition = KeepAliveCondition.ALWAYS;
 
 	/**
 	 * Creates an instance backed by a {@link java.util.concurrent.ConcurrentHashMap}
@@ -81,7 +84,9 @@ public class MapSessionRepository implements SessionRepository<ExpiringSession> 
 			return null;
 		}
 		MapSession result = new MapSession(saved);
-		result.setLastAccessedTime(System.currentTimeMillis());
+		if (keepAliveCondition.keepAlive()) {
+			result.setLastAccessedTime(System.currentTimeMillis());
+		}
 		return result;
 	}
 
@@ -95,5 +100,9 @@ public class MapSessionRepository implements SessionRepository<ExpiringSession> 
 			result.setMaxInactiveIntervalInSeconds(defaultMaxInactiveInterval);
 		}
 		return result;
+	}
+
+	public void setKeepAliveCondition(KeepAliveCondition keepAliveCondition) {
+		this.keepAliveCondition = keepAliveCondition;
 	}
 }

--- a/spring-session/src/main/java/org/springframework/session/keepalive/KeepAliveCondition.java
+++ b/spring-session/src/main/java/org/springframework/session/keepalive/KeepAliveCondition.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.springframework.session.keepalive;
+
+/**
+ * Interface for defining a conditional session keep-alive.
+ * 
+ * @since 1.0.1
+ * @author Peter Lajko
+ */
+public interface KeepAliveCondition {
+
+	/** Always return true (Recommended default) */
+	KeepAliveCondition ALWAYS = new KeepAliveCondition() {
+		@Override
+		public boolean keepAlive() {
+			return true;
+		}
+	};
+
+	/**
+	 * Whether to keep alive the actual session by modifying the last access time.
+	 *
+	 * @return true, if last access time must be refreshed
+	 */
+	boolean keepAlive();
+}

--- a/spring-session/src/main/java/org/springframework/session/web/context/RequestPatternKeepAliveCondition.java
+++ b/spring-session/src/main/java/org/springframework/session/web/context/RequestPatternKeepAliveCondition.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.springframework.session.web.context;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.session.keepalive.KeepAliveCondition;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.util.UrlPathHelper;
+
+/**
+ * Thread local request path pattern matcher condition for integration with Spring framework.
+ * All requests matching the defined exclude patterns will leave the session's last modified time unchanged.
+ * (Useful for long-polling implementations)
+ * @see <a href="http://en.wikipedia.org/wiki/Push_technology#Long_polling">Long polling</a>
+ * Registration of {@link org.springframework.web.context.request.RequestContextListener} is required.
+ * 
+ * @see <a href="http://google.com">http://google.com</a>
+ * @since 1.0.1
+ * @author Peter Lajko
+ */
+public class RequestPatternKeepAliveCondition implements KeepAliveCondition {
+
+	private static final PathMatcher PATH_MATCHER = new AntPathMatcher();
+
+	private static final UrlPathHelper PATH_HELPER = new UrlPathHelper();
+
+	private String[] excludes;
+
+	private static HttpServletRequest getThreadLocalRequest() {
+		return ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+	}
+
+	private static boolean matchesAnyOf(String[] patterns) {
+		if (patterns != null) {
+			String lookupPath = PATH_HELPER.getPathWithinApplication(getThreadLocalRequest());
+			for (String pattern : patterns) {
+				if (PATH_MATCHER.match(pattern, lookupPath)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean keepAlive() {
+		// keep the session alive if none of the excludes matched
+		return !matchesAnyOf(excludes);
+	}
+
+	public String[] getExcludes() {
+		return excludes;
+	}
+
+	public void setExcludes(String[] excludes) {
+		this.excludes = excludes;
+	}
+}


### PR DESCRIPTION
It makes possible to control the session keep-alive based on a condition. It can be useful for long-polling solutions, when you don't want the continuous polling to keep the session alive.