### PR TITLE
Perform save operation in mongo when something has changed

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/data/mongo/MongoOperationsSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/data/mongo/MongoOperationsSessionRepository.java
@@ -39,6 +39,7 @@ import org.springframework.session.FindByIndexNameSessionRepository;
  * done every minute.
  *
  * @author Jakub Kubrynski
+ * @author Eddú Meléndez
  * @since 1.2
  */
 public class MongoOperationsSessionRepository
@@ -70,8 +71,11 @@ public class MongoOperationsSessionRepository
 	}
 
 	public void save(MongoExpiringSession session) {
-		DBObject sessionDbObject = convertToDBObject(session);
-		this.mongoOperations.getCollection(this.collectionName).save(sessionDbObject);
+		if (session.isChanged()) {
+			DBObject sessionDbObject = convertToDBObject(session);
+			this.mongoOperations.getCollection(this.collectionName).save(sessionDbObject);
+			session.markUnchanged();
+		}
 	}
 
 	public MongoExpiringSession getSession(String id) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

Nowadays, MongoOperationsSessionRepository perform save operation at
anytime. This commit ensure to perform a save when the session is
created the first time and when something has changed.

Fixes gh-526
