### PR TITLE
gh-441 update jvmroute on failover

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
+++ b/spring-session/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
@@ -322,13 +322,29 @@ public class SessionRepositoryFilter<S extends ExpiringSession>
 		}
 
 		private S getSession(String sessionId) {
+			String cleanSessionId = removeJVMRoute(sessionId);
 			S session = SessionRepositoryFilter.this.sessionRepository
-					.getSession(sessionId);
+					.getSession(cleanSessionId);
 			if (session == null) {
 				return null;
 			}
 			session.setLastAccessedTime(System.currentTimeMillis());
 			return session;
+		}
+
+		/**
+		 * @param sessionId
+		 * @return
+		 */
+		private String removeJVMRoute(String sessionId) {
+			if (sessionId == null) {
+				return null;
+			}
+			int indexOfJvmRoute = sessionId.indexOf(".");
+			if (indexOfJvmRoute > 0) {
+				return sessionId.substring(0, indexOfJvmRoute);
+			}
+			return sessionId;
 		}
 
 		@Override

--- a/spring-session/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
+++ b/spring-session/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
@@ -332,10 +332,6 @@ public class SessionRepositoryFilter<S extends ExpiringSession>
 			return session;
 		}
 
-		/**
-		 * @param sessionId
-		 * @return
-		 */
 		private String removeJVMRoute(String sessionId) {
 			if (sessionId == null) {
 				return null;

--- a/spring-session/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
+++ b/spring-session/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
@@ -1317,6 +1317,34 @@ public class SessionRepositoryFilterTests {
 		verifyZeroInteractions(sessionRepository);
 	}
 
+	@Test
+	public void doFilterIdWithDifferentJVMRouteInCookie() throws Exception { // gh-441
+		final String ID_ATTR = "create";
+		this.filter = new SessionRepositoryFilter<ExpiringSession>(this.sessionRepository);
+		ExpiringSession createSession = this.sessionRepository.createSession();
+		this.sessionRepository.save(createSession);
+		final String id = createSession.getId();
+
+		// When the jvmroute doesn't match the configured one, it needs to be ignored when getting a session
+		final String idWithJVMRoute = id + ".jvmroute";
+		given(this.strategy.getRequestedSessionId(any(HttpServletRequest.class))).willReturn(idWithJVMRoute);
+		this.filter.setHttpSessionStrategy(this.strategy);
+		// the session should still be found...
+		setSessionCookie(idWithJVMRoute);
+
+		doFilter(new DoInFilter() {
+			@Override
+			public void doFilter(HttpServletRequest wrappedRequest) {
+				String newId = wrappedRequest.getSession().getId();
+				assertThat(newId).isNotNull();
+				assertThat(newId).isEqualTo(id);
+			}
+		});
+
+		// The cookie should be rewritten because the requested session id (with a different jvmroute) doesn't match the session id
+		verify(this.strategy, times(1)).onNewSession(any(Session.class), any(HttpServletRequest.class), any(HttpServletResponse.class));
+	}
+
 	// --- order
 
 	@Test


### PR DESCRIPTION
When getting the session from the repository, make sure we remove the jvmroute if it didn't match the configured route.

This also updates the cookie with the current jvmroute for the node.

Fixes gh-441