### PR TITLE
Make the Redis hash key prefix configurable

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
@@ -15,11 +15,6 @@
  */
 package org.springframework.session.data.redis;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.BoundHashOperations;
 import org.springframework.data.redis.core.RedisOperations;
@@ -33,6 +28,11 @@ import org.springframework.session.SessionRepository;
 import org.springframework.session.events.SessionDestroyedEvent;
 import org.springframework.session.web.http.SessionRepositoryFilter;
 import org.springframework.util.Assert;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * <p>
@@ -175,6 +175,8 @@ public class RedisOperationsSessionRepository implements SessionRepository<Redis
 	 */
 	private Integer defaultMaxInactiveInterval;
 
+	private String boundedHashKeyPrefix;
+
 	/**
 	 * Allows creating an instance and uses a default {@link RedisOperations} for both managing the session and the expirations.
 	 *
@@ -205,6 +207,10 @@ public class RedisOperationsSessionRepository implements SessionRepository<Redis
 	 */
 	public void setDefaultMaxInactiveInterval(int defaultMaxInactiveInterval) {
 		this.defaultMaxInactiveInterval = defaultMaxInactiveInterval;
+	}
+
+	public void setBoundedHashKeyPrefix(String boundedHashKeyPrefix) {
+	    this.boundedHashKeyPrefix = boundedHashKeyPrefix;
 	}
 
 	public void save(RedisSession session) {
@@ -284,8 +290,8 @@ public class RedisOperationsSessionRepository implements SessionRepository<Redis
 	 * @param sessionId the session id
 	 * @return the Hash key for this session by prefixing it appropriately.
 	 */
-	static String getKey(String sessionId) {
-		return BOUNDED_HASH_KEY_PREFIX + sessionId;
+	public String getKey(String sessionId) {
+		return this.getBoundedHashKeyPrefix() + sessionId;
 	}
 
 	/**
@@ -296,6 +302,13 @@ public class RedisOperationsSessionRepository implements SessionRepository<Redis
 	 */
 	static String getSessionAttrNameKey(String attributeName) {
 		return SESSION_ATTR_PREFIX + attributeName;
+	}
+
+	private String getBoundedHashKeyPrefix() {
+		if (this.boundedHashKeyPrefix != null) {
+			return this.boundedHashKeyPrefix;
+		}
+		return BOUNDED_HASH_KEY_PREFIX;
 	}
 
 	/**

--- a/spring-session/src/main/java/org/springframework/session/data/redis/SessionMessageListener.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/SessionMessageListener.java
@@ -35,15 +35,20 @@ public class SessionMessageListener implements MessageListener {
 	private static final Log logger = LogFactory.getLog(SessionMessageListener.class);
 
 	private final ApplicationEventPublisher eventPublisher;
+	private String boundedHashKeyPrefix;
 
 	/**
 	 * Creates a new instance
 	 *
 	 * @param eventPublisher the {@link ApplicationEventPublisher} to use. Cannot be null.
 	 */
-	public SessionMessageListener(ApplicationEventPublisher eventPublisher) {
+	public SessionMessageListener(ApplicationEventPublisher eventPublisher, String boundedHashKeyPrefix) {
 		Assert.notNull(eventPublisher, "eventPublisher cannot be null");
 		this.eventPublisher = eventPublisher;
+		if (boundedHashKeyPrefix == null) {
+			this.boundedHashKeyPrefix = "spring:session:sessions:";
+		}
+		this.boundedHashKeyPrefix = boundedHashKeyPrefix;
 	}
 
 	public void onMessage(Message message, byte[] pattern) {
@@ -57,7 +62,7 @@ public class SessionMessageListener implements MessageListener {
 			return;
 		}
 		String body = new String(messageBody);
-		if(!body.startsWith("spring:session:sessions:")) {
+		if(!body.startsWith(this.boundedHashKeyPrefix)) {
 			return;
 		}
 

--- a/spring-session/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/EnableRedisHttpSession.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/EnableRedisHttpSession.java
@@ -15,13 +15,13 @@
  */
 package org.springframework.session.data.redis.config.annotation.web.http;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
 /**
  * Add this annotation to an {@code @Configuration} class to expose the
@@ -54,4 +54,5 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 @Configuration
 public @interface EnableRedisHttpSession {
 	int maxInactiveIntervalInSeconds() default 1800;
+	String boundedHashKeyPrefix() default "spring:session:sessions:";
 }

--- a/spring-session/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfiguration.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfiguration.java
@@ -15,11 +15,6 @@
  */
 package org.springframework.session.data.redis.config.annotation.web.http;
 
-import java.util.Arrays;
-import java.util.Map;
-
-import javax.servlet.ServletContext;
-
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,6 +42,10 @@ import org.springframework.session.web.http.HttpSessionStrategy;
 import org.springframework.session.web.http.SessionRepositoryFilter;
 import org.springframework.util.ClassUtils;
 
+import javax.servlet.ServletContext;
+import java.util.Arrays;
+import java.util.Map;
+
 /**
  * Exposes the {@link SessionRepositoryFilter} as a bean named
  * "springSessionRepositoryFilter". In order to use this a single
@@ -64,6 +63,8 @@ public class RedisHttpSessionConfiguration implements ImportAware, BeanClassLoad
 	private ClassLoader beanClassLoader;
 
 	private Integer maxInactiveIntervalInSeconds = 1800;
+
+	private String boundedHashKeyPrefix = "spring:session:sessions:";
 
 	private HttpSessionStrategy httpSessionStrategy;
 
@@ -84,7 +85,7 @@ public class RedisHttpSessionConfiguration implements ImportAware, BeanClassLoad
 
 	@Bean
 	public SessionMessageListener redisSessionMessageListener() {
-		return new SessionMessageListener(eventPublisher);
+		return new SessionMessageListener(eventPublisher, boundedHashKeyPrefix);
 	}
 
 	@Bean
@@ -100,6 +101,7 @@ public class RedisHttpSessionConfiguration implements ImportAware, BeanClassLoad
 	public RedisOperationsSessionRepository sessionRepository(RedisTemplate<String, ExpiringSession> sessionRedisTemplate) {
 		RedisOperationsSessionRepository sessionRepository = new RedisOperationsSessionRepository(sessionRedisTemplate);
 		sessionRepository.setDefaultMaxInactiveInterval(maxInactiveIntervalInSeconds);
+		sessionRepository.setBoundedHashKeyPrefix(boundedHashKeyPrefix);
 		return sessionRepository;
 	}
 
@@ -135,6 +137,7 @@ public class RedisHttpSessionConfiguration implements ImportAware, BeanClassLoad
 			}
 		}
 		maxInactiveIntervalInSeconds = enableAttrs.getNumber("maxInactiveIntervalInSeconds");
+		boundedHashKeyPrefix = enableAttrs.getString("boundedHashKeyPrefix");
 	}
 
 	@Autowired(required = false)

--- a/spring-session/src/test/java/org/springframework/session/data/redis/SessionMessageListenerTests.java
+++ b/spring-session/src/test/java/org/springframework/session/data/redis/SessionMessageListenerTests.java
@@ -15,11 +15,6 @@
  */
 package org.springframework.session.data.redis;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.mockito.Mockito.*;
-
-import java.io.UnsupportedEncodingException;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,6 +26,11 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.session.events.SessionDestroyedEvent;
+
+import java.io.UnsupportedEncodingException;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 
 /**
@@ -55,12 +55,12 @@ public class SessionMessageListenerTests {
 
 	@Before
 	public void setup() {
-		listener = new SessionMessageListener(eventPublisher);
+		listener = new SessionMessageListener(eventPublisher, "spring:session:sessions:");
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void constructorNullEventPublisher() {
-		new SessionMessageListener(null);
+		new SessionMessageListener(null, null);
 	}
 
 	@Test


### PR DESCRIPTION
The hash key prefix can now be configured via @EnableRedisHttpSession