### PR TITLE
Upgrade to Gradle Wrapper 2.9

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-bin.zip


### PR DESCRIPTION
BTW, I'm curious why `wrapper` task isn't used in `build.gradle` as follows:

```
task wrapper(type: Wrapper) {
    gradleVersion = '2.9'
}
```