### PR TITLE
enable configuration of cookie domain and httpOnly flag

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/web/http/CookieHttpSessionStrategy.java
+++ b/spring-session/src/main/java/org/springframework/session/web/http/CookieHttpSessionStrategy.java
@@ -234,15 +234,34 @@ public final class CookieHttpSessionStrategy implements MultiHttpSessionStrategy
 		return sessionsWritten;
 	}
 
+
+	private Boolean httpOnly = true;
+	public void setHttpOnly(Boolean _httpOnly) {
+		this.httpOnly = _httpOnly;
+	}
+	public Boolean getHttpOnly() {
+		return httpOnly;
+	}
+
+	private String domain;
+	public void setDomain(String _domain) {
+		this.domain = _domain;
+	}
+	public String getDomain() {
+		return domain;
+	}
+
 	private Cookie createSessionCookie(HttpServletRequest request,
 			Map<String, String> sessionIds) {
 		Cookie sessionCookie = new Cookie(cookieName,"");
 		if(isServlet3Plus) {
-			sessionCookie.setHttpOnly(true);
+			sessionCookie.setHttpOnly(this.httpOnly);
 		}
 		sessionCookie.setSecure(request.isSecure());
 		sessionCookie.setPath(cookiePath(request));
-		// TODO set domain?
+		if (this.domain != null) {
+			sessionCookie.setDomain(this.domain);
+		}
 
 		if(sessionIds.isEmpty()) {
 			sessionCookie.setMaxAge(0);


### PR DESCRIPTION
I've been working off of 1.0.2.RELEASE, but made the change on master for the sake of the pull request. This feature was mentioned in #299 #141 among others i can't seem to find right now. This pull request allows domain and httpOnly flags to be set from java config like so;

	@Value("${spring.cookie.domain}")
	private String COOKIE_DOMAIN;

	@Bean
	public CookieHttpSessionStrategy httpSessionStrategy() {
		CookieHttpSessionStrategy strategy = new CookieHttpSessionStrategy();
		strategy.setDomain(COOKIE_DOMAIN);
		strategy.setHttpOnly(false);
		return strategy;
	}

For our project this was necessary in order to share sessions across multiple subdomains. 