### PR TITLE
Remove unnecessary code in HazelcastHttpSessionConfiguration

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfiguration.java
+++ b/spring-session/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfiguration.java
@@ -106,19 +106,6 @@ public class HazelcastHttpSessionConfiguration extends SpringHttpSessionConfigur
 	public void setImportMetadata(AnnotationMetadata importMetadata) {
 		Map<String, Object> enableAttrMap = importMetadata.getAnnotationAttributes(EnableHazelcastHttpSession.class.getName());
 		AnnotationAttributes enableAttrs = AnnotationAttributes.fromMap(enableAttrMap);
-		if (enableAttrs == null) {
-			// search parent classes
-			Class<?> currentClass = ClassUtils.resolveClassName(importMetadata.getClassName(), beanClassLoader);
-			for (Class<?> classToInspect = currentClass; classToInspect != null; classToInspect = classToInspect.getSuperclass()) {
-				EnableHazelcastHttpSession enableHazelcastHttpSessionAnnotation = AnnotationUtils.findAnnotation(classToInspect, EnableHazelcastHttpSession.class);
-				if (enableHazelcastHttpSessionAnnotation == null) {
-					continue;
-				}
-				enableAttrMap = AnnotationUtils
-						.getAnnotationAttributes(enableHazelcastHttpSessionAnnotation);
-				enableAttrs = AnnotationAttributes.fromMap(enableAttrMap);
-			}
-		}
 
 		transferAnnotationAttributes(enableAttrs);
 	}


### PR DESCRIPTION
I copied this code from `RedisHttpSessionConfiguration` without really understanding why it was needed. I should have asked then, which would have prevented it from being introduced in the first place. As this workaround is no longer needed, I am removing this unnecessary code.

Related to #306 