### PR TITLE
Fix EnableRedisHttpSession.redisFlushMode javadoc

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/EnableRedisHttpSession.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/EnableRedisHttpSession.java
@@ -79,10 +79,10 @@ public @interface EnableRedisHttpSession {
 
 	/**
 	 * <p>
-	 * Sets the flush mode for the Redis sessions. The default is IMMEDIATE which only
+	 * Sets the flush mode for the Redis sessions. The default is ON_SAVE which only
 	 * updates the backing Redis when
 	 * {@link SessionRepository#save(org.springframework.session.Session)} is invoked. In
-	 * a web environment this happens just before the HTTP resposne is committed.
+	 * a web environment this happens just before the HTTP response is committed.
 	 * </p>
 	 * <p>
 	 * Setting the value to IMMEDIATE will ensure that the any updates to the Session are


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
```EnableRedisHttpSession.redisFlushMode``` javadoc incorrectly states that ```IMMEDIATE``` flush mode is the default.

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA