### PR TITLE
Fixes gh-396

### DIFF
--- a/spring-session/src/integration-test/java/org/springframework/session/data/gemfire/AbstractGemFireIntegrationTests.java
+++ b/spring-session/src/integration-test/java/org/springframework/session/data/gemfire/AbstractGemFireIntegrationTests.java
@@ -62,7 +62,7 @@ import com.gemstone.gemfire.cache.server.CacheServer;
  * @see com.gemstone.gemfire.cache.server.CacheServer
  * @since 1.1.0
  */
-public class AbstractGemFireIntegrationTests {
+public abstract class AbstractGemFireIntegrationTests {
 
 	protected static final boolean DEFAULT_ENABLE_QUERY_DEBUGGING = false;
 	protected static final boolean GEMFIRE_QUERY_DEBUG = Boolean.getBoolean("spring.session.data.gemfire.query.debug");

--- a/spring-session/src/integration-test/java/org/springframework/session/data/gemfire/ClientServerGemFireOperationsSessionRepositoryIntegrationTests.java
+++ b/spring-session/src/integration-test/java/org/springframework/session/data/gemfire/ClientServerGemFireOperationsSessionRepositoryIntegrationTests.java
@@ -49,12 +49,12 @@ import org.springframework.data.gemfire.server.CacheServerFactoryBean;
 import org.springframework.data.gemfire.support.ConnectionEndpoint;
 import org.springframework.session.ExpiringSession;
 import org.springframework.session.data.gemfire.config.annotation.web.http.EnableGemFireHttpSession;
-import org.springframework.session.data.gemfire.config.annotation.web.http.GemFireHttpSessionConfiguration;
 import org.springframework.session.data.gemfire.support.GemFireUtils;
 import org.springframework.session.events.AbstractSessionEvent;
 import org.springframework.session.events.SessionCreatedEvent;
 import org.springframework.session.events.SessionDeletedEvent;
 import org.springframework.session.events.SessionExpiredEvent;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -78,6 +78,7 @@ import com.gemstone.gemfire.cache.client.Pool;
  * @see org.springframework.session.data.gemfire.AbstractGemFireIntegrationTests
  * @see org.springframework.session.data.gemfire.config.annotation.web.http.EnableGemFireHttpSession
  * @see org.springframework.session.data.gemfire.config.annotation.web.http.GemFireHttpSessionConfiguration
+ * @see org.springframework.test.annotation.DirtiesContext
  * @see org.springframework.test.context.ContextConfiguration
  * @see org.springframework.test.context.junit4.SpringJUnit4ClassRunner
  * @see org.springframework.test.context.web.WebAppConfiguration
@@ -90,6 +91,7 @@ import com.gemstone.gemfire.cache.client.Pool;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes =
 	ClientServerGemFireOperationsSessionRepositoryIntegrationTests.SpringSessionGemFireClientConfiguration.class)
+@DirtiesContext
 @WebAppConfiguration
 public class ClientServerGemFireOperationsSessionRepositoryIntegrationTests extends AbstractGemFireIntegrationTests {
 
@@ -100,6 +102,8 @@ public class ClientServerGemFireOperationsSessionRepositoryIntegrationTests exte
 	private static File processWorkingDirectory;
 
 	private static Process gemfireServer;
+
+	private static final String SPRING_SESSION_GEMFIRE_REGION_NAME = "TestClientServerSessions";
 
 	@Autowired
 	private SessionEventListener sessionEventListener;
@@ -147,7 +151,7 @@ public class ClientServerGemFireOperationsSessionRepositoryIntegrationTests exte
 		assertThat(GemFireUtils.isClient(gemfireCache)).isTrue();
 
 		Region<Object, ExpiringSession> springSessionGemFireRegion = gemfireCache.getRegion(
-			GemFireHttpSessionConfiguration.DEFAULT_SPRING_SESSION_GEMFIRE_REGION_NAME);
+			SPRING_SESSION_GEMFIRE_REGION_NAME);
 
 		assertThat(springSessionGemFireRegion).isNotNull();
 
@@ -235,7 +239,8 @@ public class ClientServerGemFireOperationsSessionRepositoryIntegrationTests exte
 		assertThat(deletedSession).isNull();
 	}
 
