### PR TITLE
Enable transaction management for JdbcOperationsSessionRepository operations

### DIFF
--- a/docs/src/docs/asciidoc/guides/httpsession-jdbc-xml.adoc
+++ b/docs/src/docs/asciidoc/guides/httpsession-jdbc-xml.adoc
@@ -85,6 +85,7 @@ The filter is what is in charge of replacing the `HttpSession` implementation to
 In this instance Spring Session is backed by a relational database.
 <2> We create a `dataSource` that connects Spring Session to an embedded instance of H2 database.
 We configure the H2 database to create database tables using the SQL script which is included in Spring Session.
+<3> We create a `transactionManager` that manages transactions for previously configured `dataSource`.
 
 == XML Servlet Container Initialization
 

--- a/docs/src/docs/asciidoc/guides/httpsession-jdbc.adoc
+++ b/docs/src/docs/asciidoc/guides/httpsession-jdbc.adoc
@@ -83,6 +83,7 @@ The filter is what is in charge of replacing the `HttpSession` implementation to
 In this instance Spring Session is backed by a relational database.
 <2> We create a `dataSource` that connects Spring Session to an embedded instance of H2 database.
 We configure the H2 database to create database tables using the SQL script which is included in Spring Session.
+<3> We create a `transactionManager` that manages transactions for previously configured `dataSource`.
 
 == Java Servlet Container Initialization
 

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -1012,7 +1012,7 @@ A typical example of how to create a new instance can be seen below:
 include::{indexdoc-tests}[tags=new-jdbcoperationssessionrepository]
 ----
 
-For additional information on how to create and configure a `JdbcTemplate`, refer to the Spring Framework Reference Documentation.
+For additional information on how to create and configure `JdbcTemplate` and `PlatformTransactionManager`, refer to the Spring Framework Reference Documentation.
 
 [[api-jdbcoperationssessionrepository-config]]
 ==== EnableJdbcHttpSession
@@ -1055,6 +1055,11 @@ And with MySQL database:
 ----
 include::{session-main-resources-dir}org/springframework/session/jdbc/schema-mysql.sql[]
 ----
+
+==== Transaction management
+
+All JDBC operations in `JdbcOperationsSessionRepository` are executed in a transactional manner.
+Transactions are executed with propagation set to `REQUIRES_NEW` in order to avoid unexpected behavior due to interference with existing transactions (for example, executing `save` operation in a thread that already participates in a read-only transaction).
 
 [[community]]
 == Spring Session Community

--- a/docs/src/test/java/docs/IndexDocTests.java
+++ b/docs/src/test/java/docs/IndexDocTests.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.session.ExpiringSession;
 import org.springframework.session.MapSessionRepository;
@@ -28,6 +29,7 @@ import org.springframework.session.SessionRepository;
 import org.springframework.session.data.redis.RedisOperationsSessionRepository;
 import org.springframework.session.jdbc.JdbcOperationsSessionRepository;
 import org.springframework.session.web.http.SessionRepositoryFilter;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -124,8 +126,12 @@ public class IndexDocTests {
 
 		// ... configure JdbcTemplate ...
 
+		PlatformTransactionManager transactionManager = new DataSourceTransactionManager();
+
+		// ... configure transactionManager ...
+
 		SessionRepository<? extends ExpiringSession> repository =
-				new JdbcOperationsSessionRepository(jdbcTemplate);
+				new JdbcOperationsSessionRepository(jdbcTemplate, transactionManager);
 		// end::new-jdbcoperationssessionrepository[]
 	}
 

--- a/spring-session/src/integration-test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryITests.java
+++ b/spring-session/src/integration-test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryITests.java
@@ -46,6 +46,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -112,6 +113,15 @@ public class JdbcOperationsSessionRepositoryITests {
 		this.repository.delete(toSave.getId());
 
 		assertThat(this.repository.getSession(toSave.getId())).isNull();
+	}
+
+	@Test
+	@Transactional(readOnly = true)
+	public void savesInReadOnlyTransaction() {
+		JdbcOperationsSessionRepository.JdbcSession toSave = this.repository
+				.createSession();
+
+		this.repository.save(toSave);
 	}
 
 	@Test

--- a/spring-session/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfiguration.java
+++ b/spring-session/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.jdbc.support.lob.LobHandler;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.session.config.annotation.web.http.SpringHttpSessionConfiguration;
 import org.springframework.session.jdbc.JdbcOperationsSessionRepository;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.util.StringUtils;
 
 /**
@@ -71,9 +72,10 @@ public class JdbcHttpSessionConfiguration extends SpringHttpSessionConfiguration
 
 	@Bean
 	public JdbcOperationsSessionRepository sessionRepository(
-			@Qualifier("springSessionJdbcOperations") JdbcOperations jdbcOperations) {
-		JdbcOperationsSessionRepository sessionRepository = new JdbcOperationsSessionRepository(
-				jdbcOperations);
+			@Qualifier("springSessionJdbcOperations") JdbcOperations jdbcOperations,
+			PlatformTransactionManager transactionManager) {
+		JdbcOperationsSessionRepository sessionRepository =
+				new JdbcOperationsSessionRepository(jdbcOperations, transactionManager);
 		String tableName = getTableName();
 		if (StringUtils.hasText(tableName)) {
 			sessionRepository.setTableName(tableName);

--- a/spring-session/src/test/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfigurationTests.java
+++ b/spring-session/src/test/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfigurationTests.java
@@ -31,6 +31,7 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.jdbc.support.lob.LobHandler;
 import org.springframework.session.jdbc.JdbcOperationsSessionRepository;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -160,6 +161,11 @@ public class JdbcHttpSessionConfigurationTests {
 		@Bean
 		public DataSource dataSource() {
 			return mock(DataSource.class);
+		}
+
+		@Bean
+		public PlatformTransactionManager transactionManager() {
+			return mock(PlatformTransactionManager.class);
 		}
 
 	}


### PR DESCRIPTION
This PR adds option to enable transactional execution of write operations in ```JdbcOperationsSessionRepository```.

Transactional execution is enabled by using ```@EnableJdbcHttpSession(transactional = true)``` and providing ```PlatformTransactionManager``` or , in case of manual configuration, by setting ```PlatformTransactionManager``` directly on ```JdbcOperationsSessionRepository``` using appropriate setter method. Transactions will be executed using propagation ```REQUIRES_NEW```.

This change fixes #446 and #459.

@rwinch please review. If you're OK with this approach I'll proceed to update the PR documentation updates.

I've signed the CLA.