### PR TITLE
Allow using a system property to set cron task of cleaning up expired JDBC sessions

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
@@ -134,6 +134,9 @@ public class JdbcOperationsSessionRepository implements
 	 */
 	public static final String DEFAULT_TABLE_NAME = "SPRING_SESSION";
 
+	/**
+	 * The default CRON expression used by Spring Session to clean up expired sessions.
+	 */
 	public static final String CLEAN_UP_EXPIRED_SESSIONS_DEFAULT_CRON = "0 * * * * *";
 
 	private static final String SPRING_SECURITY_CONTEXT = "SPRING_SECURITY_CONTEXT";

--- a/spring-session/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
@@ -47,6 +47,7 @@ import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.support.lob.DefaultLobHandler;
 import org.springframework.jdbc.support.lob.LobHandler;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.session.ExpiringSession;
 import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.session.MapSession;
@@ -178,8 +179,6 @@ public class JdbcOperationsSessionRepository implements
 			"DELETE FROM %TABLE_NAME% " +
 					"WHERE LAST_ACCESS_TIME < ?";
 
-	public static final String CLEAN_UP_EXPIRED_SESSIONS_DEFAULT_CRON = "0 * * * * *";
-
 	private static final Log logger = LogFactory
 			.getLog(JdbcOperationsSessionRepository.class);
 
