### PR TITLE
Rename getRequestedSessionId -> getRequestedSessionIds

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/web/http/CookieHttpSessionStrategy.java
+++ b/spring-session/src/main/java/org/springframework/session/web/http/CookieHttpSessionStrategy.java
@@ -18,6 +18,7 @@ package org.springframework.session.web.http;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -135,6 +136,7 @@ import org.springframework.util.Assert;
  *
  *
  * @author Rob Winch
+ * @author Eddú Meléndez
  * @since 1.0
  */
 public final class CookieHttpSessionStrategy
@@ -168,10 +170,11 @@ public final class CookieHttpSessionStrategy
 	 */
 	private String serializationDelimiter = DEFAULT_DELIMITER;
 
-	public String getRequestedSessionId(HttpServletRequest request) {
+	public List<String> getRequestedSessionIds(HttpServletRequest request) {
 		Map<String, String> sessionIds = getSessionIds(request);
 		String sessionAlias = getCurrentSessionAlias(request);
-		return sessionIds.get(sessionAlias);
+		String sessionId = sessionIds.get(sessionAlias);
+		return sessionId == null ? Collections.<String>emptyList() : Collections.singletonList(sessionId);
 	}
 
 	public String getCurrentSessionAlias(HttpServletRequest request) {

--- a/spring-session/src/main/java/org/springframework/session/web/http/HeaderHttpSessionStrategy.java
+++ b/spring-session/src/main/java/org/springframework/session/web/http/HeaderHttpSessionStrategy.java
@@ -16,6 +16,9 @@
 
 package org.springframework.session.web.http;
 
+import java.util.Collections;
+import java.util.List;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -53,13 +56,15 @@ import org.springframework.util.Assert;
  * </pre>
  *
  * @author Rob Winch
+ * @author Eddú Meléndez
  * @since 1.0
  */
 public class HeaderHttpSessionStrategy implements HttpSessionStrategy {
 	private String headerName = "x-auth-token";
 
-	public String getRequestedSessionId(HttpServletRequest request) {
-		return request.getHeader(this.headerName);
+	public List<String> getRequestedSessionIds(HttpServletRequest request) {
+		String headerValue = request.getHeader(this.headerName);
+		return headerValue == null ? Collections.<String>emptyList() : Collections.singletonList(headerValue);
 	}
 
 	public void onNewSession(Session session, HttpServletRequest request,

--- a/spring-session/src/main/java/org/springframework/session/web/http/HttpSessionStrategy.java
+++ b/spring-session/src/main/java/org/springframework/session/web/http/HttpSessionStrategy.java
@@ -16,6 +16,8 @@
 
 package org.springframework.session.web.http;
 
+import java.util.List;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -25,21 +27,22 @@ import org.springframework.session.Session;
  * A strategy for mapping HTTP request and responses to a {@link Session}.
  *
  * @author Rob Winch
+ * @author Eddú Meléndez
  * @since 1.0
  */
 public interface HttpSessionStrategy {
 
 	/**
-	 * Obtains the requested session id from the provided
-	 * {@link javax.servlet.http.HttpServletRequest}. For example, the session id might
+	 * Obtains the requested session ids from the provided
+	 * {@link javax.servlet.http.HttpServletRequest}. For example, the session ids might
 	 * come from a cookie or a request header.
 	 *
 	 * @param request the {@link javax.servlet.http.HttpServletRequest} to obtain the
-	 * session id from. Cannot be null.
+	 * session ids from. Cannot be null.
 	 * @return the {@link javax.servlet.http.HttpServletRequest} to obtain the session id
 	 * from.
 	 */
-	String getRequestedSessionId(HttpServletRequest request);
+	List<String> getRequestedSessionIds(HttpServletRequest request);
 
 	/**
 	 * This method is invoked when a new session is created and should inform a client

--- a/spring-session/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
+++ b/spring-session/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
@@ -19,6 +19,7 @@ package org.springframework.session.web.http;
 import java.io.IOException;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.FilterChain;
@@ -53,8 +54,8 @@ import org.springframework.session.SessionRepository;
  * {@link org.springframework.session.Session} abstraction. Specifically:
  *
  * <ul>
- * <li>The session id is looked up using
- * {@link HttpSessionStrategy#getRequestedSessionId(javax.servlet.http.HttpServletRequest)}
+ * <li>The session ids is looked up using
+ * {@link HttpSessionStrategy#getRequestedSessionIds(javax.servlet.http.HttpServletRequest)}
  * . The default is to look in a cookie named SESSION.</li>
  * <li>The session id of newly created {@link org.springframework.session.ExpiringSession}
  * is sent to the client using
@@ -72,6 +73,7 @@ import org.springframework.session.SessionRepository;
  * @param <S> the {@link ExpiringSession} type.
  * @since 1.0
  * @author Rob Winch
+ * @author Eddú Meléndez
  */
 @Order(SessionRepositoryFilter.DEFAULT_ORDER)
 public class SessionRepositoryFilter<S extends ExpiringSession>
@@ -391,8 +393,12 @@ public class SessionRepositoryFilter<S extends ExpiringSession>
 
 		@Override
 		public String getRequestedSessionId() {
-			return SessionRepositoryFilter.this.httpSessionStrategy
-					.getRequestedSessionId(this);
+			List<String> sessionIds = SessionRepositoryFilter.this
+					.httpSessionStrategy.getRequestedSessionIds(this);
+			if (sessionIds.size() > 0) {
+				return sessionIds.get(0);
+			}
+			return null;
 		}
 
 		/**
@@ -431,8 +437,8 @@ public class SessionRepositoryFilter<S extends ExpiringSession>
 			this.delegate = delegate;
 		}
 
-		public String getRequestedSessionId(HttpServletRequest request) {
-			return this.delegate.getRequestedSessionId(request);
+		public List<String> getRequestedSessionIds(HttpServletRequest request) {
+			return this.delegate.getRequestedSessionIds(request);
 		}
 
 		public void onNewSession(Session session, HttpServletRequest request,

--- a/spring-session/src/test/java/org/springframework/session/web/http/CookieHttpSessionStrategyTests.java
+++ b/spring-session/src/test/java/org/springframework/session/web/http/CookieHttpSessionStrategyTests.java
@@ -49,22 +49,22 @@ public class CookieHttpSessionStrategyTests {
 
 	@Test
 	public void getRequestedSessionIdNull() throws Exception {
-		assertThat(this.strategy.getRequestedSessionId(this.request)).isNull();
+		assertThat(this.strategy.getRequestedSessionIds(this.request)).isEmpty();
 	}
 
 	@Test
 	public void getRequestedSessionIdNotNull() throws Exception {
 		setSessionCookie(this.session.getId());
-		assertThat(this.strategy.getRequestedSessionId(this.request))
-				.isEqualTo(this.session.getId());
+		assertThat(this.strategy.getRequestedSessionIds(this.request))
+				.contains(this.session.getId());
 	}
 
 	@Test
 	public void getRequestedSessionIdNotNullCustomCookieName() throws Exception {
 		setCookieName("CUSTOM");
 		setSessionCookie(this.session.getId());
-		assertThat(this.strategy.getRequestedSessionId(this.request))
-				.isEqualTo(this.session.getId());
+		assertThat(this.strategy.getRequestedSessionIds(this.request))
+				.contains(this.session.getId());
 	}
 
 	@Test

--- a/spring-session/src/test/java/org/springframework/session/web/http/HeaderSessionStrategyTests.java
+++ b/spring-session/src/test/java/org/springframework/session/web/http/HeaderSessionStrategyTests.java
@@ -45,22 +45,22 @@ public class HeaderSessionStrategyTests {
 
 	@Test
 	public void getRequestedSessionIdNull() throws Exception {
-		assertThat(this.strategy.getRequestedSessionId(this.request)).isNull();
+		assertThat(this.strategy.getRequestedSessionIds(this.request)).isEmpty();
 	}
 
 	@Test
 	public void getRequestedSessionIdNotNull() throws Exception {
 		setSessionId(this.session.getId());
-		assertThat(this.strategy.getRequestedSessionId(this.request))
-				.isEqualTo(this.session.getId());
+		assertThat(this.strategy.getRequestedSessionIds(this.request))
+				.contains(this.session.getId());
 	}
 
 	@Test
 	public void getRequestedSessionIdNotNullCustomHeaderName() throws Exception {
 		setHeaderName("CUSTOM");
 		setSessionId(this.session.getId());
-		assertThat(this.strategy.getRequestedSessionId(this.request))
-				.isEqualTo(this.session.getId());
+		assertThat(this.strategy.getRequestedSessionIds(this.request))
+				.contains(this.session.getId());
 	}
 
 	@Test

--- a/spring-session/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
+++ b/spring-session/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
@@ -1158,11 +1158,11 @@ public class SessionRepositoryFilterTests {
 
 	@Test
 	public void doFilterAdapterGetRequestedSessionId() throws Exception {
+		this.sessionRepository.save(new MapSession("MultiHttpSessionStrategyAdapter-requested-id"));
 		this.filter.setHttpSessionStrategy(this.strategy);
 		final String expectedId = "MultiHttpSessionStrategyAdapter-requested-id";
-		given(this.strategy.getRequestedSessionId(any(HttpServletRequest.class)))
-				.willReturn(expectedId);
-
+		given(this.strategy.getRequestedSessionIds(any(HttpServletRequest.class)))
+				.willReturn(Collections.singletonList(expectedId));
 		doFilter(new DoInFilter() {
 			@Override
 			public void doFilter(HttpServletRequest wrappedRequest,
@@ -1205,8 +1205,8 @@ public class SessionRepositoryFilterTests {
 
 		HttpServletRequest request = (HttpServletRequest) this.chain.getRequest();
 		String id = request.getSession().getId();
-		given(this.strategy.getRequestedSessionId(any(HttpServletRequest.class)))
-				.willReturn(id);
+		given(this.strategy.getRequestedSessionIds(any(HttpServletRequest.class)))
+				.willReturn(Collections.singletonList(id));
 		setupRequest();
 
 		doFilter(new DoInFilter() {
@@ -1237,8 +1237,8 @@ public class SessionRepositoryFilterTests {
 
 		HttpServletRequest request = (HttpServletRequest) this.chain.getRequest();
 		String id = request.getSession().getId();
-		given(this.strategy.getRequestedSessionId(any(HttpServletRequest.class)))
-				.willReturn(id);
+		given(this.strategy.getRequestedSessionIds(any(HttpServletRequest.class)))
+				.willReturn(Collections.singletonList(id));
 
 		doFilter(new DoInFilter() {
 			@Override
@@ -1361,7 +1361,7 @@ public class SessionRepositoryFilterTests {
 						.getAttribute(SessionRepositoryFilter.INVALID_SESSION_ID_ATTR))
 								.isNull();
 
-				// First call should go all the way through to the sessioRepository (it
+				// First call should go all the way through to the sessionRepository (it
 				// will not find the session)
 				HttpSession session = wrappedRequest.getSession(false);
 				verify(SessionRepositoryFilterTests.this.sessionRepository, times(1))


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

Currently the method signature at HttpSessionStrategy is
getRequestedSessionId. Now, has been renamed to getRequestedSessionIds
in order to store all the session ids present in the request.

Fixes gh-362
