### PR TITLE
Extract PrincipalNameResolver

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/PrincipalNameResolver.java
+++ b/spring-session/src/main/java/org/springframework/session/PrincipalNameResolver.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session;
+
+/**
+ * Strategy interface used for resolving principal name from the {@link Session}.
+ *
+ * @author Vedran Pavic
+ */
+public interface PrincipalNameResolver {
+
+	/**
+	 * Resolve the principal name from the given {@link Session}
+	 * @param session the session
+	 * @return the principal name
+	 */
+	String resolvePrincipal(Session session);
+
+}

--- a/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -34,13 +34,13 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import org.springframework.expression.Expression;
-import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.session.ExpiringSession;
 import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.session.MapSession;
+import org.springframework.session.PrincipalNameResolver;
 import org.springframework.session.Session;
+import org.springframework.session.security.SpringSecurityPrincipalNameResolver;
 import org.springframework.session.events.SessionCreatedEvent;
 import org.springframework.session.events.SessionDeletedEvent;
 import org.springframework.session.events.SessionDestroyedEvent;
@@ -250,11 +250,10 @@ import org.springframework.util.Assert;
  * @author Rob Winch
  */
 public class RedisOperationsSessionRepository implements FindByIndexNameSessionRepository<RedisOperationsSessionRepository.RedisSession>, MessageListener {
+
 	private static final Log logger = LogFactory.getLog(RedisOperationsSessionRepository.class);
 
 	private static final String SPRING_SECURITY_CONTEXT = "SPRING_SECURITY_CONTEXT";
-
-	static PrincipalNameResolver PRINCIPAL_NAME_RESOLVER = new PrincipalNameResolver();
 
 	/**
 	 * The default prefix for each key and channel in Redis used by Spring Session
@@ -305,6 +304,8 @@ public class RedisOperationsSessionRepository implements FindByIndexNameSessionR
 	private RedisSerializer<Object> defaultSerializer = new JdkSerializationRedisSerializer();
 
 	private RedisFlushMode redisFlushMode = RedisFlushMode.ON_SAVE;
+
+	private PrincipalNameResolver principalNameResolver = new SpringSecurityPrincipalNameResolver();
 
 	/**
 	 * Allows creating an instance and uses a default {@link RedisOperations} for both managing the session and the expirations.
@@ -368,6 +369,15 @@ public class RedisOperationsSessionRepository implements FindByIndexNameSessionR
 	public void setRedisFlushMode(RedisFlushMode redisFlushMode) {
 		Assert.notNull(redisFlushMode, "redisFlushMode cannot be null");
 		this.redisFlushMode = redisFlushMode;
+	}
+
+	/**
+	 * Sets the principal name resolver.
+	 * @param principalNameResolver the principal name resolver
+	 */
+	public void setPrincipalNameResolver(PrincipalNameResolver principalNameResolver) {
+		Assert.notNull(principalNameResolver, "PrincipalNameResolver cannot be null");
+		this.principalNameResolver = principalNameResolver;
 	}
 
 	public void save(RedisSession session) {
@@ -520,7 +530,7 @@ public class RedisOperationsSessionRepository implements FindByIndexNameSessionR
 			return;
 		}
 		String sessionId = session.getId();
-		String principal = PRINCIPAL_NAME_RESOLVER.resolvePrincipal(session);
+		String principal = principalNameResolver.resolvePrincipal(session);
 		if(principal != null) {
 			sessionRedisOperations.boundSetOps(getPrincipalKey(principal)).remove(sessionId);
 		}
@@ -666,7 +676,7 @@ public class RedisOperationsSessionRepository implements FindByIndexNameSessionR
 		RedisSession(MapSession cached) {
 			Assert.notNull("MapSession cannot be null");
 			this.cached = cached;
-			this.originalPrincipalName = PRINCIPAL_NAME_RESOLVER.resolvePrincipal(this);
+			this.originalPrincipalName = principalNameResolver.resolvePrincipal(this);
 		}
 
 		public void setNew(boolean isNew) {
@@ -749,7 +759,7 @@ public class RedisOperationsSessionRepository implements FindByIndexNameSessionR
 					String originalPrincipalRedisKey = getPrincipalKey((String) originalPrincipalName);
 					sessionRedisOperations.boundSetOps(originalPrincipalRedisKey).remove(sessionId);
 				}
-				String principal = PRINCIPAL_NAME_RESOLVER.resolvePrincipal(this);
+				String principal = principalNameResolver.resolvePrincipal(this);
 				originalPrincipalName = principal;
 				if(principal != null) {
 					String principalRedisKey = getPrincipalKey(principal);
@@ -764,21 +774,4 @@ public class RedisOperationsSessionRepository implements FindByIndexNameSessionR
 		}
 	}
 
-	static class PrincipalNameResolver {
-		private SpelExpressionParser parser = new SpelExpressionParser();
-
-		public String resolvePrincipal(Session session) {
-			String principalName = session.getAttribute(PRINCIPAL_NAME_INDEX_NAME);
-			if(principalName != null) {
-				return principalName;
-			}
-			Object authentication = session.getAttribute(SPRING_SECURITY_CONTEXT);
-			if(authentication != null) {
-				Expression expression = parser.parseExpression("authentication?.name");
-				return expression.getValue(authentication, String.class);
-			}
-			return null;
-		}
-
-	}
 }

