### PR TITLE
Don't send expirations del events when expiration time does not change.

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/data/redis/RedisSessionExpirationPolicy.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/RedisSessionExpirationPolicy.java
@@ -68,13 +68,15 @@ final class RedisSessionExpirationPolicy {
 
 	public void onExpirationUpdated(Long originalExpirationTimeInMilli, ExpiringSession session) {
 		String keyToExpire = "expires:" + session.getId();
+		long toExpire = roundUpToNextMinute(expiresInMillis(session));
+
 		if(originalExpirationTimeInMilli != null) {
 			long originalRoundedUp = roundUpToNextMinute(originalExpirationTimeInMilli);
-			String expireKey = getExpirationKey(originalRoundedUp);
-			redis.boundSetOps(expireKey).remove(keyToExpire);
+			if(toExpire != originalRoundedUp) {
+				String expireKey = getExpirationKey(originalRoundedUp);
+				redis.boundSetOps(expireKey).remove(keyToExpire);
+			}
 		}
-
-		long toExpire = roundUpToNextMinute(expiresInMillis(session));
 
 		String expireKey = getExpirationKey(toExpire);
 		BoundSetOperations<Object, Object> expireOperations = redis.boundSetOps(expireKey);


### PR DESCRIPTION
Expiration time is rounded up, so in case of many request per second from a
single session we can skip sending of delete event to reduce the traffic.
This is good because actually at the moment the redis repository is subscribed
for this events, even though it ignores them.

Fix gh-315