### PR TITLE
Spring security session registry

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 				"org.springframework:spring-websocket:${springVersion}",
 				"org.springframework:spring-messaging:${springVersion}",
 				"org.springframework:spring-jdbc:${springVersion}",
+				"org.springframework.security:spring-security-config:${springSecurityVersion}",
 				"org.springframework.security:spring-security-web:${springSecurityVersion}",
 				"org.springframework.security:spring-security-test:${springSecurityVersion}",
 				'junit:junit:4.11',

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -501,6 +501,53 @@ Before using WebSocket integration, you should be sure that you have <<httpsessi
 
 include::guides/websocket.adoc[tags=config,leveloffset=+2]
 
+[[spring-security-concurrent-sessions]]
+== Spring Security Integration
+
+Spring Session provides integration with Spring Security to support its concurrent session control.
+This allows limiting the number of active sessions that a single user can have concurrently, but unlike the default
+Spring Security support this will also work in a clustered environment. This is done by providing a custom
+implementation of Spring Security's `SessionRegistry` interface.
+
+[[spring-security-concurrent-sessions-how]]
+=== Configuring Spring Security's concurrent session management
+
+When using Spring Security's Java config DSL, you can configure the custom `SessionRegistry` through the
+`SessionManagementConfigurer` like this:
+[source,java,indent=0]
+----
+include::{docs-test-dir}docs/security/SecurityConfiguration.java[tags=class]
+----
+
+This assumes that you've also configured Spring Session to provide a `FindByIndexNameSessionRepository` that
+returns `ExpiringSession` instances.
+
+When using XML configuration, it would look something like this:
+[source,xml,indent=0]
+----
+include::{docs-test-resources-dir}docs/security/security-config.xml[tags=config]
+----
+
+This assumes that your Spring Session `SessionRegistry` bean is called `sessionRegistry`, which is the name used by all
+`SpringHttpSessionConfiguration` subclasses except for the one for MongoDB: there it's called `mongoSessionRepository`.
+
+[[spring-security-concurrent-sessions-limitations]]
+=== Limitations
+
+Out of the box, Spring Security will _expire_ a session when the configured maximum number of concurrent sessions
+has been exceeded. The effect of this expiry is that on the next request made in the context of this session, the user
+will be shown a message explaining that their session has been expired because they have logged in on some other
+device. After that, the session will be deleted.
+
+Spring Session doesn't support this concept of expiring a session programmatically, nor can it return expired sessions
+when querying for a user's sessions. Therefore this implementation simply deletes a session when it is marked as
+expired by Spring Security. That means that the user will immediately be logged out from that session without an
+explanation why that was.
+
+Spring Session's implementation of Spring Security's `SessionRegistry` interface does not support the `getAllPrincipals`
+method, as this information cannot be retrieved using Spring Session. This method is never called by Spring Security,
+so this only affects applications that access the `SessionRegistry` themselves.
+
 [[api]]
 == API Documentation
 
@@ -833,7 +880,7 @@ For example, Java Configuration can use the following:
 include::{docs-test-dir}docs/RedisHttpSessionConfigurationNoOpConfigureRedisActionTests.java[tags=configure-redis-action]
 ----
 
