### PR TITLE
Handle negative maxInactiveInterval values correctly

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/data/mongo/MongoExpiringSession.java
+++ b/spring-session/src/main/java/org/springframework/session/data/mongo/MongoExpiringSession.java
@@ -116,7 +116,7 @@ public class MongoExpiringSession implements ExpiringSession {
 	}
 
 	public boolean isExpired() {
-		return new Date().after(this.expireAt);
+		return this.interval >= 0 && new Date().after(this.expireAt);
 	}
 
 	public Date getExpireAt() {


### PR DESCRIPTION
This addresses issue #628 for Redis and Mongo.