-	@EnableGemFireHttpSession(maxInactiveIntervalInSeconds = MAX_INACTIVE_INTERVAL_IN_SECONDS)
+	@EnableGemFireHttpSession(regionName =  SPRING_SESSION_GEMFIRE_REGION_NAME,
+		maxInactiveIntervalInSeconds = MAX_INACTIVE_INTERVAL_IN_SECONDS)
 	static class SpringSessionGemFireClientConfiguration {
 
 		//TODO remove when SGF-458 is released
@@ -313,7 +318,8 @@ public class ClientServerGemFireOperationsSessionRepositoryIntegrationTests exte
 		}
 	}
 
-	@EnableGemFireHttpSession(maxInactiveIntervalInSeconds = MAX_INACTIVE_INTERVAL_IN_SECONDS)
+	@EnableGemFireHttpSession(regionName = SPRING_SESSION_GEMFIRE_REGION_NAME,
+		maxInactiveIntervalInSeconds = MAX_INACTIVE_INTERVAL_IN_SECONDS)
 	static class SpringSessionGemFireServerConfiguration {
 
 		static final int MAX_CONNECTIONS = 50;

--- a/spring-session/src/integration-test/java/org/springframework/session/data/gemfire/GemFireOperationsSessionRepositoryIntegrationTests.java
+++ b/spring-session/src/integration-test/java/org/springframework/session/data/gemfire/GemFireOperationsSessionRepositoryIntegrationTests.java
@@ -39,6 +39,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.session.ExpiringSession;
 import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.session.data.gemfire.config.annotation.web.http.EnableGemFireHttpSession;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -64,13 +65,17 @@ import com.gemstone.gemfire.pdx.PdxWriter;
  * @see org.junit.runner.RunWith
  * @see org.springframework.session.data.gemfire.AbstractGemFireIntegrationTests
  * @see org.springframework.session.data.gemfire.GemFireOperationsSessionRepository
+ * @see org.springframework.test.annotation.DirtiesContext
  * @see org.springframework.test.context.ContextConfiguration
  * @see org.springframework.test.context.junit4.SpringJUnit4ClassRunner
  * @see org.springframework.test.context.web.WebAppConfiguration
+ * @see com.gemstone.gemfire.cache.Cache
+ * @see com.gemstone.gemfire.cache.Region
  * @since 1.1.0
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
+@DirtiesContext
 @WebAppConfiguration
 public class GemFireOperationsSessionRepositoryIntegrationTests extends AbstractGemFireIntegrationTests {
 

--- a/spring-session/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/EnableGemFireHttpSessionEventsIntegrationTests.java
+++ b/spring-session/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/EnableGemFireHttpSessionEventsIntegrationTests.java
@@ -36,6 +36,7 @@ import org.springframework.session.events.AbstractSessionEvent;
 import org.springframework.session.events.SessionCreatedEvent;
 import org.springframework.session.events.SessionDeletedEvent;
 import org.springframework.session.events.SessionExpiredEvent;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -58,6 +59,7 @@ import com.gemstone.gemfire.cache.RegionShortcut;
  * @see org.springframework.session.events.SessionCreatedEvent
  * @see org.springframework.session.events.SessionDeletedEvent
  * @see org.springframework.session.events.SessionExpiredEvent
+ * @see org.springframework.test.annotation.DirtiesContext
  * @see org.springframework.test.context.ContextConfiguration
  * @see org.springframework.test.context.junit4.SpringJUnit4ClassRunner
  * @see org.springframework.test.context.web.WebAppConfiguration
@@ -66,6 +68,7 @@ import com.gemstone.gemfire.cache.RegionShortcut;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
+@DirtiesContext
 @WebAppConfiguration
 public class EnableGemFireHttpSessionEventsIntegrationTests extends AbstractGemFireIntegrationTests {
 

--- a/spring-session/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionJavaConfigurationTests.java
+++ b/spring-session/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionJavaConfigurationTests.java
@@ -42,10 +42,20 @@ import com.gemstone.gemfire.cache.query.Index;
 import com.gemstone.gemfire.cache.query.QueryService;
 
 /**
- * The GemFireHttpSessionJavaConfigurationTests class...
+ * The GemFireHttpSessionJavaConfigurationTests class is a test suite of test cases testing the configuration of
+ * Spring Session backed by GemFire using Java-based configuration meta-data.
  *
  * @author John Blum
- * @since 1.0.0
+ * @see org.junit.Test
+ * @see org.springframework.session.ExpiringSession
+ * @see org.springframework.session.data.gemfire.AbstractGemFireIntegrationTests
+ * @see org.springframework.test.annotation.DirtiesContext
+ * @see org.springframework.test.context.ContextConfiguration
+ * @see org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+ * @see org.springframework.test.context.web.WebAppConfiguration
+ * @see com.gemstone.gemfire.cache.Cache
+ * @see com.gemstone.gemfire.cache.Region
+ * @since 1.1.0
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -68,7 +78,7 @@ public class GemFireHttpSessionJavaConfigurationTests extends AbstractGemFireInt
 
 	@Test
 	public void gemfireCacheConfigurationIsValid() {
-		Region<Object, ExpiringSession> example = assertCacheAndRegion(gemfireCache, "Example",
+		Region<Object, ExpiringSession> example = assertCacheAndRegion(gemfireCache, "JavaExample",
 			DataPolicy.REPLICATE);
 
 		assertEntryIdleTimeout(example, ExpirationAction.INVALIDATE, 900);
@@ -76,7 +86,7 @@ public class GemFireHttpSessionJavaConfigurationTests extends AbstractGemFireInt
 
 	@Test
 	public void verifyGemFireExampleCacheRegionPrincipalNameIndexWasCreatedSuccessfully() {
-		Region<Object, ExpiringSession> example = assertCacheAndRegion(gemfireCache, "Example",
+		Region<Object, ExpiringSession> example = assertCacheAndRegion(gemfireCache, "JavaExample",
 			DataPolicy.REPLICATE);
 
 		QueryService queryService = example.getRegionService().getQueryService();
@@ -90,7 +100,7 @@ public class GemFireHttpSessionJavaConfigurationTests extends AbstractGemFireInt
 
 	@Test
 	public void verifyGemFireExampleCacheRegionSessionAttributesIndexWasNotCreated() {
-		Region<Object, ExpiringSession> example = assertCacheAndRegion(gemfireCache, "Example",
+		Region<Object, ExpiringSession> example = assertCacheAndRegion(gemfireCache, "JavaExample",
 			DataPolicy.REPLICATE);
 
 		QueryService queryService = example.getRegionService().getQueryService();
@@ -103,7 +113,7 @@ public class GemFireHttpSessionJavaConfigurationTests extends AbstractGemFireInt
 	}
 
 	@EnableGemFireHttpSession(indexableSessionAttributes = {}, maxInactiveIntervalInSeconds = 900,
-		regionName = "Example", serverRegionShortcut = RegionShortcut.REPLICATE)
+		regionName = "JavaExample", serverRegionShortcut = RegionShortcut.REPLICATE)
 	public static class GemFireConfiguration {
 
 		@Bean

--- a/spring-session/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionXmlConfigurationTests.java
+++ b/spring-session/src/integration-test/java/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionXmlConfigurationTests.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.session.ExpiringSession;
 import org.springframework.session.data.gemfire.AbstractGemFireIntegrationTests;
 import org.springframework.session.data.gemfire.support.GemFireUtils;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -43,13 +44,17 @@ import com.gemstone.gemfire.cache.query.QueryService;
  * @see org.junit.Test
  * @see org.springframework.session.ExpiringSession
  * @see org.springframework.session.data.gemfire.AbstractGemFireIntegrationTests
+ * @see org.springframework.test.annotation.DirtiesContext
  * @see org.springframework.test.context.ContextConfiguration
- * @see org.springframework.test.context.web.WebAppConfiguration
  * @see org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+ * @see org.springframework.test.context.web.WebAppConfiguration
+ * @see com.gemstone.gemfire.cache.Cache
+ * @see com.gemstone.gemfire.cache.Region
  * @since 1.1.0
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
+@DirtiesContext
 @WebAppConfiguration
 public class GemFireHttpSessionXmlConfigurationTests extends AbstractGemFireIntegrationTests {
 
@@ -68,14 +73,14 @@ public class GemFireHttpSessionXmlConfigurationTests extends AbstractGemFireInte
 
 	@Test
 	public void gemfireCacheConfigurationIsValid() {
-		Region<Object, ExpiringSession> example = assertCacheAndRegion(gemfireCache, "Example", DataPolicy.NORMAL);
+		Region<Object, ExpiringSession> example = assertCacheAndRegion(gemfireCache, "XmlExample", DataPolicy.NORMAL);
 
 		assertEntryIdleTimeout(example, ExpirationAction.INVALIDATE, 3600);
 	}
 
 	@Test
 	public void verifyGemFireExampleCacheRegionPrincipalNameIndexWasCreatedSuccessfully() {
-		Region<Object, ExpiringSession> example = assertCacheAndRegion(gemfireCache, "Example", DataPolicy.NORMAL);
+		Region<Object, ExpiringSession> example = assertCacheAndRegion(gemfireCache, "XmlExample", DataPolicy.NORMAL);
 
 		QueryService queryService = example.getRegionService().getQueryService();
 
@@ -88,7 +93,7 @@ public class GemFireHttpSessionXmlConfigurationTests extends AbstractGemFireInte
 
 	@Test
 	public void verifyGemFireExampleCacheRegionSessionAttributesIndexWasCreatedSuccessfully() {
-		Region<Object, ExpiringSession> example = assertCacheAndRegion(gemfireCache, "Example", DataPolicy.NORMAL);
+		Region<Object, ExpiringSession> example = assertCacheAndRegion(gemfireCache, "XmlExample", DataPolicy.NORMAL);
 
 		QueryService queryService = example.getRegionService().getQueryService();
 

--- a/spring-session/src/test/java/org/springframework/session/data/gemfire/AbstractGemFireOperationsSessionRepositoryTest.java
+++ b/spring-session/src/test/java/org/springframework/session/data/gemfire/AbstractGemFireOperationsSessionRepositoryTest.java
@@ -227,7 +227,7 @@ public class AbstractGemFireOperationsSessionRepositoryTest {
 		ApplicationEventPublisher mockApplicationEventPublisher = mock(ApplicationEventPublisher.class);
 
 		doAnswer(new Answer<Void>() {
-			public Void answer(final InvocationOnMock invocation) throws Throwable {
+			public Void answer(InvocationOnMock invocation) throws Throwable {
 				ApplicationEvent applicationEvent = invocation.getArgumentAt(0, ApplicationEvent.class);
 
 				assertThat(applicationEvent).isInstanceOf(SessionCreatedEvent.class);
@@ -267,7 +267,7 @@ public class AbstractGemFireOperationsSessionRepositoryTest {
 		ApplicationEventPublisher mockApplicationEventPublisher = mock(ApplicationEventPublisher.class);
 
 		doAnswer(new Answer<Void>() {
-			public Void answer(final InvocationOnMock invocation) throws Throwable {
+			public Void answer(InvocationOnMock invocation) throws Throwable {
 				ApplicationEvent applicationEvent = invocation.getArgumentAt(0, ApplicationEvent.class);
 
 				assertThat(applicationEvent).isInstanceOf(SessionCreatedEvent.class);
@@ -302,7 +302,7 @@ public class AbstractGemFireOperationsSessionRepositoryTest {
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void afterCreatedWithNonSessionTypeDoesNotPublishSessionCreatedEvent() {
 		TestGemFireOperationsSessionRepository sessionRepository = new TestGemFireOperationsSessionRepository(mockGemfireOperations) {
-			@Override protected void handleCreated(final String sessionId, final ExpiringSession session) {
+			@Override protected void handleCreated(String sessionId, ExpiringSession session) {
 				fail("handleCreated(..) should not have been called");
 			}
 		};
@@ -310,7 +310,7 @@ public class AbstractGemFireOperationsSessionRepositoryTest {
 		EntryEvent mockEntryEvent = mock(EntryEvent.class);
 
 		when(mockEntryEvent.getKey()).thenReturn("abc123");
-		when(mockEntryEvent.getNewValue()).thenReturn(new Object());
+		when(mockEntryEvent.getNewValue()).thenReturn(new Tombstone());
 
 		sessionRepository.afterCreate((EntryEvent<Object, ExpiringSession>) mockEntryEvent);
 
@@ -330,7 +330,7 @@ public class AbstractGemFireOperationsSessionRepositoryTest {
 		ApplicationEventPublisher mockApplicationEventPublisher = mock(ApplicationEventPublisher.class);
 
 		doAnswer(new Answer<Void>() {
-			public Void answer(final InvocationOnMock invocation) throws Throwable {
+			public Void answer(InvocationOnMock invocation) throws Throwable {
 				ApplicationEvent applicationEvent = invocation.getArgumentAt(0, ApplicationEvent.class);
 
 				assertThat(applicationEvent).isInstanceOf(SessionDestroyedEvent.class);
@@ -370,7 +370,7 @@ public class AbstractGemFireOperationsSessionRepositoryTest {
 		ApplicationEventPublisher mockApplicationEventPublisher = mock(ApplicationEventPublisher.class);
 
 		doAnswer(new Answer<Void>() {
-			public Void answer(final InvocationOnMock invocation) throws Throwable {
+			public Void answer(InvocationOnMock invocation) throws Throwable {
 				ApplicationEvent applicationEvent = invocation.getArgumentAt(0, ApplicationEvent.class);
 
 				assertThat(applicationEvent).isInstanceOf(SessionDestroyedEvent.class);
@@ -409,7 +409,7 @@ public class AbstractGemFireOperationsSessionRepositoryTest {
 		ApplicationEventPublisher mockApplicationEventPublisher = mock(ApplicationEventPublisher.class);
 
 		doAnswer(new Answer<Void>() {
-			public Void answer(final InvocationOnMock invocation) throws Throwable {
+			public Void answer(InvocationOnMock invocation) throws Throwable {
 				ApplicationEvent applicationEvent = invocation.getArgumentAt(0, ApplicationEvent.class);
 
 				assertThat(applicationEvent).isInstanceOf(SessionDestroyedEvent.class);
@@ -427,7 +427,7 @@ public class AbstractGemFireOperationsSessionRepositoryTest {
 		EntryEvent mockEntryEvent = mock(EntryEvent.class);
 
 		when(mockEntryEvent.getKey()).thenReturn(sessionId);
-		when(mockEntryEvent.getOldValue()).thenReturn(new Object());
+		when(mockEntryEvent.getOldValue()).thenReturn(new Tombstone());
 
 		sessionRepository.setApplicationEventPublisher(mockApplicationEventPublisher);
 		sessionRepository.afterDestroy((EntryEvent<Object, ExpiringSession>) mockEntryEvent);
@@ -451,7 +451,7 @@ public class AbstractGemFireOperationsSessionRepositoryTest {
 		ApplicationEventPublisher mockApplicationEventPublisher = mock(ApplicationEventPublisher.class);
 
 		doAnswer(new Answer<Void>() {
-			public Void answer(final InvocationOnMock invocation) throws Throwable {
+			public Void answer(InvocationOnMock invocation) throws Throwable {
 				ApplicationEvent applicationEvent = invocation.getArgumentAt(0, ApplicationEvent.class);
 
 				assertThat(applicationEvent).isInstanceOf(SessionExpiredEvent.class);
@@ -491,7 +491,7 @@ public class AbstractGemFireOperationsSessionRepositoryTest {
 		ApplicationEventPublisher mockApplicationEventPublisher = mock(ApplicationEventPublisher.class);
 
 		doAnswer(new Answer<Void>() {
-			public Void answer(final InvocationOnMock invocation) throws Throwable {
+			public Void answer(InvocationOnMock invocation) throws Throwable {
 				ApplicationEvent applicationEvent = invocation.getArgumentAt(0, ApplicationEvent.class);
 
 				assertThat(applicationEvent).isInstanceOf(SessionExpiredEvent.class);
@@ -530,7 +530,7 @@ public class AbstractGemFireOperationsSessionRepositoryTest {
 		ApplicationEventPublisher mockApplicationEventPublisher = mock(ApplicationEventPublisher.class);
 
 		doAnswer(new Answer<Void>() {
-			public Void answer(final InvocationOnMock invocation) throws Throwable {
+			public Void answer(InvocationOnMock invocation) throws Throwable {
 				ApplicationEvent applicationEvent = invocation.getArgumentAt(0, ApplicationEvent.class);
 
 				assertThat(applicationEvent).isInstanceOf(SessionExpiredEvent.class);
@@ -548,7 +548,7 @@ public class AbstractGemFireOperationsSessionRepositoryTest {
 		EntryEvent mockEntryEvent = mock(EntryEvent.class);
 
 		when(mockEntryEvent.getKey()).thenReturn(sessionId);
-		when(mockEntryEvent.getOldValue()).thenReturn(new Object());
+		when(mockEntryEvent.getOldValue()).thenReturn(new Tombstone());
 
 		sessionRepository.setApplicationEventPublisher(mockApplicationEventPublisher);
 		sessionRepository.afterInvalidate((EntryEvent<Object, ExpiringSession>) mockEntryEvent);
@@ -571,7 +571,7 @@ public class AbstractGemFireOperationsSessionRepositoryTest {
 		ApplicationEventPublisher mockApplicationEventPublisher = mock(ApplicationEventPublisher.class);
 
 		doAnswer(new Answer<Void>() {
-			public Void answer(final InvocationOnMock invocation) throws Throwable {
+			public Void answer(InvocationOnMock invocation) throws Throwable {
 				ApplicationEvent applicationEvent = invocation.getArgumentAt(0, ApplicationEvent.class);
 
 				assertThat(applicationEvent).isInstanceOf(SessionDeletedEvent.class);
@@ -602,7 +602,7 @@ public class AbstractGemFireOperationsSessionRepositoryTest {
 		ApplicationEventPublisher mockApplicationEventPublisher = mock(ApplicationEventPublisher.class);
 
 		doAnswer(new Answer<Void>() {
-			public Void answer(final InvocationOnMock invocation) throws Throwable {
+			public Void answer(InvocationOnMock invocation) throws Throwable {
 				ApplicationEvent applicationEvent = invocation.getArgumentAt(0, ApplicationEvent.class);
 
 				assertThat(applicationEvent).isInstanceOf(SessionDeletedEvent.class);
@@ -1510,6 +1510,9 @@ public class AbstractGemFireOperationsSessionRepositoryTest {
 		public void finish() {
 			session = null;
 		}
+	}
+
+	static class Tombstone {
 	}
 
 	protected static class TestGemFireOperationsSessionRepository extends AbstractGemFireOperationsSessionRepository {

--- a/spring-session/src/test/resources/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionXmlConfigurationTests-context.xml
+++ b/spring-session/src/test/resources/org/springframework/session/data/gemfire/config/annotation/web/http/GemFireHttpSessionXmlConfigurationTests-context.xml
@@ -19,7 +19,8 @@
 	<gfe:cache properties-ref="gemfireProperties" close="true"/>
 
 	<bean class="org.springframework.session.data.gemfire.config.annotation.web.http.GemFireHttpSessionConfiguration"
-		p:indexableSessionAttributes="one, two, three" p:maxInactiveIntervalInSeconds="3600" p:springSessionGemFireRegionName="Example"
-		  p:serverRegionShortcut="#{T(com.gemstone.gemfire.cache.RegionShortcut).LOCAL}"/>
+		p:indexableSessionAttributes="one, two, three" p:maxInactiveIntervalInSeconds="3600"
+		  p:serverRegionShortcut="#{T(com.gemstone.gemfire.cache.RegionShortcut).LOCAL}"
+		  	p:springSessionGemFireRegionName="XmlExample"/>
 
 </beans>


### PR DESCRIPTION
Applies @DirtiesContext to all Spring Session Data GemFire integration tests to ensure that no lingering GemFire (peer or client) cache instances cause conflicts on downstream tests.