-XML Configuraiton can use the following:
+XML Configuration can use the following:
 
 [source,xml,indent=0]
 ----

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -534,16 +534,6 @@ This assumes that your Spring Session `SessionRegistry` bean is called `sessionR
 [[spring-security-concurrent-sessions-limitations]]
 === Limitations
 
-Out of the box, Spring Security will _expire_ a session when the configured maximum number of concurrent sessions
-has been exceeded. The effect of this expiry is that on the next request made in the context of this session, the user
-will be shown a message explaining that their session has been expired because they have logged in on some other
-device. After that, the session will be deleted.
-
-Spring Session doesn't support this concept of expiring a session programmatically, nor can it return expired sessions
-when querying for a user's sessions. Therefore this implementation simply deletes a session when it is marked as
-expired by Spring Security. That means that the user will immediately be logged out from that session without an
-explanation why that was.
-
 Spring Session's implementation of Spring Security's `SessionRegistry` interface does not support the `getAllPrincipals`
 method, as this information cannot be retrieved using Spring Session. This method is never called by Spring Security,
 so this only affects applications that access the `SessionRegistry` themselves.

--- a/docs/src/test/java/docs/security/SecurityConfiguration.java
+++ b/docs/src/test/java/docs/security/SecurityConfiguration.java
@@ -33,7 +33,7 @@ import org.springframework.session.security.SpringSessionBackedSessionRegistry;
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 	@Autowired
-	FindByIndexNameSessionRepository<? extends ExpiringSession> sessionRepository;
+	FindByIndexNameSessionRepository<ExpiringSession> sessionRepository;
 
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {

--- a/docs/src/test/java/docs/security/SecurityConfiguration.java
+++ b/docs/src/test/java/docs/security/SecurityConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package docs.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.session.ExpiringSession;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.security.SpringSessionBackedSessionRegistry;
+
+/**
+ * @author Joris Kuipers
+ */
+// tag::class[]
+@Configuration
+public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+	@Autowired
+	FindByIndexNameSessionRepository<? extends ExpiringSession> sessionRepository;
+
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+		http
+			// other config goes here...
+			.sessionManagement()
+				.maximumSessions(2)
+				.sessionRegistry(sessionRegistry());
+	}
+
+	@Bean
+	SpringSessionBackedSessionRegistry sessionRegistry() {
+		return new SpringSessionBackedSessionRegistry(this.sessionRepository);
+	}
+}
+// end::class[]

--- a/docs/src/test/resources/docs/security/security-config.xml
+++ b/docs/src/test/resources/docs/security/security-config.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:security="http://www.springframework.org/schema/security"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+						   http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+
+	<!-- tag::config[] -->
+	<security:http>
+		<!-- other config goes here... -->
+		<security:session-management>
+			<security:concurrency-control max-sessions="2" session-registry-ref="sessionRegistry"
+		</security:session-management>
+	</security:http>
+
+	<bean id="sessionRegistry"
+		  class="org.springframework.session.security.SpringSessionBackedSessionRegistry">
+		<constructor-arg ref="sessionRepository"/>
+	</bean>
+	<!-- end::config[] -->
+
+</beans>

--- a/spring-session/build.gradle
+++ b/spring-session/build.gradle
@@ -24,7 +24,8 @@ dependencies {
 			"org.springframework:spring-context:$springVersion",
 			"org.springframework:spring-web:$springVersion",
 			"org.springframework:spring-messaging:$springVersion",
-			"org.springframework:spring-websocket:$springVersion"
+			"org.springframework:spring-websocket:$springVersion",
+			"org.springframework.security:spring-security-core:$springSecurityVersion"
 	provided "javax.servlet:javax.servlet-api:$servletApiVersion"
 	integrationTestCompile "redis.clients:jedis:$jedisVersion",
 			"org.apache.commons:commons-pool2:2.2",

--- a/spring-session/src/main/java/org/springframework/session/security/SpringSessionBackedSessionInformation.java
+++ b/spring-session/src/main/java/org/springframework/session/security/SpringSessionBackedSessionInformation.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.security;
+
+import java.util.Date;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.session.SessionInformation;
+
+import org.springframework.session.ExpiringSession;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.Session;
+import org.springframework.session.SessionRepository;
+
+/**
+ * Ensures that calling {@link #expireNow()} propagates to Spring Session,
+ * since this session information contains only derived data and is not the authoritative source.
+ *
+ * @author Joris Kuipers
+ * @since 1.2
+ */
+class SpringSessionBackedSessionInformation extends SessionInformation {
+
+	private static final Log logger = LogFactory.getLog(SpringSessionBackedSessionInformation.class);
+
+	private static final String SPRING_SECURITY_CONTEXT = "SPRING_SECURITY_CONTEXT";
+
+	/**
+	 * Tries to determine the principal's name from the given Session.
+	 *
+	 * @param session Spring Session session
+	 * @return the principal's name, or empty String if it couldn't be determined
+	 */
+	private static String resolvePrincipal(Session session) {
+		String principalName = session.getAttribute(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME);
+		if (principalName != null) {
+			return principalName;
+		}
+		SecurityContext securityContext = session.getAttribute(SPRING_SECURITY_CONTEXT);
+		if (securityContext != null && securityContext.getAuthentication() != null) {
+			return securityContext.getAuthentication().getName();
+		}
+		return "";
+	}
+
+	private final SessionRepository<? extends ExpiringSession> sessionRepository;
+
+	SpringSessionBackedSessionInformation(ExpiringSession session, SessionRepository<? extends ExpiringSession> sessionRepository) {
+		super(resolvePrincipal(session), session.getId(), new Date(session.getLastAccessedTime()));
+		this.sessionRepository = sessionRepository;
+		if (session.isExpired()) {
+			super.expireNow();
+		}
+	}
+
+	@Override
+	public void expireNow() {
+		if (logger.isDebugEnabled()) {
+			logger.debug("Deleting session " + getSessionId() + " for user '" + getPrincipal() +
+					"', presumably because maximum allowed concurrent sessions was exceeded");
+		}
+		super.expireNow();
+		this.sessionRepository.delete(getSessionId());
+	}
+
+}

--- a/spring-session/src/main/java/org/springframework/session/security/SpringSessionBackedSessionRegistry.java
+++ b/spring-session/src/main/java/org/springframework/session/security/SpringSessionBackedSessionRegistry.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.security;
+
+import java.security.Principal;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.security.core.session.SessionInformation;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import org.springframework.session.ExpiringSession;
+import org.springframework.session.FindByIndexNameSessionRepository;
+
+import org.springframework.util.Assert;
+
+/**
+ * A {@link SessionRegistry} that retrieves session information from Spring Session, rather than maintaining it itself.
+ * This allows concurrent session management with Spring Security in a clustered environment.
+ * <p>
+ * Note that expiring a returned {@link SessionInformation} when exceeding the configured maximum will simply delete
+ * an existing session rather than marking it as expired, since Spring Session has no way to programmatically mark
+ * a session as expired nor to retrieve expired sessions. <br>
+ * This means that you cannot configure an expired URL; users will simply lose their session as if they logged out.
+ * <p>
+ * Relies on being able to derive the same String-based representation of the principal given to
+ * {@link #getAllSessions(Object, boolean)} as used by Spring Session in order to look up the user's sessions.
+ * <p>
+ * Does not support {@link #getAllPrincipals()}, since that information is not available.
+ *
+ * @author Joris Kuipers
+ * @since 1.2
+ */
+public class SpringSessionBackedSessionRegistry implements SessionRegistry {
+
+	private final FindByIndexNameSessionRepository<? extends ExpiringSession> sessionRepository;
+
+	public SpringSessionBackedSessionRegistry(FindByIndexNameSessionRepository<? extends ExpiringSession> sessionRepository) {
+		Assert.notNull(sessionRepository, "sessionRepository cannot be null");
+		this.sessionRepository = sessionRepository;
+	}
+
+	public List<Object> getAllPrincipals() {
+		throw new UnsupportedOperationException("SpringSessionBackedSessionRegistry does not support retrieving all principals, " +
+				"since Spring Session provides no way to obtain that information");
+	}
+
+	public List<SessionInformation> getAllSessions(Object principal, boolean includeExpiredSessions) {
+		Collection<? extends ExpiringSession> sessions =
+			this.sessionRepository.findByIndexNameAndIndexValue(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME, name(principal)).values();
+		List<SessionInformation> infos = new ArrayList<SessionInformation>();
+		for (ExpiringSession session : sessions) {
+			if (includeExpiredSessions || !session.isExpired()) {
+				infos.add(new SpringSessionBackedSessionInformation(session, this.sessionRepository));
+			}
+		}
+		return infos;
+	}
+
+	public SessionInformation getSessionInformation(String sessionId) {
+		ExpiringSession session = this.sessionRepository.getSession(sessionId);
+		if (session != null) {
+			return new SpringSessionBackedSessionInformation(session, this.sessionRepository);
+		}
+		return null;
+	}
+
+	/*
+	 * This is a no-op, as we don't administer sessions ourselves.
+	 */
+	public void refreshLastRequest(String sessionId) {
+	}
+
+	/*
+	 * This is a no-op, as we don't administer sessions ourselves.
+	 */
+	public void registerNewSession(String sessionId, Object principal) {
+	}
+
+	/*
+	 * This is a no-op, as we don't administer sessions ourselves.
+	 */
+	public void removeSessionInformation(String sessionId) {
+	}
+
+	/**
+	 * Derives a String name for the given principal.
+	 *
+	 * @param principal as provided by Spring Security
+	 * @return name of the principal, or its {@code toString()} representation if no name could be derived
+	 */
+	private String name(Object principal) {
+		if (principal instanceof UserDetails) {
+			return ((UserDetails) principal).getUsername();
+		}
+		if (principal instanceof Principal) {
+			return ((Principal) principal).getName();
+		}
+		return principal.toString();
+	}
+}

--- a/spring-session/src/test/java/org/springframework/session/security/SpringSessionBackedSessionRegistryTest.java
+++ b/spring-session/src/test/java/org/springframework/session/security/SpringSessionBackedSessionRegistryTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -34,7 +35,6 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.security.core.session.SessionInformation;
 import org.springframework.security.core.userdetails.User;
-
 import org.springframework.session.ExpiringSession;
 import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.session.MapSession;
@@ -48,7 +48,9 @@ import static org.mockito.BDDMockito.when;
 public class SpringSessionBackedSessionRegistryTest {
 
 	static final String SESSION_ID = "sessionId";
+	static final String SESSION_ID2 = "otherSessionId";
 	static final String USER_NAME = "userName";
+	static final User PRINCIPAL = new User(USER_NAME, "password", Collections.<GrantedAuthority>emptyList());
 	static final Date NOW = new Date();
 
 	@Mock
@@ -71,25 +73,40 @@ public class SpringSessionBackedSessionRegistryTest {
 	}
 
 	@Test
+	public void sessionInformationForExpiredSession() {
+		ExpiringSession session = createSession(SESSION_ID, USER_NAME, NOW.getTime());
+		session.setAttribute(SpringSessionBackedSessionInformation.EXPIRED_ATTR, Boolean.TRUE);
+		when(this.sessionRepository.getSession(SESSION_ID)).thenReturn(session);
+
+		SessionInformation sessionInfo = this.sessionRegistry.getSessionInformation(SESSION_ID);
+
+		assertThat(sessionInfo.getSessionId()).isEqualTo(SESSION_ID);
+		assertThat(sessionInfo.getLastRequest()).isEqualTo(NOW);
+		assertThat(sessionInfo.getPrincipal()).isEqualTo(USER_NAME);
+		assertThat(sessionInfo.isExpired()).isTrue();
+	}
+
+	@Test
 	public void noSessionInformationForMissingSession() {
 		assertThat(this.sessionRegistry.getSessionInformation("nonExistingSessionId")).isNull();
 	}
 
 	@Test
 	public void getAllSessions() {
-		ExpiringSession session1 = createSession(SESSION_ID, USER_NAME, NOW.getTime());
-		ExpiringSession session2 = createSession("OtherSession", USER_NAME, NOW.getTime());
-		Map<String, ExpiringSession> sessions = new LinkedHashMap<String, ExpiringSession>();
-		sessions.put(session1.getId(), session1);
-		sessions.put(session2.getId(), session2);
-		when(this.sessionRepository.findByIndexNameAndIndexValue(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME, USER_NAME)).thenReturn(sessions);
+		setUpSessions();
 
-		User principal = new User(USER_NAME, "password", Collections.<GrantedAuthority>emptyList());
-		List<SessionInformation> sessionInfos = this.sessionRegistry.getAllSessions(principal, false);
+		List<SessionInformation> allSessionInfos = this.sessionRegistry.getAllSessions(PRINCIPAL, true);
 
-		assertThat(sessionInfos).hasSize(2);
-		assertThat(sessionInfos.get(0).getSessionId()).isEqualTo(SESSION_ID);
-		assertThat(sessionInfos.get(1).getSessionId()).isEqualTo("OtherSession");
+		assertThat(allSessionInfos).extracting("sessionId").containsExactly(SESSION_ID, SESSION_ID2);
+	}
+
+	@Test
+	public void getNonExpiredSessions() {
+		setUpSessions();
+
+		List<SessionInformation> nonExpiredSessionInfos = this.sessionRegistry.getAllSessions(PRINCIPAL, false);
+
+		assertThat(nonExpiredSessionInfos).extracting("sessionId").containsExactly(SESSION_ID2);
 	}
 
 	@Test
@@ -103,7 +120,9 @@ public class SpringSessionBackedSessionRegistryTest {
 		sessionInfo.expireNow();
 
 		assertThat(sessionInfo.isExpired()).isTrue();
-		verify(this.sessionRepository).delete(SESSION_ID);
+		ArgumentCaptor<ExpiringSession> captor = ArgumentCaptor.forClass(ExpiringSession.class);
+		verify(this.sessionRepository).save(captor.capture());
+		assertThat(captor.getValue().getAttribute(SpringSessionBackedSessionInformation.EXPIRED_ATTR)).isEqualTo(Boolean.TRUE);
 	}
 
 	private ExpiringSession createSession(String sessionId, String userName, Long lastAccessed) {
@@ -115,6 +134,16 @@ public class SpringSessionBackedSessionRegistryTest {
 		securityContext.setAuthentication(authentication);
 		session.setAttribute("SPRING_SECURITY_CONTEXT", securityContext);
 		return session;
+	}
+
+	private void setUpSessions() {
+		ExpiringSession session1 = createSession(SESSION_ID, USER_NAME, NOW.getTime());
+		session1.setAttribute(SpringSessionBackedSessionInformation.EXPIRED_ATTR, Boolean.TRUE);
+		ExpiringSession session2 = createSession(SESSION_ID2, USER_NAME, NOW.getTime());
+		Map<String, ExpiringSession> sessions = new LinkedHashMap<String, ExpiringSession>();
+		sessions.put(session1.getId(), session1);
+		sessions.put(session2.getId(), session2);
+		when(this.sessionRepository.findByIndexNameAndIndexValue(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME, USER_NAME)).thenReturn(sessions);
 	}
 
 }

--- a/spring-session/src/test/java/org/springframework/session/security/SpringSessionBackedSessionRegistryTest.java
+++ b/spring-session/src/test/java/org/springframework/session/security/SpringSessionBackedSessionRegistryTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.security;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.core.session.SessionInformation;
+import org.springframework.security.core.userdetails.User;
+
+import org.springframework.session.ExpiringSession;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.MapSession;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SpringSessionBackedSessionRegistryTest {
+
+	static final String SESSION_ID = "sessionId";
+	static final String USER_NAME = "userName";
+	static final Date NOW = new Date();
+
+	@Mock
+	FindByIndexNameSessionRepository<ExpiringSession> sessionRepository;
+
+	@InjectMocks
+	SpringSessionBackedSessionRegistry sessionRegistry;
+
+	@Test
+	public void sessionInformationForExistingSession() {
+		ExpiringSession session = createSession(SESSION_ID, USER_NAME, NOW.getTime());
+		when(this.sessionRepository.getSession(SESSION_ID)).thenReturn(session);
+
+		SessionInformation sessionInfo = this.sessionRegistry.getSessionInformation(SESSION_ID);
+
+		assertThat(sessionInfo.getSessionId()).isEqualTo(SESSION_ID);
+		assertThat(sessionInfo.getLastRequest()).isEqualTo(NOW);
+		assertThat(sessionInfo.getPrincipal()).isEqualTo(USER_NAME);
+		assertThat(sessionInfo.isExpired()).isFalse();
+	}
+
+	@Test
+	public void noSessionInformationForMissingSession() {
+		assertThat(this.sessionRegistry.getSessionInformation("nonExistingSessionId")).isNull();
+	}
+
+	@Test
+	public void getAllSessions() {
+		ExpiringSession session1 = createSession(SESSION_ID, USER_NAME, NOW.getTime());
+		ExpiringSession session2 = createSession("OtherSession", USER_NAME, NOW.getTime());
+		Map<String, ExpiringSession> sessions = new LinkedHashMap<String, ExpiringSession>();
+		sessions.put(session1.getId(), session1);
+		sessions.put(session2.getId(), session2);
+		when(this.sessionRepository.findByIndexNameAndIndexValue(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME, USER_NAME)).thenReturn(sessions);
+
+		User principal = new User(USER_NAME, "password", Collections.<GrantedAuthority>emptyList());
+		List<SessionInformation> sessionInfos = this.sessionRegistry.getAllSessions(principal, false);
+
+		assertThat(sessionInfos).hasSize(2);
+		assertThat(sessionInfos.get(0).getSessionId()).isEqualTo(SESSION_ID);
+		assertThat(sessionInfos.get(1).getSessionId()).isEqualTo("OtherSession");
+	}
+
+	@Test
+	public void expireNow() {
+		ExpiringSession session = createSession(SESSION_ID, USER_NAME, NOW.getTime());
+		when(this.sessionRepository.getSession(SESSION_ID)).thenReturn(session);
+
+		SessionInformation sessionInfo = this.sessionRegistry.getSessionInformation(SESSION_ID);
+		assertThat(sessionInfo.isExpired()).isFalse();
+
+		sessionInfo.expireNow();
+
+		assertThat(sessionInfo.isExpired()).isTrue();
+		verify(this.sessionRepository).delete(SESSION_ID);
+	}
+
+	private ExpiringSession createSession(String sessionId, String userName, Long lastAccessed) {
+		MapSession session = new MapSession(sessionId);
+		session.setLastAccessedTime(lastAccessed);
+		Authentication authentication = mock(Authentication.class);
+		when(authentication.getName()).thenReturn(userName);
+		SecurityContextImpl securityContext = new SecurityContextImpl();
+		securityContext.setAuthentication(authentication);
+		session.setAttribute("SPRING_SECURITY_CONTEXT", securityContext);
+		return session;
+	}
+
+}


### PR DESCRIPTION
This provides support to use a Spring Session-backed SessionRepository for Spring Security, which allows concurrent session control in a clustered environment. It relates to https://github.com/spring-projects/spring-session/issues/65.

I've created this PR per Rob's request: I've tried to clean up my sample code that I wrote earlier a bit and have added some documentation on configuration and limitiations of the provided solution. I hope this helps!

I have already signed the Contributor License Agreement for Spring in the past.