### PR TITLE
Changed maxInactiveIntervalSeconds to long in order to prevent intege…

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
@@ -464,7 +464,7 @@ public class JdbcOperationsSessionRepository implements
 	@Scheduled(cron = "0 * * * * *")
 	public void cleanUpExpiredSessions() {
 		long now = System.currentTimeMillis();
-		int maxInactiveIntervalSeconds = (this.defaultMaxInactiveInterval != null)
+		long maxInactiveIntervalSeconds = (this.defaultMaxInactiveInterval != null)
 				? this.defaultMaxInactiveInterval
 				: MapSession.DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS;
 


### PR DESCRIPTION
…r overflow

if you set timeout to 30 days  or something, you get integer overflow at below line:

    (maxInactiveIntervalSeconds * 1000)