--- a/spring-session/src/main/java/org/springframework/session/security/SpringSecurityPrincipalNameResolver.java
+++ b/spring-session/src/main/java/org/springframework/session/security/SpringSecurityPrincipalNameResolver.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.security;
+
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.PrincipalNameResolver;
+import org.springframework.session.Session;
+
+/**
+ * Implementation of {@link PrincipalNameResolver} which resolves the principal name from
+ * Spring Security Context.
+ *
+ * @author Rob Winch
+ * @author Vedran Pavic
+ */
+public class SpringSecurityPrincipalNameResolver implements PrincipalNameResolver {
+
+	private static final String SPRING_SECURITY_CONTEXT = "SPRING_SECURITY_CONTEXT";
+
+	private SpelExpressionParser parser = new SpelExpressionParser();
+
+	@Override
+	public String resolvePrincipal(Session session) {
+		String principalName = session.getAttribute(
+				FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME);
+		if (principalName != null) {
+			return principalName;
+		}
+		Object authentication = session.getAttribute(SPRING_SECURITY_CONTEXT);
+		if (authentication != null) {
+			Expression expression = parser.parseExpression("authentication?.name");
+			return expression.getValue(authentication, String.class);
+		}
+		return null;
+	}
+
+}

--- a/spring-session/src/test/java/org/springframework/session/data/redis/RedisOperationsSessionRepositoryTests.java
+++ b/spring-session/src/test/java/org/springframework/session/data/redis/RedisOperationsSessionRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,15 +56,9 @@ import org.springframework.data.redis.core.BoundValueOperations;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.session.ExpiringSession;
 import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.session.MapSession;
-import org.springframework.session.data.redis.RedisOperationsSessionRepository.PrincipalNameResolver;
 import org.springframework.session.data.redis.RedisOperationsSessionRepository.RedisSession;
 import org.springframework.session.events.AbstractSessionEvent;
 
@@ -72,7 +66,6 @@ import org.springframework.session.events.AbstractSessionEvent;
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings({"unchecked","rawtypes"})
 public class RedisOperationsSessionRepositoryTests {
-	static final String SPRING_SECURITY_CONTEXT_KEY = "SPRING_SECURITY_CONTEXT";
 
 	@Mock
 	RedisConnectionFactory factory;
@@ -446,31 +439,6 @@ public class RedisOperationsSessionRepositoryTests {
 	}
 
 	@Test
-	public void resolvePrincipalIndex() {
-		PrincipalNameResolver resolver = RedisOperationsSessionRepository.PRINCIPAL_NAME_RESOLVER;
-		String username = "username";
-		RedisSession session = redisRepository.createSession();
-		session.setAttribute(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME, username);
-
-		assertThat(resolver.resolvePrincipal(session)).isEqualTo(username);
-	}
-
-	@Test
-	public void resolveIndexOnSecurityContext() {
-		String principal = "resolveIndexOnSecurityContext";
-		Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "notused", AuthorityUtils.createAuthorityList("ROLE_USER"));
-		SecurityContext context = new SecurityContextImpl();
-		context.setAuthentication(authentication);
-
-		PrincipalNameResolver resolver = RedisOperationsSessionRepository.PRINCIPAL_NAME_RESOLVER;
-
-		RedisSession session = redisRepository.createSession();
-		session.setAttribute(SPRING_SECURITY_CONTEXT_KEY, context);
-
-		assertThat(resolver.resolvePrincipal(session)).isEqualTo(principal);
-	}
-
-	@Test
 	public void flushModeOnSaveCreate() {
 		redisRepository.createSession();
 
@@ -594,6 +562,11 @@ public class RedisOperationsSessionRepositoryTests {
 	@Test(expected = IllegalArgumentException.class)
 	public void setRedisFlushModeNull() {
 		redisRepository.setRedisFlushMode(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setPrincipalNameResolverNull() {
+		redisRepository.setPrincipalNameResolver(null);
 	}
 
 	private String getKey(String id) {

--- a/spring-session/src/test/java/org/springframework/session/security/SpringSecurityPrincipalNameResolverTests.java
+++ b/spring-session/src/test/java/org/springframework/session/security/SpringSecurityPrincipalNameResolverTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.security;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.MapSession;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SpringSecurityPrincipalNameResolver}.
+ *
+ * @author Rob Winch
+ * @author Vedran Pavic
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SpringSecurityPrincipalNameResolverTests {
+
+	private static final String SPRING_SECURITY_CONTEXT = "SPRING_SECURITY_CONTEXT";
+
+	private SpringSecurityPrincipalNameResolver resolver = new SpringSecurityPrincipalNameResolver();
+
+	@Test
+	public void resolvePrincipalIndex() {
+		String username = "username";
+		MapSession session = new MapSession();
+		session.setAttribute(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME, username);
+
+		assertThat(this.resolver.resolvePrincipal(session)).isEqualTo(username);
+	}
+
+	@Test
+	public void resolveIndexOnSecurityContext() {
+		String principal = "resolveIndexOnSecurityContext";
+		Authentication authentication = new UsernamePasswordAuthenticationToken(
+				principal, "notused", AuthorityUtils.createAuthorityList("ROLE_USER"));
+		SecurityContext context = new SecurityContextImpl();
+		context.setAuthentication(authentication);
+
+		MapSession session = new MapSession();
+		session.setAttribute(SPRING_SECURITY_CONTEXT, context);
+
+		assertThat(this.resolver.resolvePrincipal(session)).isEqualTo(principal);
+	}
+
+}


### PR DESCRIPTION
While working on a PR for #364, I've noticed that I also required the same functionality that ```RedisOperationsSessionRepository``` implements in its inner ```PrincipalNameResolver```. Further inspection showed that ```AbstractGemFireOperationsSessionRepository``` has the same functionality implemented internally.

To avoid code duplication this PR extracts ```PrincipalNameResolver``` as a strategy interface and provides the default implementation based on Spring Security (effectively the same to the current implementation) and a test class.

I've signed the CLA.