### PR TITLE
GH-358 Tests: Close only used `HazelcastInstance`

### DIFF
--- a/spring-session/src/integration-test/java/org/springframework/session/data/SessionEventRegistry.java
+++ b/spring-session/src/integration-test/java/org/springframework/session/data/SessionEventRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ public class SessionEventRegistry implements ApplicationListener<AbstractSession
 			lock.notifyAll();
 		}
 	}
-	
+
 	public void setLock(Object lock) {
 		this.lock = lock;
 	}
@@ -50,7 +50,7 @@ public class SessionEventRegistry implements ApplicationListener<AbstractSession
 	private <E extends AbstractSessionEvent> E waitForEvent() throws InterruptedException {
 		synchronized(lock) {
 			if(event == null) {
-				lock.wait(3000);
+				lock.wait(10000);
 			}
 		}
 		return (E) event;

--- a/spring-session/src/integration-test/java/org/springframework/session/hazelcast/AbstractHazelcastRepositoryITests.java
+++ b/spring-session/src/integration-test/java/org/springframework/session/hazelcast/AbstractHazelcastRepositoryITests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,20 @@
 
 package org.springframework.session.hazelcast;
 
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.session.ExpiringSession;
 import org.springframework.session.SessionRepository;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
 
 /**
  * Abstract base class for Hazelcast integration tests.
- * 
+ *
  * @author Tommy Ludwig
  * @author Vedran Pavic
  */
@@ -41,7 +42,7 @@ public abstract class AbstractHazelcastRepositoryITests<S extends ExpiringSessio
 	private SessionRepository<S> repository;
 
 	@Test
-	public void createAndDestorySession() {
+	public void createAndDestroySession() {
 		S sessionToSave = repository.createSession();
 		String sessionId = sessionToSave.getId();
 

--- a/spring-session/src/integration-test/java/org/springframework/session/hazelcast/HazelcastClientRepositoryITests.java
+++ b/spring-session/src/integration-test/java/org/springframework/session/hazelcast/HazelcastClientRepositoryITests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,6 @@
 
 package org.springframework.session.hazelcast;
 
-import com.hazelcast.client.HazelcastClient;
-import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.core.Hazelcast;
-import com.hazelcast.core.HazelcastInstance;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -33,11 +29,17 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.util.SocketUtils;
 
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.core.HazelcastInstance;
+
 /**
  * Integration tests that check the underlying data source - in this case
  * Hazelcast Client.
  *
  * @author Vedran Pavic
+ * @author Artem Bilan
+ * @since 1.1
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -47,14 +49,17 @@ public class HazelcastClientRepositoryITests<S extends ExpiringSession>
 
 	private static final int PORT = SocketUtils.findAvailableTcpPort();
 
+	private static HazelcastInstance hazelcastInstance;
+
+
 	@BeforeClass
 	public static void setup() {
-		HazelcastITestUtils.embeddedHazelcastServer(PORT);
+		hazelcastInstance = HazelcastITestUtils.embeddedHazelcastServer(PORT);
 	}
 
 	@AfterClass
 	public static void teardown() {
-		Hazelcast.shutdownAll();
+		hazelcastInstance.shutdown();
 	}
 
 	@Configuration


### PR DESCRIPTION
Fixes GH-358 (https://github.com/spring-projects/spring-session/issues/358)

* It might be dangerous to `shutdownAll()` `HazelcastInstance`s from the test-case, especially when we are ran in with the integration test and on the CI environment.
Therefore extract the `instance` variable in the test and close only it from the `@AfterClass`
* Fix typo in the `AbstractHazelcastRepositoryITests` test method name
* Increase lock wait timeout to the 10 seconds in the `SessionEventRegistry`. Looks like 3 seconds isn't enough for my Windows machine.