### PR TITLE
Fix `cleanUpExpiredSessions` operation in `JdbcOperationsSessionRepository`

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -1080,6 +1080,7 @@ However, you can override the default `ConversionService` by providing a Bean na
 
 By default, this implementation uses `SPRING_SESSION` and `SPRING_SESSION_ATTRIBUTES` tables to store sessions.
 Note that the table name can be easily customized as already described. In that case the table used to store attributes will be named using the provided table name, suffixed with `_ATTRIBUTES`.
+If further customizations are needed, SQL queries used by the repository can be customized using `set*Query` setter methods. In this case you need to manually configure the `sessionRepository` bean.
 
 Due to the differences between the various database vendors, especially when it comes to storing binary data, make sure to use SQL script specific to your database.
 Scripts for most major database vendors are packaged as `org/springframework/session/jdbc/schema-\*.sql`, where `*` is the target database type.

--- a/spring-session/src/integration-test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryITests.java
+++ b/spring-session/src/integration-test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryITests.java
@@ -18,6 +18,7 @@ package org.springframework.session.jdbc;
 
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import javax.sql.DataSource;
 
@@ -505,9 +506,7 @@ public class JdbcOperationsSessionRepositoryITests {
 	}
 
 	@Test
-	public void cleanupCleansUpInactiveSessions() {
-		this.repository.setDefaultMaxInactiveInterval(1800); // 30 minutes
-
+	public void cleanupInactiveSessionsUsingRepositoryDefinedInterval() {
 		JdbcOperationsSessionRepository.JdbcSession session = this.repository
 				.createSession();
 
@@ -517,32 +516,50 @@ public class JdbcOperationsSessionRepositoryITests {
 
 		this.repository.cleanUpExpiredSessions();
 
-		// verify its not cleaned up immediately after creation
 		assertThat(this.repository.getSession(session.getId())).isNotNull();
 
 		long now = System.currentTimeMillis();
-		long tenMinutesInMilliseconds = 1000 * 60 * 10;
-		long thirtyMinutesInMilliseconds = 1000 * 60 * 30;
 
-		// set the last accessed time to 10 minutes in the past, session should not get
-		// cleaned up because it has not been inactive for 30 minutes yet
-		long tenMinutesInThePast = now - tenMinutesInMilliseconds;
-		session.setLastAccessedTime(tenMinutesInThePast);
+		session.setLastAccessedTime(now - TimeUnit.MINUTES.toMillis(10));
 		this.repository.save(session);
-
 		this.repository.cleanUpExpiredSessions();
 
-		// session should still exist
 		assertThat(this.repository.getSession(session.getId())).isNotNull();
 
-		// set the last accessed time to 30 minutes in the past, session should get
-		// cleaned up as it has been inactive for 30 minutes
-		long thirtyMinutesInThePast = now - thirtyMinutesInMilliseconds;
-		session.setLastAccessedTime(thirtyMinutesInThePast);
+		session.setLastAccessedTime(now - TimeUnit.MINUTES.toMillis(30));
+		this.repository.save(session);
+		this.repository.cleanUpExpiredSessions();
+
+		assertThat(this.repository.getSession(session.getId())).isNull();
+	}
+
+	// gh-580
+	@Test
+	public void cleanupInactiveSessionsUsingSessionDefinedInterval() {
+		JdbcOperationsSessionRepository.JdbcSession session = this.repository
+				.createSession();
+		session.setMaxInactiveIntervalInSeconds((int) TimeUnit.MINUTES.toSeconds(45));
+
 		this.repository.save(session);
 
+		assertThat(this.repository.getSession(session.getId())).isNotNull();
+
 		this.repository.cleanUpExpiredSessions();
-		// session should have been cleaned up
+
+		assertThat(this.repository.getSession(session.getId())).isNotNull();
+
+		long now = System.currentTimeMillis();
+
+		session.setLastAccessedTime(now - TimeUnit.MINUTES.toMillis(40));
+		this.repository.save(session);
+		this.repository.cleanUpExpiredSessions();
+
+		assertThat(this.repository.getSession(session.getId())).isNotNull();
+
+		session.setLastAccessedTime(now - TimeUnit.MINUTES.toMillis(50));
+		this.repository.save(session);
+		this.repository.cleanUpExpiredSessions();
+
 		assertThat(this.repository.getSession(session.getId())).isNull();
 	}
 

--- a/spring-session/src/test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryTests.java
+++ b/spring-session/src/test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryTests.java
@@ -140,6 +140,150 @@ public class JdbcOperationsSessionRepositoryTests {
 	}
 
 	@Test
+	public void setCreateSessionQueryNull() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setCreateSessionQuery(null);
+	}
+
+	@Test
+	public void setCreateSessionQueryEmpty() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setCreateSessionQuery(" ");
+	}
+
+	@Test
+	public void setCreateSessionAttributeQueryNull() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setCreateSessionAttributeQuery(null);
+	}
+
+	@Test
+	public void setCreateSessionAttributeQueryEmpty() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setCreateSessionAttributeQuery(" ");
+	}
+
+	@Test
+	public void setGetSessionQueryNull() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setGetSessionQuery(null);
+	}
+
+	@Test
+	public void setGetSessionQueryEmpty() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setGetSessionQuery(" ");
+	}
+
+	@Test
+	public void setUpdateSessionQueryNull() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setUpdateSessionQuery(null);
+	}
+
+	@Test
+	public void setUpdateSessionQueryEmpty() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setUpdateSessionQuery(" ");
+	}
+
+	@Test
+	public void setUpdateSessionAttributeQueryNull() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setUpdateSessionAttributeQuery(null);
+	}
+
+	@Test
+	public void setUpdateSessionAttributeQueryEmpty() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setUpdateSessionAttributeQuery(" ");
+	}
+
+	@Test
+	public void setDeleteSessionAttributeQueryNull() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setDeleteSessionAttributeQuery(null);
+	}
+
+	@Test
+	public void setDeleteSessionAttributeQueryEmpty() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setDeleteSessionAttributeQuery(" ");
+	}
+
+	@Test
+	public void setDeleteSessionQueryNull() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setDeleteSessionQuery(null);
+	}
+
+	@Test
+	public void setDeleteSessionQueryEmpty() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setDeleteSessionQuery(" ");
+	}
+
+	@Test
+	public void setListSessionsByPrincipalNameQueryNull() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setListSessionsByPrincipalNameQuery(null);
+	}
+
+	@Test
+	public void setListSessionsByPrincipalNameQueryEmpty() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setListSessionsByPrincipalNameQuery(" ");
+	}
+
+	@Test
+	public void setDeleteSessionsByLastAccessTimeQueryNull() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setDeleteSessionsByLastAccessTimeQuery(null);
+	}
+
+	@Test
+	public void setDeleteSessionsByLastAccessTimeQueryEmpty() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("Query must not be empty");
+
+		this.repository.setDeleteSessionsByLastAccessTimeQuery(" ");
+	}
+
+	@Test
 	public void setLobHandlerNull() {
 		this.thrown.expect(IllegalArgumentException.class);
 		this.thrown.expectMessage("LobHandler must not be null");

--- a/spring-session/src/test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryTests.java
+++ b/spring-session/src/test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryTests.java
@@ -22,7 +22,6 @@ import java.util.Map;
 
 import javax.sql.DataSource;
 
-import org.assertj.core.data.Offset;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -522,22 +521,6 @@ public class JdbcOperationsSessionRepositoryTests {
 
 		assertPropagationRequiresNew();
 		verify(this.jdbcOperations, times(1)).update(startsWith("DELETE"), anyLong());
-	}
-
-	// gh-564
-	@Test
-	public void cleanupExpiredSessionsNoOverflow() {
-		long now = System.currentTimeMillis();
-		long toDelete = now - (new Long(Integer.MAX_VALUE) * 1000L);
-		this.repository.setDefaultMaxInactiveInterval(Integer.MAX_VALUE);
-
-		this.repository.cleanUpExpiredSessions();
-
-		ArgumentCaptor<Long> time = ArgumentCaptor.forClass(Long.class);
-		assertPropagationRequiresNew();
-		verify(this.jdbcOperations, times(1)).update(startsWith("DELETE"),
-				time.capture());
-		assertThat(time.getValue()).isCloseTo(toDelete, Offset.offset(5L));
 	}
 
 	private void assertPropagationRequiresNew() {


### PR DESCRIPTION
Currently, `JdbcOperationsSessionRepository#cleanUpExpiredSessions` only considers the repository defined max inactive interval which causes incorrect cleanup of sessions that define custom inactive interval. This commit fixes the problem by delegating calculation of deletion interval to the underlying SQL DELETE statement.

Additionally, due to shortcomings in H2 and Derby databases which make them incompatible with newly introduced DELETE statement, the setters for customizing SQL queries have been also added.

This resolves #580 and #609.