### PR TITLE
Set collectionName attribute in MongoOperationsSessionRepository

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/data/mongo/config/annotation/web/http/MongoHttpSessionConfiguration.java
+++ b/spring-session/src/main/java/org/springframework/session/data/mongo/config/annotation/web/http/MongoHttpSessionConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.session.config.annotation.web.http.SpringHttpSessionConfiguration;
 import org.springframework.session.data.mongo.AbstractMongoSessionConverter;
 import org.springframework.session.data.mongo.MongoOperationsSessionRepository;
+import org.springframework.util.StringUtils;
 
 /**
  * Configuration class registering {@code MongoSessionRepository} bean. To import this
@@ -51,6 +52,9 @@ public class MongoHttpSessionConfiguration extends SpringHttpSessionConfiguratio
 		repository.setMaxInactiveIntervalInSeconds(this.maxInactiveIntervalInSeconds);
 		if (this.mongoSessionConverter != null) {
 			repository.setMongoSessionConverter(this.mongoSessionConverter);
+		}
+		if (StringUtils.hasText(this.collectionName)) {
+			repository.setCollectionName(this.collectionName);
 		}
 		return repository;
 	}

--- a/spring-session/src/test/java/org/springframework/session/data/mongo/config/annotation/web/http/MongoHttpSessionConfigurationTest.java
+++ b/spring-session/src/test/java/org/springframework/session/data/mongo/config/annotation/web/http/MongoHttpSessionConfigurationTest.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.IndexOperations;
 import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.session.data.mongo.MongoOperationsSessionRepository;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,6 +61,9 @@ public class MongoHttpSessionConfigurationTest {
 		assertThat(session).isNotNull();
 		assertThat(ReflectionTestUtils.getField(session, "collectionName")).isEqualTo(
 				"sessions");
+		MongoOperationsSessionRepository repository = this.context.getBean(MongoOperationsSessionRepository.class);
+		assertThat(ReflectionTestUtils.getField(repository, "collectionName")).isEqualTo(
+				"sessions");
 	}
 
 	@Test
@@ -69,6 +73,10 @@ public class MongoHttpSessionConfigurationTest {
 				.getBean(MongoHttpSessionConfiguration.class);
 		assertThat(session).isNotNull();
 		assertThat(ReflectionTestUtils.getField(session, "collectionName")).isEqualTo(
+				"testSessions");
+
+		MongoOperationsSessionRepository repository = this.context.getBean(MongoOperationsSessionRepository.class);
+		assertThat(ReflectionTestUtils.getField(repository, "collectionName")).isEqualTo(
 				"testSessions");
 	}
 
@@ -80,6 +88,9 @@ public class MongoHttpSessionConfigurationTest {
 		assertThat(session).isNotNull();
 		assertThat(ReflectionTestUtils.getField(session, "collectionName")).isEqualTo(
 				"customSession");
+		MongoOperationsSessionRepository repository = this.context.getBean(MongoOperationsSessionRepository.class);
+		assertThat(ReflectionTestUtils.getField(repository, "collectionName")).isEqualTo(
+				"customSession");
 	}
 
 	@Test
@@ -89,6 +100,9 @@ public class MongoHttpSessionConfigurationTest {
 				.getBean(MongoHttpSessionConfiguration.class);
 		assertThat(session).isNotNull();
 		assertThat(ReflectionTestUtils.getField(session, "maxInactiveIntervalInSeconds")).isEqualTo(
+				10);
+		MongoOperationsSessionRepository repository = this.context.getBean(MongoOperationsSessionRepository.class);
+		assertThat(ReflectionTestUtils.getField(repository, "maxInactiveIntervalInSeconds")).isEqualTo(
 				10);
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [x] I have signed the CLA

Previous to this commit, collectionName could be set in
MongoHttpSessionConfiguration but it was never used. Now, attribute
can be set into MongoOperationsSessionRepository to take effect.

See gh-489