### PR TITLE
Fix broken samples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		maven { url "https://repo.spring.io/plugins-release" }
 	}
 	dependencies {
-		classpath("org.gradle.api.plugins:gradle-tomcat-plugin:1.2.3")
+		classpath("com.bmuschko:gradle-tomcat-plugin:2.2.5")
 		classpath("org.springframework.build.gradle:propdeps-plugin:0.0.7")
 		classpath("io.spring.gradle:spring-io-plugin:0.0.4.RELEASE")
 		classpath('me.champeau.gradle:gradle-javadoc-hotfix-plugin:0.1')

--- a/gradle/tomcat.gradle
+++ b/gradle/tomcat.gradle
@@ -3,19 +3,18 @@ buildscript {
 		maven { url "https://repo.spring.io/plugins-release" }
 	}
 	dependencies {
-		classpath("org.gradle.api.plugins:gradle-tomcat-plugin:1.2.3")
+		classpath("com.bmuschko:gradle-tomcat-plugin:2.2.5")
 	}
 }
 
 apply plugin: 'war'
-apply plugin: 'tomcat'
+apply plugin: 'com.bmuschko.tomcat'
 
 [tomcatRun,tomcatRunWar]*.contextPath = '/'
 
 
-task integrationTomcatRun(type: org.gradle.api.plugins.tomcat.tasks.TomcatRun) {
+task integrationTomcatRun(type: com.bmuschko.gradle.tomcat.tasks.TomcatRun) {
 	onlyIf { !sourceSets.integrationTest.allSource.empty }
-	buildscriptClasspath = tomcatRun.buildscriptClasspath
 	contextPath = tomcatRun.contextPath
 	daemon = true
 	tomcatClasspath = tomcatRun.tomcatClasspath
@@ -36,7 +35,7 @@ task integrationTomcatRun(type: org.gradle.api.plugins.tomcat.tasks.TomcatRun) {
 	}
 }
 
-task integrationTomcatStop(type: org.gradle.api.plugins.tomcat.tasks.TomcatStop) {
+task integrationTomcatStop(type: com.bmuschko.gradle.tomcat.tasks.TomcatStop) {
 	onlyIf { !sourceSets.integrationTest.allSource.empty }
 	doFirst {
 		stopPort = integrationTomcatRun.stopPort

--- a/gradle/tomcat7.gradle
+++ b/gradle/tomcat7.gradle
@@ -3,8 +3,6 @@ apply from: TOMCAT_GRADLE
 dependencies {
 	def tomcatVersion = '7.0.59'
 	tomcat "org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}",
-			"org.apache.tomcat.embed:tomcat-embed-logging-juli:${tomcatVersion}"
-	tomcat("org.apache.tomcat.embed:tomcat-embed-jasper:${tomcatVersion}") {
-		exclude group: 'org.eclipse.jdt.core.compiler', module: 'ecj'
-	}
+			"org.apache.tomcat.embed:tomcat-embed-logging-juli:${tomcatVersion}",
+			"org.apache.tomcat.embed:tomcat-embed-jasper:${tomcatVersion}"
 }

--- a/samples/custom-cookie/build.gradle
+++ b/samples/custom-cookie/build.gradle
@@ -2,10 +2,6 @@ apply from: JAVA_GRADLE
 apply from: TOMCAT_7_GRADLE
 apply from: SAMPLE_GRADLE
 
-configurations {
-	compile.exclude group: 'org.slf4j', module: 'slf4j-api'
-}
-
 dependencies {
 	compile project(':spring-session-data-redis'),
 			"org.springframework:spring-web:$springVersion",

--- a/samples/custom-cookie/src/main/webapp/index.jsp
+++ b/samples/custom-cookie/src/main/webapp/index.jsp
@@ -4,7 +4,8 @@
 <html lang="en">
 <head>
 	<title>Session Attributes</title>
-	<link rel="stylesheet" href="<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources"/>">
+	<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources" var="bootstrapCssLocation"/>
+	<link rel="stylesheet" href="<c:url value="${bootstrapCssLocation}"/>">
 	<style type="text/css">
 		body {
 			padding: 1em;

--- a/samples/hazelcast-spring/build.gradle
+++ b/samples/hazelcast-spring/build.gradle
@@ -2,10 +2,6 @@ apply from: JAVA_GRADLE
 apply from: TOMCAT_7_GRADLE
 apply from: SAMPLE_GRADLE
 
-configurations {
-	compile.exclude group: 'org.slf4j', module: 'slf4j-api'
-}
-
 dependencies {
 	compile project(':spring-session'),
 			"org.springframework:spring-web:$springVersion",

--- a/samples/hazelcast-spring/src/main/webapp/index.jsp
+++ b/samples/hazelcast-spring/src/main/webapp/index.jsp
@@ -4,7 +4,8 @@
 <html lang="en">
 <head>
 	<title>Secured Content</title>
-	<link rel="stylesheet" href="<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources"/>">
+	<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources" var="bootstrapCssLocation"/>
+	<link rel="stylesheet" href="<c:url value="${bootstrapCssLocation}"/>">
 	<style type="text/css">
 		body {
 			padding: 1em;

--- a/samples/hazelcast/build.gradle
+++ b/samples/hazelcast/build.gradle
@@ -2,10 +2,6 @@ apply from: JAVA_GRADLE
 apply from: TOMCAT_7_GRADLE
 apply from: SAMPLE_GRADLE
 
-configurations {
-	compile.exclude group: 'org.slf4j', module: 'slf4j-api'
-}
-
 dependencies {
 	compile project(':spring-session'),
 			"org.webjars:bootstrap:$bootstrapVersion",

--- a/samples/hazelcast/src/main/webapp/index.jsp
+++ b/samples/hazelcast/src/main/webapp/index.jsp
@@ -4,7 +4,8 @@
 <html lang="en">
 <head>
     <title>Session Attributes</title>
-    <link rel="stylesheet" href="<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources"/>">
+    <wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources" var="bootstrapCssLocation"/>
+    <link rel="stylesheet" href="<c:url value="${bootstrapCssLocation}"/>">
     <style type="text/css">
         body {
             padding: 1em;

--- a/samples/httpsession-gemfire-clientserver-xml/build.gradle
+++ b/samples/httpsession-gemfire-clientserver-xml/build.gradle
@@ -8,10 +8,6 @@ sonarqube {
 	skipProject = true
 }
 
-configurations {
-	compile.exclude group: 'org.slf4j', module: 'slf4j-api'
-}
-
 dependencies {
 	compile project(':spring-session-data-geode'),
 		"org.springframework:spring-web:$springVersion",

--- a/samples/httpsession-gemfire-clientserver-xml/src/main/webapp/WEB-INF/web.xml
+++ b/samples/httpsession-gemfire-clientserver-xml/src/main/webapp/WEB-INF/web.xml
@@ -23,7 +23,6 @@
 		<url-pattern>/*</url-pattern>
 		<dispatcher>REQUEST</dispatcher>
 		<dispatcher>ERROR</dispatcher>
-		<dispatcher>ASYNC</dispatcher>
 	</filter-mapping>
 	<!-- end::springSessionRepositoryFilter[] -->
 

--- a/samples/httpsession-gemfire-clientserver-xml/src/main/webapp/index.jsp
+++ b/samples/httpsession-gemfire-clientserver-xml/src/main/webapp/index.jsp
@@ -4,7 +4,8 @@
 <html lang="en">
 <head>
 	<title>Session Attributes</title>
-	<link rel="stylesheet" href="<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources"/>">
+	<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources" var="bootstrapCssLocation"/>
+	<link rel="stylesheet" href="<c:url value="${bootstrapCssLocation}"/>">
 	<style type="text/css">
 		body {
 			padding: 1em;

--- a/samples/httpsession-gemfire-clientserver/build.gradle
+++ b/samples/httpsession-gemfire-clientserver/build.gradle
@@ -3,10 +3,6 @@ apply from: TOMCAT_7_GRADLE
 apply plugin: "application"
 apply from: SAMPLE_GRADLE
 
-configurations {
-	compile.exclude group: 'org.slf4j', module: 'slf4j-api'
-}
-
 dependencies {
 	compile project(':spring-session-data-gemfire'),
 		"org.springframework:spring-web:$springVersion",

--- a/samples/httpsession-gemfire-clientserver/src/main/webapp/index.jsp
+++ b/samples/httpsession-gemfire-clientserver/src/main/webapp/index.jsp
@@ -4,7 +4,8 @@
 <html lang="en">
 <head>
 	<title>Session Attributes</title>
-	<link rel="stylesheet" href="<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources"/>">
+	<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources" var="bootstrapCssLocation"/>
+	<link rel="stylesheet" href="<c:url value="${bootstrapCssLocation}"/>">
 	<style type="text/css">
 		body {
 			padding: 1em;

--- a/samples/httpsession-gemfire-p2p-xml/build.gradle
+++ b/samples/httpsession-gemfire-p2p-xml/build.gradle
@@ -2,10 +2,6 @@ apply from: JAVA_GRADLE
 apply from: TOMCAT_7_GRADLE
 apply from: SAMPLE_GRADLE
 
-configurations {
-	compile.exclude group: 'org.slf4j', module: 'slf4j-api'
-}
-
 dependencies {
 	compile project(':spring-session-data-gemfire'),
 		"org.springframework:spring-web:$springVersion",

--- a/samples/httpsession-gemfire-p2p-xml/src/main/webapp/WEB-INF/web.xml
+++ b/samples/httpsession-gemfire-p2p-xml/src/main/webapp/WEB-INF/web.xml
@@ -23,9 +23,8 @@
 	<filter-mapping>
 		<filter-name>springSessionRepositoryFilter</filter-name>
 		<url-pattern>/*</url-pattern>
-                <dispatcher>REQUEST</dispatcher>
-                <dispatcher>ERROR</dispatcher>
-                <dispatcher>ASYNC</dispatcher>
+		<dispatcher>REQUEST</dispatcher>
+		<dispatcher>ERROR</dispatcher>
 	</filter-mapping>
 	<!-- end::springSessionRepositoryFilter[] -->
 

--- a/samples/httpsession-gemfire-p2p-xml/src/main/webapp/index.jsp
+++ b/samples/httpsession-gemfire-p2p-xml/src/main/webapp/index.jsp
@@ -4,7 +4,8 @@
 <html lang="en">
 <head>
     <title>Session Attributes</title>
-    <link rel="stylesheet" href="<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources"/>">
+    <wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources" var="bootstrapCssLocation"/>
+    <link rel="stylesheet" href="<c:url value="${bootstrapCssLocation}"/>">
     <style type="text/css">
         body {
             padding: 1em;

--- a/samples/httpsession-gemfire-p2p/build.gradle
+++ b/samples/httpsession-gemfire-p2p/build.gradle
@@ -2,10 +2,6 @@ apply from: JAVA_GRADLE
 apply from: TOMCAT_7_GRADLE
 apply from: SAMPLE_GRADLE
 
-configurations {
-	compile.exclude group: 'org.slf4j', module: 'slf4j-api'
-}
-
 dependencies {
 	compile project(':spring-session-data-geode'),
 		"org.springframework:spring-web:$springVersion",

--- a/samples/httpsession-gemfire-p2p/src/main/webapp/index.jsp
+++ b/samples/httpsession-gemfire-p2p/src/main/webapp/index.jsp
@@ -4,7 +4,8 @@
 <html lang="en">
 <head>
 	<title>Session Attributes</title>
-	<link rel="stylesheet" href="<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources"/>">
+	<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources" var="bootstrapCssLocation"/>
+	<link rel="stylesheet" href="<c:url value="${bootstrapCssLocation}"/>">
 	<style type="text/css">
 		body {
 			padding: 1em;

--- a/samples/httpsession-jdbc-xml/build.gradle
+++ b/samples/httpsession-jdbc-xml/build.gradle
@@ -1,10 +1,6 @@
 apply from: JAVA_GRADLE
-apply from: TOMCAT_6_GRADLE
+apply from: TOMCAT_7_GRADLE
 apply from: SAMPLE_GRADLE
-
-configurations {
-	compile.exclude group: 'org.slf4j', module: 'slf4j-api'
-}
 
 dependencies {
 	compile project(':spring-session-jdbc'),

--- a/samples/httpsession-jdbc-xml/src/main/webapp/WEB-INF/web.xml
+++ b/samples/httpsession-jdbc-xml/src/main/webapp/WEB-INF/web.xml
@@ -23,9 +23,8 @@
 	<filter-mapping>
 		<filter-name>springSessionRepositoryFilter</filter-name>
 		<url-pattern>/*</url-pattern>
-                <dispatcher>REQUEST</dispatcher>
-                <dispatcher>ERROR</dispatcher>
-                <dispatcher>ASYNC</dispatcher>
+		<dispatcher>REQUEST</dispatcher>
+		<dispatcher>ERROR</dispatcher>
 	</filter-mapping>
 	<!-- end::springSessionRepositoryFilter[] -->
 

--- a/samples/httpsession-jdbc-xml/src/main/webapp/index.jsp
+++ b/samples/httpsession-jdbc-xml/src/main/webapp/index.jsp
@@ -4,7 +4,8 @@
 <html lang="en">
 <head>
 	<title>Session Attributes</title>
-	<link rel="stylesheet" href="<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources"/>">
+	<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources" var="bootstrapCssLocation"/>
+	<link rel="stylesheet" href="<c:url value="${bootstrapCssLocation}"/>">
 	<style type="text/css">
 		body {
 			padding: 1em;

--- a/samples/httpsession-jdbc/build.gradle
+++ b/samples/httpsession-jdbc/build.gradle
@@ -2,10 +2,6 @@ apply from: JAVA_GRADLE
 apply from: TOMCAT_7_GRADLE
 apply from: SAMPLE_GRADLE
 
-configurations {
-	compile.exclude group: 'org.slf4j', module: 'slf4j-api'
-}
-
 dependencies {
 	compile project(':spring-session-jdbc'),
 			"org.springframework:spring-web:$springVersion",

--- a/samples/httpsession-jdbc/src/main/webapp/index.jsp
+++ b/samples/httpsession-jdbc/src/main/webapp/index.jsp
@@ -4,7 +4,8 @@
 <html lang="en">
 <head>
 	<title>Session Attributes</title>
-	<link rel="stylesheet" href="<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources"/>">
+	<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources" var="bootstrapCssLocation"/>
+	<link rel="stylesheet" href="<c:url value="${bootstrapCssLocation}"/>">
 	<style type="text/css">
 		body {
 			padding: 1em;

--- a/samples/httpsession-xml/build.gradle
+++ b/samples/httpsession-xml/build.gradle
@@ -1,10 +1,6 @@
 apply from: JAVA_GRADLE
-apply from: TOMCAT_6_GRADLE
+apply from: TOMCAT_7_GRADLE
 apply from: SAMPLE_GRADLE
-
-configurations {
-	compile.exclude group: 'org.slf4j', module: 'slf4j-api'
-}
 
 dependencies {
 	compile project(':spring-session-data-redis'),

--- a/samples/httpsession-xml/src/main/webapp/WEB-INF/web.xml
+++ b/samples/httpsession-xml/src/main/webapp/WEB-INF/web.xml
@@ -23,8 +23,8 @@
 	<filter-mapping>
 		<filter-name>springSessionRepositoryFilter</filter-name>
 		<url-pattern>/*</url-pattern>
-                <dispatcher>REQUEST</dispatcher>
-                <dispatcher>ERROR</dispatcher>
+		<dispatcher>REQUEST</dispatcher>
+		<dispatcher>ERROR</dispatcher>
 	</filter-mapping>
 	<!-- end::springSessionRepositoryFilter[] -->
 

--- a/samples/httpsession-xml/src/main/webapp/index.jsp
+++ b/samples/httpsession-xml/src/main/webapp/index.jsp
@@ -4,7 +4,8 @@
 <html lang="en">
 <head>
     <title>Session Attributes</title>
-    <link rel="stylesheet" href="<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources"/>">
+    <wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources" var="bootstrapCssLocation"/>
+    <link rel="stylesheet" href="<c:url value="${bootstrapCssLocation}"/>">
     <style type="text/css">
         body {
             padding: 1em;

--- a/samples/httpsession/build.gradle
+++ b/samples/httpsession/build.gradle
@@ -2,10 +2,6 @@ apply from: JAVA_GRADLE
 apply from: TOMCAT_7_GRADLE
 apply from: SAMPLE_GRADLE
 
-configurations {
-	compile.exclude group: 'org.slf4j', module: 'slf4j-api'
-}
-
 dependencies {
 	compile project(':spring-session-data-redis'),
 			"org.springframework:spring-web:$springVersion",

--- a/samples/httpsession/src/main/webapp/index.jsp
+++ b/samples/httpsession/src/main/webapp/index.jsp
@@ -1,9 +1,11 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="wj" uri="http://www.webjars.org/tags" %>
 <!DOCTYPE html>
 <html lang="en">
 <head>
 	<title>Session Attributes</title>
-	<link rel="stylesheet" href="<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources"/>">
+	<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources" var="bootstrapCssLocation"/>
+	<link rel="stylesheet" href="<c:url value="${bootstrapCssLocation}"/>">
 	<style type="text/css">
 		body {
 			padding: 1em;

--- a/samples/security/build.gradle
+++ b/samples/security/build.gradle
@@ -2,10 +2,6 @@ apply from: JAVA_GRADLE
 apply from: TOMCAT_7_GRADLE
 apply from: SAMPLE_GRADLE
 
-configurations {
-	compile.exclude group: 'org.slf4j', module: 'slf4j-api'
-}
-
 dependencies {
 	compile project(':spring-session-data-redis'),
 			"org.springframework:spring-web:$springVersion",

--- a/samples/security/src/main/webapp/index.jsp
+++ b/samples/security/src/main/webapp/index.jsp
@@ -4,7 +4,8 @@
 <html lang="en">
 <head>
 	<title>Secured Content</title>
-	<link rel="stylesheet" href="<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources"/>">
+	<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources" var="bootstrapCssLocation"/>
+	<link rel="stylesheet" href="<c:url value="${bootstrapCssLocation}"/>">
 	<style type="text/css">
 		body {
 			padding: 1em;

--- a/samples/users/build.gradle
+++ b/samples/users/build.gradle
@@ -2,10 +2,6 @@ apply from: JAVA_GRADLE
 apply from: TOMCAT_7_GRADLE
 apply from: SAMPLE_GRADLE
 
-configurations {
-	compile.exclude group: 'org.slf4j', module: 'slf4j-api'
-}
-
 dependencies {
 	compile project(':spring-session-data-redis'),
 			"org.springframework:spring-web:$springVersion",

--- a/samples/users/src/main/webapp/index.jsp
+++ b/samples/users/src/main/webapp/index.jsp
@@ -4,7 +4,8 @@
 <html lang="en">
 <head>
     <title>Demonstrates Multi User Log In</title>
-    <link rel="stylesheet" href="<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources"/>">
+    <wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources" var="bootstrapCssLocation"/>
+    <link rel="stylesheet" href="<c:url value="${bootstrapCssLocation}"/>">
     <style type="text/css">
         body {
             padding: 1em;
@@ -101,8 +102,10 @@
     <!-- Bootstrap core JavaScript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="<wj:locate path="jquery.min.js" relativeTo="META-INF/resources"/>"></script>
-    <script src="<wj:locate path="bootstrap.min.js" relativeTo="META-INF/resources"/>"></script>
+    <wj:locate path="jquery.min.js" relativeTo="META-INF/resources" var="jqueryLocation"/>
+    <script src="<c:url value="${jqueryLocation}"/>"></script>
+    <wj:locate path="bootstrap.min.js" relativeTo="META-INF/resources" var="bootstrapJsLocation"/>
+    <script src="<c:url value="${bootstrapJsLocation}"/>"></script>
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="<c:url value="/assets/js/ie10-viewport-bug-workaround.js"/>"></script>
 </body>

--- a/samples/users/src/main/webapp/link.jsp
+++ b/samples/users/src/main/webapp/link.jsp
@@ -4,7 +4,8 @@
 <html lang="en">
 <head>
     <title>Linked Page</title>
-    <link rel="stylesheet" href="<wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources"/>">
+    <wj:locate path="bootstrap.min.css" relativeTo="META-INF/resources" var="bootstrapCssLocation"/>
+    <link rel="stylesheet" href="<c:url value="${bootstrapCssLocation}"/>">
     <style type="text/css">
         body {
             padding: 1em;
@@ -74,8 +75,10 @@
     <!-- Bootstrap core JavaScript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="<wj:locate path="jquery.min.js" relativeTo="META-INF/resources"/>"></script>
-    <script src="<wj:locate path="bootstrap.min.js" relativeTo="META-INF/resources"/>"></script>
+    <wj:locate path="jquery.min.js" relativeTo="META-INF/resources" var="jqueryLocation"/>
+    <script src="<c:url value="${jqueryLocation}"/>"></script>
+    <wj:locate path="bootstrap.min.js" relativeTo="META-INF/resources" var="bootstrapJsLocation"/>
+    <script src="<c:url value="${bootstrapJsLocation}"/>"></script>
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="<c:url value="/assets/js/ie10-viewport-bug-workaround.js"/>"></script>
 </body>


### PR DESCRIPTION
#587 actually broke JSP based samples (sorry about that @rwinch :smile:).

This PR addresses the following issues:

- missing taglib declaration in `httpsession` sample
- Webjars locator taglib generated URLs did not consider context path
- missing SLF4J dependency that caused JSP based samples to blow up in runtime (this was in particular a nasty one since `webjars-locator` pulls in SLF4J causing [this issue](https://discuss.gradle.org/t/gradle-2-4-tomcat-plugin-with-weld-servlet-slf4j-crashes/9833) requiring the upgrade of `gradle-tomcat-plugin`)
- fixed `web.xml` errors