### PR TITLE
Use the latest version of the Spring IO Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 	dependencies {
 		classpath("org.gradle.api.plugins:gradle-tomcat-plugin:1.2.3")
 		classpath("org.springframework.build.gradle:propdeps-plugin:0.0.7")
-		classpath("org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE")
+		classpath("io.spring.gradle:spring-io-plugin:0.0.4.RELEASE")
 		classpath('me.champeau.gradle:gradle-javadoc-hotfix-plugin:0.1')
 		classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.2'
 	}

--- a/spring-session-data-redis/build.gradle
+++ b/spring-session-data-redis/build.gradle
@@ -10,6 +10,12 @@ dependencies {
 			"org.springframework.data:spring-data-redis:$springDataRedisVersion",
 			"redis.clients:jedis:$jedisVersion",
 			"org.apache.commons:commons-pool2:$commonsPoolVersion"
+}
 
-	springIoVersions "io.spring.platform:platform-versions:${springIoVersion}@properties"
+dependencyManagement {
+	springIoTestRuntime {
+		imports {
+			mavenBom "io.spring.platform:platform-bom:${springIoVersion}"
+		}
+	}
 }

--- a/spring-session/build.gradle
+++ b/spring-session/build.gradle
@@ -32,7 +32,14 @@ dependencies {
 
 	jacoco "org.jacoco:org.jacoco.agent:0.7.2.201409121644:runtime"
 
-	springIoVersions "io.spring.platform:platform-versions:${springIoVersion}@properties"
+}
+
+dependencyManagement {
+	springIoTestRuntime {
+		imports {
+			mavenBom "io.spring.platform:platform-bom:${springIoVersion}"
+		}
+	}
 }
 
 ext.javadocLinks = [


### PR DESCRIPTION
This change is necessary to allow Spring IO Platform 2.0 to remove the platform-versions properties file that was deprecated in 1.1. To allow Spring Session's Platform compliance to be verified as part of Spring IO Platform 2.0's build and release process, I'd like this to be included in Spring Session 1.0.x which is the version that's currently in Spring IO Platform 2.0. If you have any questions, please let me know.