@@ -277,7 +276,6 @@ public class JdbcOperationsSessionRepository implements
 		if (session.isNew()) {
 			this.transactionOperations.execute(new TransactionCallbackWithoutResult() {
 
-				@Override
 				protected void doInTransactionWithoutResult(TransactionStatus status) {
 					JdbcOperationsSessionRepository.this.jdbcOperations.update(
 							getQuery(CREATE_SESSION_QUERY),
@@ -318,7 +316,6 @@ public class JdbcOperationsSessionRepository implements
 		else {
 			this.transactionOperations.execute(new TransactionCallbackWithoutResult() {
 
-				@Override
 				protected void doInTransactionWithoutResult(TransactionStatus status) {
 					if (session.isChanged()) {
 						JdbcOperationsSessionRepository.this.jdbcOperations.update(
@@ -422,7 +419,6 @@ public class JdbcOperationsSessionRepository implements
 	public void delete(final String id) {
 		this.transactionOperations.execute(new TransactionCallbackWithoutResult() {
 
-			@Override
 			protected void doInTransactionWithoutResult(TransactionStatus status) {
 				JdbcOperationsSessionRepository.this.jdbcOperations.update(
 						getQuery(DELETE_SESSION_QUERY), id);
@@ -465,6 +461,7 @@ public class JdbcOperationsSessionRepository implements
 		return sessionMap;
 	}
 
+	@Scheduled(cron = "0 * * * * *")
 	public void cleanUpExpiredSessions() {
 		long now = System.currentTimeMillis();
 		long maxInactiveIntervalSeconds = (this.defaultMaxInactiveInterval != null)

--- a/spring-session/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
@@ -47,7 +47,6 @@ import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.support.lob.DefaultLobHandler;
 import org.springframework.jdbc.support.lob.LobHandler;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.session.ExpiringSession;
 import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.session.MapSession;
@@ -179,6 +178,8 @@ public class JdbcOperationsSessionRepository implements
 			"DELETE FROM %TABLE_NAME% " +
 					"WHERE LAST_ACCESS_TIME < ?";
 
+	public static final String CLEAN_UP_EXPIRED_SESSIONS_DEFAULT_CRON = "0 * * * * *";
+
 	private static final Log logger = LogFactory
 			.getLog(JdbcOperationsSessionRepository.class);
 
@@ -276,6 +277,7 @@ public class JdbcOperationsSessionRepository implements
 		if (session.isNew()) {
 			this.transactionOperations.execute(new TransactionCallbackWithoutResult() {
 
+				@Override
 				protected void doInTransactionWithoutResult(TransactionStatus status) {
 					JdbcOperationsSessionRepository.this.jdbcOperations.update(
 							getQuery(CREATE_SESSION_QUERY),
@@ -316,6 +318,7 @@ public class JdbcOperationsSessionRepository implements
 		else {
 			this.transactionOperations.execute(new TransactionCallbackWithoutResult() {
 
+				@Override
 				protected void doInTransactionWithoutResult(TransactionStatus status) {
 					if (session.isChanged()) {
 						JdbcOperationsSessionRepository.this.jdbcOperations.update(
@@ -419,6 +422,7 @@ public class JdbcOperationsSessionRepository implements
 	public void delete(final String id) {
 		this.transactionOperations.execute(new TransactionCallbackWithoutResult() {
 
+			@Override
 			protected void doInTransactionWithoutResult(TransactionStatus status) {
 				JdbcOperationsSessionRepository.this.jdbcOperations.update(
 						getQuery(DELETE_SESSION_QUERY), id);
@@ -461,7 +465,6 @@ public class JdbcOperationsSessionRepository implements
 		return sessionMap;
 	}
 
-	@Scheduled(cron = "0 * * * * *")
 	public void cleanUpExpiredSessions() {
 		long now = System.currentTimeMillis();
 		long maxInactiveIntervalSeconds = (this.defaultMaxInactiveInterval != null)

--- a/spring-session/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
@@ -47,7 +47,6 @@ import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.support.lob.DefaultLobHandler;
 import org.springframework.jdbc.support.lob.LobHandler;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.session.ExpiringSession;
 import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.session.MapSession;
@@ -134,6 +133,8 @@ public class JdbcOperationsSessionRepository implements
 	 * The default name of database table used by Spring Session to store sessions.
 	 */
 	public static final String DEFAULT_TABLE_NAME = "SPRING_SESSION";
+
+	public static final String CLEAN_UP_EXPIRED_SESSIONS_DEFAULT_CRON = "0 * * * * *";
 
 	private static final String SPRING_SECURITY_CONTEXT = "SPRING_SECURITY_CONTEXT";
 
@@ -276,6 +277,7 @@ public class JdbcOperationsSessionRepository implements
 		if (session.isNew()) {
 			this.transactionOperations.execute(new TransactionCallbackWithoutResult() {
 
+				@Override
 				protected void doInTransactionWithoutResult(TransactionStatus status) {
 					JdbcOperationsSessionRepository.this.jdbcOperations.update(
 							getQuery(CREATE_SESSION_QUERY),
@@ -316,6 +318,7 @@ public class JdbcOperationsSessionRepository implements
 		else {
 			this.transactionOperations.execute(new TransactionCallbackWithoutResult() {
 
+				@Override
 				protected void doInTransactionWithoutResult(TransactionStatus status) {
 					if (session.isChanged()) {
 						JdbcOperationsSessionRepository.this.jdbcOperations.update(
@@ -419,6 +422,7 @@ public class JdbcOperationsSessionRepository implements
 	public void delete(final String id) {
 		this.transactionOperations.execute(new TransactionCallbackWithoutResult() {
 
+			@Override
 			protected void doInTransactionWithoutResult(TransactionStatus status) {
 				JdbcOperationsSessionRepository.this.jdbcOperations.update(
 						getQuery(DELETE_SESSION_QUERY), id);
@@ -461,7 +465,6 @@ public class JdbcOperationsSessionRepository implements
 		return sessionMap;
 	}
 
-	@Scheduled(cron = "0 * * * * *")
 	public void cleanUpExpiredSessions() {
 		long now = System.currentTimeMillis();
 		long maxInactiveIntervalSeconds = (this.defaultMaxInactiveInterval != null)

--- a/spring-session/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/EnableJdbcHttpSession.java
+++ b/spring-session/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/EnableJdbcHttpSession.java
@@ -87,4 +87,12 @@ public @interface EnableJdbcHttpSession {
 	 */
 	int maxInactiveIntervalInSeconds() default MapSession.DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS;
 
+	/**
+	 * The cron expression used to trigger running of the
+	 * {@link JdbcOperationsSessionRepository#cleanUpExpiredSessions()} method
+	 *
+	 * @return the cron expression used to trigger cleaning up of sessions
+	 */
+	String cleanUpCron() default JdbcOperationsSessionRepository.CLEAN_UP_EXPIRED_SESSIONS_DEFAULT_CRON;
+
 }

--- a/spring-session/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/EnableJdbcHttpSession.java
+++ b/spring-session/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/EnableJdbcHttpSession.java
@@ -89,7 +89,7 @@ public @interface EnableJdbcHttpSession {
 
 	/**
 	 * The cron expression used to trigger running of the
-	 * {@link JdbcOperationsSessionRepository#cleanUpExpiredSessions()} method
+	 * {@link JdbcOperationsSessionRepository#cleanUpExpiredSessions()} method.
 	 *
 	 * @return the cron expression used to trigger cleaning up of sessions
 	 */

--- a/spring-session/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/EnableJdbcHttpSession.java
+++ b/spring-session/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/EnableJdbcHttpSession.java
@@ -87,4 +87,11 @@ public @interface EnableJdbcHttpSession {
 	 */
 	int maxInactiveIntervalInSeconds() default MapSession.DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS;
 
+	/**
+	 * The cron expression used to trigger running of the
+	 * {@link JdbcOperationsSessionRepository#cleanUpExpiredSessions()} method
+	 *
+	 * @return the cron expression used to trigger cleaning up of sessions
+	 */
+	String cleanUpCron() default JdbcOperationsSessionRepository.CLEAN_UP_EXPIRED_SESSIONS_DEFAULT_CRON;
 }

--- a/spring-session/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/EnableJdbcHttpSession.java
+++ b/spring-session/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/EnableJdbcHttpSession.java
@@ -87,12 +87,4 @@ public @interface EnableJdbcHttpSession {
 	 */
 	int maxInactiveIntervalInSeconds() default MapSession.DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS;
 
-	/**
-	 * The cron expression used to trigger running of the
-	 * {@link JdbcOperationsSessionRepository#cleanUpExpiredSessions()} method
-	 *
-	 * @return the cron expression used to trigger cleaning up of sessions
-	 */
-	String cleanUpCron() default JdbcOperationsSessionRepository.CLEAN_UP_EXPIRED_SESSIONS_DEFAULT_CRON;
-
 }

--- a/spring-session/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfiguration.java
+++ b/spring-session/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfiguration.java
@@ -16,6 +16,8 @@
 package org.springframework.session.jdbc.config.annotation.web.http;
 
 import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import javax.sql.DataSource;
 
@@ -35,6 +37,9 @@ import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.lob.LobHandler;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.config.CronTask;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.springframework.session.config.annotation.web.http.SpringHttpSessionConfiguration;
 import org.springframework.session.jdbc.JdbcOperationsSessionRepository;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -57,11 +62,13 @@ import org.springframework.util.StringUtils;
 @Configuration
 @EnableScheduling
 public class JdbcHttpSessionConfiguration extends SpringHttpSessionConfiguration
-		implements BeanClassLoaderAware, ImportAware {
+		implements BeanClassLoaderAware, ImportAware, SchedulingConfigurer {
 
 	private String tableName;
 
 	private Integer maxInactiveIntervalInSeconds;
+
+	private String cleanUpCron;
 
 	private LobHandler lobHandler;
 
@@ -72,6 +79,9 @@ public class JdbcHttpSessionConfiguration extends SpringHttpSessionConfiguration
 	private ConversionService springSessionConversionService;
 
 	private ClassLoader classLoader;
+
+	@Autowired
+	private JdbcOperationsSessionRepository sessionRepository;
 
 	@Bean
 	public JdbcTemplate springSessionJdbcOperations(DataSource dataSource) {
@@ -104,6 +114,11 @@ public class JdbcHttpSessionConfiguration extends SpringHttpSessionConfiguration
 			sessionRepository.setConversionService(conversionService);
 		}
 		return sessionRepository;
+	}
+
+	@Bean
+	public Executor executor() {
+		return Executors.newScheduledThreadPool(10);
 	}
 
 	/**
@@ -150,6 +165,10 @@ public class JdbcHttpSessionConfiguration extends SpringHttpSessionConfiguration
 		this.maxInactiveIntervalInSeconds = maxInactiveIntervalInSeconds;
 	}
 
+	public void setCleanUpCron(String cleanUpCron) {
+		this.cleanUpCron = cleanUpCron;
+	}
+
 	private String getTableName() {
 		String systemProperty = System.getProperty("spring.session.jdbc.tableName", "");
 		if (StringUtils.hasText(systemProperty)) {
@@ -158,8 +177,26 @@ public class JdbcHttpSessionConfiguration extends SpringHttpSessionConfiguration
 		return this.tableName;
 	}
 
+	private String getCleanUpCron() {
+		String systemProperty = System.getProperty("spring.session.jdbc.cleanUpCron", "");
+		if (StringUtils.hasText(systemProperty)) {
+			return systemProperty;
+		}
+		return this.cleanUpCron;
+	}
+
 	private boolean deserializingConverterSupportsCustomClassLoader() {
 		return ClassUtils.hasConstructor(DeserializingConverter.class, ClassLoader.class);
+	}
+
+	public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+		taskRegistrar.setScheduler(executor());
+		taskRegistrar.addCronTask(new CronTask(new Runnable() {
+			public void run() {
+				JdbcHttpSessionConfiguration.this.sessionRepository
+						.cleanUpExpiredSessions();
+			}
+		}, getCleanUpCron()));
 	}
 
 	public void setImportMetadata(AnnotationMetadata importMetadata) {
@@ -169,6 +206,6 @@ public class JdbcHttpSessionConfiguration extends SpringHttpSessionConfiguration
 		this.tableName = enableAttrs.getString("tableName");
 		this.maxInactiveIntervalInSeconds = enableAttrs
 				.getNumber("maxInactiveIntervalInSeconds");
+		this.cleanUpCron = enableAttrs.getString("cleanUpCron");
 	}
-
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

Issue #616 

Allow using a system property to set CRON expression for cleaning up expired JDBC sessions.  It looks like the `@Scheduled` annotation wouldn't allow a placeholder to be resolved with a system property, so adding the task to the task registrar is now handled in the `JdbcHttpSessionConfiguration`.  Also, there is now a property on `@EnableJdbcHttpSession` to set the CRON expression.