### PR TITLE
Introduce IndexResolver

### DIFF
--- a/spring-session-core/src/main/java/org/springframework/session/DelegatingIndexResolver.java
+++ b/spring-session-core/src/main/java/org/springframework/session/DelegatingIndexResolver.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * An {@link IndexResolver} that resolves indexes using multiple @{link IndexResolver}
+ * delegates.
+ *
+ * @param <S> the type of Session being handled
+ * @author Vedran Pavic
+ * @since 2.2.0
+ */
+public class DelegatingIndexResolver<S extends Session> implements IndexResolver<S> {
+
+	private Set<IndexResolver<S>> delegates;
+
+	public DelegatingIndexResolver(Set<IndexResolver<S>> delegates) {
+		this.delegates = Collections.unmodifiableSet(delegates);
+	}
+
+	public Map<String, String> resolveIndexesFor(S session) {
+		Map<String, String> indexes = new HashMap<>();
+		for (IndexResolver<S> delegate : this.delegates) {
+			indexes.putAll(delegate.resolveIndexesFor(session));
+		}
+		return indexes;
+	}
+
+}

--- a/spring-session-core/src/main/java/org/springframework/session/IndexResolver.java
+++ b/spring-session-core/src/main/java/org/springframework/session/IndexResolver.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session;
+
+import java.util.Map;
+
+/**
+ * Strategy interface for resolving the {@link Session}'s indexes.
+ *
+ * @param <S> the type of Session being handled
+ * @author Rob Winch
+ * @author Vedran Pavic
+ * @since 2.2.0
+ * @see FindByIndexNameSessionRepository
+ */
+public interface IndexResolver<S extends Session> {
+
+	/**
+	 * Resolve indexes for the session.
+	 * @param session the session
+	 * @return a map of resolved indexes, never {@code null}
+	 */
+	Map<String, String> resolveIndexesFor(S session);
+
+}

--- a/spring-session-core/src/main/java/org/springframework/session/PrincipalNameIndexResolver.java
+++ b/spring-session-core/src/main/java/org/springframework/session/PrincipalNameIndexResolver.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session;
+
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+/**
+ * {@link IndexResolver} to resolve the principal name from session attribute named
+ * {@link FindByIndexNameSessionRepository#PRINCIPAL_NAME_INDEX_NAME} or Spring Security
+ * context stored in the session under {@code SPRING_SECURITY_CONTEXT} attribute.
+ *
+ * @param <S> the type of Session being handled
+ * @author Vedran Pavic
+ * @since 2.2.0
+ */
+public class PrincipalNameIndexResolver<S extends Session> extends SingleIndexResolver<S> {
+
+	private static final String SPRING_SECURITY_CONTEXT = "SPRING_SECURITY_CONTEXT";
+
+	private SpelExpressionParser parser = new SpelExpressionParser();
+
+	public PrincipalNameIndexResolver() {
+		super(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME);
+	}
+
+	public String resolveIndexValueFor(S session) {
+		String principalName = session.getAttribute(getIndexName());
+		if (principalName != null) {
+			return principalName;
+		}
+		Object authentication = session.getAttribute(SPRING_SECURITY_CONTEXT);
+		if (authentication != null) {
+			Expression expression = this.parser.parseExpression("authentication?.name");
+			return expression.getValue(authentication, String.class);
+		}
+		return null;
+	}
+
+}

--- a/spring-session-core/src/main/java/org/springframework/session/SingleIndexResolver.java
+++ b/spring-session-core/src/main/java/org/springframework/session/SingleIndexResolver.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.springframework.util.Assert;
+
+/**
+ * Base class for {@link IndexResolver}s that resolve a single index.
+ *
+ * @param <S> the type of Session being handled
+ * @author Rob Winch
+ * @author Vedran Pavic
+ * @since 2.2.0
+ */
+public abstract class SingleIndexResolver<S extends Session> implements IndexResolver<S> {
+
+	private final String indexName;
+
+	protected SingleIndexResolver(String indexName) {
+		Assert.notNull(indexName, "Index name must not be null");
+		this.indexName = indexName;
+	}
+
+	protected String getIndexName() {
+		return this.indexName;
+	}
+
+	public abstract String resolveIndexValueFor(S session);
+
+	public final Map<String, String> resolveIndexesFor(S session) {
+		String indexValue = resolveIndexValueFor(session);
+		return (indexValue != null) ? Collections.singletonMap(this.indexName, indexValue) : Collections.emptyMap();
+	}
+
+}

