### PR TITLE
Use correct RedisSerializer

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
@@ -295,6 +295,8 @@ public class RedisOperationsSessionRepository implements FindByPrincipalNameSess
 	 */
 	private Integer defaultMaxInactiveInterval;
 
+	private RedisSerializer<Object> defaultSerializer = new JdkSerializationRedisSerializer();
+
 	/**
 	 * Allows creating an instance and uses a default {@link RedisOperations} for both managing the session and the expirations.
 	 *
@@ -338,6 +340,17 @@ public class RedisOperationsSessionRepository implements FindByPrincipalNameSess
 	 */
 	public void setDefaultMaxInactiveInterval(int defaultMaxInactiveInterval) {
 		this.defaultMaxInactiveInterval = defaultMaxInactiveInterval;
+	}
+
+	/**
+	 * Sets the default redis serializer. Replaces default serializer which is based on
+	 * {@link JdkSerializationRedisSerializer}.
+	 *
+	 * @param defaultSerializer the new default redis serializer
+	 */
+	public void setDefaultSerializer(RedisSerializer<Object> defaultSerializer) {
+		Assert.notNull(defaultSerializer, "defaultSerializer cannot be null");
+		this.defaultSerializer = defaultSerializer;
 	}
 
 	public void save(RedisSession session) {
@@ -446,8 +459,8 @@ public class RedisOperationsSessionRepository implements FindByPrincipalNameSess
 
 
 		if(channel.startsWith(getSessionCreatedChannelPrefix())) {
-			RedisSerializer<Object> serializer = new JdkSerializationRedisSerializer();
-			Map<Object,Object> loaded = (Map<Object, Object>) serializer.deserialize(message.getBody());
+			// TODO: is this thread safe?
+			Map<Object,Object> loaded = (Map<Object, Object>) defaultSerializer.deserialize(message.getBody());
 			handleCreated(loaded, channel);
 			return;
 		}

--- a/spring-session/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfiguration.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfiguration.java
@@ -99,6 +99,9 @@ public class RedisHttpSessionConfiguration extends SpringHttpSessionConfiguratio
 		RedisOperationsSessionRepository sessionRepository = new RedisOperationsSessionRepository(sessionRedisTemplate);
 		sessionRepository.setApplicationEventPublisher(applicationEventPublisher);
 		sessionRepository.setDefaultMaxInactiveInterval(maxInactiveIntervalInSeconds);
+		if(defaultRedisSerializer != null) {
+			sessionRepository.setDefaultSerializer(defaultRedisSerializer);
+		}
 
 		String redisNamespace = getRedisNamespace();
 		if(StringUtils.hasText(redisNamespace)) {


### PR DESCRIPTION
- Remove hardcoded JdkSerializationRedisSerializer from onMessage
  in favour of same defaultRedisSerializer user configured as this
  is most likely the one which works.
- Fixes #309