### PR TITLE
CONFIG_NOTIFY_KEYSPACE_EVENTS is not being used in EnableRedisKeyspac…

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfiguration.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfiguration.java
@@ -153,8 +153,6 @@ public class RedisHttpSessionConfiguration implements ImportAware, BeanClassLoad
 	 * cleaned up properly. For example, the mapping of the Session to WebSocket connections may not get cleaned up.
 	 */
 	static class EnableRedisKeyspaceNotificationsInitializer implements InitializingBean {
-		static final String CONFIG_NOTIFY_KEYSPACE_EVENTS = "notify-keyspace-events";
-
 		private final RedisConnectionFactory connectionFactory;
 
 		private ConfigureRedisAction configure;


### PR DESCRIPTION
…eNotificationsInitializer

There's a duplicate of this field in org.springframework.session.data.redis.config.ConfigureNotifyKeyspaceEventsAction which is where it appears to be used.