--- a/spring-session-core/src/test/java/org/springframework/session/DelegatingIndexResolverTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/DelegatingIndexResolverTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DelegatingIndexResolver}.
+ *
+ * @author Vedran Pavic
+ */
+class DelegatingIndexResolverTests {
+
+	private DelegatingIndexResolver<MapSession> indexResolver;
+
+	@BeforeEach
+	void setUp() {
+		Set<IndexResolver<MapSession>> delegates = new HashSet<>();
+		delegates.add(new TestIndexResolver("one"));
+		delegates.add(new TestIndexResolver("two"));
+		this.indexResolver = new DelegatingIndexResolver<>(delegates);
+	}
+
+	@Test
+	void resolve() {
+		MapSession session = new MapSession();
+		session.setAttribute("one", "first");
+		session.setAttribute("two", "second");
+		Map<String, String> indexes = this.indexResolver.resolveIndexesFor(session);
+		assertThat(indexes).hasSize(2);
+		assertThat(indexes.get("one")).isEqualTo("first");
+		assertThat(indexes.get("two")).isEqualTo("second");
+	}
+
+	private static class TestIndexResolver implements IndexResolver<MapSession> {
+
+		private String supportedIndex;
+
+		TestIndexResolver(String supportedIndex) {
+			this.supportedIndex = supportedIndex;
+		}
+
+		public Map<String, String> resolveIndexesFor(MapSession session) {
+			return Collections.singletonMap(this.supportedIndex, session.getAttribute(this.supportedIndex));
+		}
+
+	}
+
+}

--- a/spring-session-core/src/test/java/org/springframework/session/PrincipalNameIndexResolverTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/PrincipalNameIndexResolverTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextImpl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link PrincipalNameIndexResolver}.
+ *
+ * @author Vedran Pavic
+ */
+class PrincipalNameIndexResolverTests {
+
+	private static final String PRINCIPAL_NAME = "principalName";
+
+	private static final String SPRING_SECURITY_CONTEXT = "SPRING_SECURITY_CONTEXT";
+
+	private PrincipalNameIndexResolver<Session> indexResolver;
+
+	@BeforeEach
+	void setUp() {
+		this.indexResolver = new PrincipalNameIndexResolver<>();
+	}
+
+	@Test
+	void resolveFromPrincipalName() {
+		MapSession session = new MapSession();
+		session.setAttribute(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME, PRINCIPAL_NAME);
+		assertThat(this.indexResolver.resolveIndexValueFor(session)).isEqualTo(PRINCIPAL_NAME);
+	}
+
+	@Test
+	void resolveFromSpringSecurityContext() {
+		Authentication authentication = new UsernamePasswordAuthenticationToken(PRINCIPAL_NAME, "notused",
+				AuthorityUtils.createAuthorityList("ROLE_USER"));
+		SecurityContext context = new SecurityContextImpl();
+		context.setAuthentication(authentication);
+		MapSession session = new MapSession();
+		session.setAttribute(SPRING_SECURITY_CONTEXT, context);
+		assertThat(this.indexResolver.resolveIndexValueFor(session)).isEqualTo(PRINCIPAL_NAME);
+	}
+
+}

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -36,10 +37,11 @@ import org.springframework.data.redis.core.BoundHashOperations;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
-import org.springframework.expression.Expression;
-import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.session.DelegatingIndexResolver;
 import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.IndexResolver;
 import org.springframework.session.MapSession;
+import org.springframework.session.PrincipalNameIndexResolver;
 import org.springframework.session.Session;
 import org.springframework.session.events.SessionCreatedEvent;
 import org.springframework.session.events.SessionDeletedEvent;
@@ -252,8 +254,6 @@ public class RedisOperationsSessionRepository
 
 	private static final String SPRING_SECURITY_CONTEXT = "SPRING_SECURITY_CONTEXT";
 
-	static PrincipalNameResolver PRINCIPAL_NAME_RESOLVER = new PrincipalNameResolver();
-
 	/**
 	 * The default Redis database used by Spring Session.
 	 */
@@ -280,6 +280,8 @@ public class RedisOperationsSessionRepository
 	private final RedisOperations<Object, Object> sessionRedisOperations;
 
 	private final RedisSessionExpirationPolicy expirationPolicy;
+
+	private final IndexResolver<RedisSession> indexResolver;
 
 	private ApplicationEventPublisher eventPublisher = new ApplicationEventPublisher() {
 		@Override
@@ -311,6 +313,7 @@ public class RedisOperationsSessionRepository
 		this.sessionRedisOperations = sessionRedisOperations;
 		this.expirationPolicy = new RedisSessionExpirationPolicy(sessionRedisOperations, this::getExpirationsKey,
 				this::getSessionKey);
+		this.indexResolver = createIndexResolver();
 		configureSessionChannels();
 	}
 
@@ -533,7 +536,8 @@ public class RedisOperationsSessionRepository
 
 	private void cleanupPrincipalIndex(RedisSession session) {
 		String sessionId = session.getId();
-		String principal = PRINCIPAL_NAME_RESOLVER.resolvePrincipal(session);
+		Map<String, String> indexes = RedisOperationsSessionRepository.this.indexResolver.resolveIndexesFor(session);
+		String principal = indexes.get(PRINCIPAL_NAME_INDEX_NAME);
 		if (principal != null) {
 			this.sessionRedisOperations.boundSetOps(getPrincipalKey(principal)).remove(sessionId);
 		}
@@ -643,6 +647,12 @@ public class RedisOperationsSessionRepository
 		return RedisSessionMapper.ATTRIBUTE_PREFIX + attributeName;
 	}
 
