### PR TITLE
Fix bad reference in IndexDocTests

### DIFF
--- a/docs/src/test/java/docs/IndexDocTests.java
+++ b/docs/src/test/java/docs/IndexDocTests.java
@@ -36,7 +36,7 @@ public class IndexDocTests {
 
 	@Test
 	public void repositoryDemo() {
-		ExpiringRepositoryDemo<ExpiringSession> demo = new ExpiringRepositoryDemo<ExpiringSession>();
+		RepositoryDemo<ExpiringSession> demo = new RepositoryDemo<ExpiringSession>();
 		demo.repository = new MapSessionRepository();
 
 		demo.demo();
@@ -75,7 +75,6 @@ public class IndexDocTests {
 		demo.demo();
 	}
 
-	@SuppressWarnings("unused")
 	// tag::expire-repository-demo[]
 	public class ExpiringRepositoryDemo<S extends ExpiringSession> {
 		private SessionRepository<S> repository; // <1>


### PR DESCRIPTION
Noticed this one while working on #413.

It seems ```repositoryDemo``` demo test was intended to work with ```RepositoryDemo``` instead of ```ExpiringRepositoryDemo``` (which has its own test). Additionally, needless ```@SuppressWarnings("unused")``` was removed from ```ExpiringRepositoryDemo```.

I've signed the CLA.