+	private static DelegatingIndexResolver<RedisSession> createIndexResolver() {
+		Set<IndexResolver<RedisSession>> delegates = new HashSet<>();
+		delegates.add(new PrincipalNameIndexResolver<>());
+		return new DelegatingIndexResolver<>(delegates);
+	}
+
 	/**
 	 * A custom implementation of {@link Session} that uses a {@link MapSession} as the
 	 * basis for its mapping. It keeps track of any attributes that have changed. When
@@ -689,8 +699,9 @@ public class RedisOperationsSessionRepository
 		RedisSession(MapSession cached) {
 			Assert.notNull(cached, "MapSession cannot be null");
 			this.cached = cached;
-			this.originalPrincipalName = PRINCIPAL_NAME_RESOLVER.resolvePrincipal(this);
 			this.originalSessionId = cached.getId();
+			Map<String, String> indexes = RedisOperationsSessionRepository.this.indexResolver.resolveIndexesFor(this);
+			this.originalPrincipalName = indexes.get(PRINCIPAL_NAME_INDEX_NAME);
 		}
 
 		public void setNew(boolean isNew) {
@@ -800,7 +811,9 @@ public class RedisOperationsSessionRepository
 					RedisOperationsSessionRepository.this.sessionRedisOperations.boundSetOps(originalPrincipalRedisKey)
 							.remove(sessionId);
 				}
-				String principal = PRINCIPAL_NAME_RESOLVER.resolvePrincipal(this);
+				Map<String, String> indexes = RedisOperationsSessionRepository.this.indexResolver
+						.resolveIndexesFor(this);
+				String principal = indexes.get(PRINCIPAL_NAME_INDEX_NAME);
 				this.originalPrincipalName = principal;
 				if (principal != null) {
 					String principalRedisKey = getPrincipalKey(principal);
@@ -847,28 +860,6 @@ public class RedisOperationsSessionRepository
 			if (!"ERR no such key".equals(NestedExceptionUtils.getMostSpecificCause(ex).getMessage())) {
 				throw ex;
 			}
-		}
-
-	}
-
-	/**
-	 * Principal name resolver helper class.
-	 */
-	static class PrincipalNameResolver {
-
-		private SpelExpressionParser parser = new SpelExpressionParser();
-
-		public String resolvePrincipal(Session session) {
-			String principalName = session.getAttribute(PRINCIPAL_NAME_INDEX_NAME);
-			if (principalName != null) {
-				return principalName;
-			}
-			Object authentication = session.getAttribute(SPRING_SECURITY_CONTEXT);
-			if (authentication != null) {
-				Expression expression = this.parser.parseExpression("authentication?.name");
-				return expression.getValue(authentication, String.class);
-			}
-			return null;
 		}
 
 	}

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisOperationsSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisOperationsSessionRepositoryTests.java
@@ -45,15 +45,9 @@ import org.springframework.data.redis.core.BoundValueOperations;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.session.MapSession;
 import org.springframework.session.Session;
-import org.springframework.session.data.redis.RedisOperationsSessionRepository.PrincipalNameResolver;
 import org.springframework.session.data.redis.RedisOperationsSessionRepository.RedisSession;
 import org.springframework.session.events.AbstractSessionEvent;
 
@@ -595,32 +589,6 @@ class RedisOperationsSessionRepositoryTests {
 		verifyZeroInteractions(this.publisher);
 		verifyZeroInteractions(this.redisOperations);
 		verifyZeroInteractions(this.boundHashOperations);
-	}
-
-	@Test
-	void resolvePrincipalIndex() {
-		PrincipalNameResolver resolver = RedisOperationsSessionRepository.PRINCIPAL_NAME_RESOLVER;
-		String username = "username";
-		RedisSession session = this.redisRepository.createSession();
-		session.setAttribute(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME, username);
-
-		assertThat(resolver.resolvePrincipal(session)).isEqualTo(username);
-	}
-
-	@Test
-	void resolveIndexOnSecurityContext() {
-		String principal = "resolveIndexOnSecurityContext";
-		Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "notused",
-				AuthorityUtils.createAuthorityList("ROLE_USER"));
-		SecurityContext context = new SecurityContextImpl();
-		context.setAuthentication(authentication);
-
-		PrincipalNameResolver resolver = RedisOperationsSessionRepository.PRINCIPAL_NAME_RESOLVER;
-
-		RedisSession session = this.redisRepository.createSession();
-		session.setAttribute(SPRING_SECURITY_CONTEXT_KEY, context);
-
-		assertThat(resolver.resolvePrincipal(session)).isEqualTo(principal);
 	}
 
 	@Test


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

This PR introduces `IndexResolver` as a strategy interface for resolving index values in `FindByIndexNameSessionRepository` implementations.

This PR assumes `IndexResolver` implementations are single purpose, meaning implementations support single index name. Each `FindByIndexNameSessionRepository` implementation then in turn defines its set of supported `IndexResolver`s. For this purpose, a convenience `CompositeIndexResolver` is provided.

Out of the box the `PrincipalNameIndexResolver` is provided as the driver for this improvement, however each `FindByIndexNameSessionRepository`` implementation can easily provide own resolvers, depending on capabilities of backing technology.

This resolves #376.