### PR TITLE
Remove code repeat inside RedisSession and use this in methods call

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
@@ -16,6 +16,7 @@
 
 package org.springframework.session.data.redis;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -667,7 +668,9 @@ public class RedisOperationsSessionRepository implements
 	 * @author Rob Winch
 	 * @since 1.0
 	 */
-	final class RedisSession implements ExpiringSession {
+	public class RedisSession implements ExpiringSession, Serializable {
+
+		private static final long serialVersionUID = 846876191496369674L;
 		private final MapSession cached;
 		private Long originalLastAccessTime;
 		private Map<String, Object> delta = new HashMap<String, Object>();
@@ -678,7 +681,7 @@ public class RedisOperationsSessionRepository implements
 		 * Creates a new instance ensuring to mark all of the new attributes to be
 		 * persisted in the next save operation.
 		 */
-		RedisSession() {
+		public RedisSession() {
 			this(new MapSession());
 			this.delta.put(CREATION_TIME_ATTR, getCreationTime());
 			this.delta.put(MAX_INACTIVE_ATTR, getMaxInactiveIntervalInSeconds());

--- a/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
@@ -761,7 +761,7 @@ public class RedisOperationsSessionRepository implements
 				saveDelta();
 			}
 		}
-		
+
 		private void putAndFlush(String a, Object v) {
 			this.delta.put(a, v);
 			this.flushImmediateIfNecessary();

--- a/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
@@ -684,7 +684,7 @@ public class RedisOperationsSessionRepository implements
 			this.delta.put(MAX_INACTIVE_ATTR, getMaxInactiveIntervalInSeconds());
 			this.delta.put(LAST_ACCESSED_ATTR, getLastAccessedTime());
 			this.isNew = true;
-			flushImmediateIfNecessary();
+			this.flushImmediateIfNecessary();
 		}
 
 		/**
@@ -705,8 +705,7 @@ public class RedisOperationsSessionRepository implements
 
 		public void setLastAccessedTime(long lastAccessedTime) {
 			this.cached.setLastAccessedTime(lastAccessedTime);
-			this.delta.put(LAST_ACCESSED_ATTR, getLastAccessedTime());
-			flushImmediateIfNecessary();
+			this.putAndFlush(LAST_ACCESSED_ATTR, getLastAccessedTime());
 		}
 
 		public boolean isExpired() {
@@ -731,8 +730,7 @@ public class RedisOperationsSessionRepository implements
 
 		public void setMaxInactiveIntervalInSeconds(int interval) {
 			this.cached.setMaxInactiveIntervalInSeconds(interval);
-			this.delta.put(MAX_INACTIVE_ATTR, getMaxInactiveIntervalInSeconds());
-			flushImmediateIfNecessary();
+			this.putAndFlush(MAX_INACTIVE_ATTR, getMaxInactiveIntervalInSeconds());
 		}
 
 		public int getMaxInactiveIntervalInSeconds() {
@@ -750,20 +748,23 @@ public class RedisOperationsSessionRepository implements
 
 		public void setAttribute(String attributeName, Object attributeValue) {
 			this.cached.setAttribute(attributeName, attributeValue);
-			this.delta.put(getSessionAttrNameKey(attributeName), attributeValue);
-			flushImmediateIfNecessary();
+			this.putAndFlush(getSessionAttrNameKey(attributeName), attributeValue);
 		}
 
 		public void removeAttribute(String attributeName) {
 			this.cached.removeAttribute(attributeName);
-			this.delta.put(getSessionAttrNameKey(attributeName), null);
-			flushImmediateIfNecessary();
+			this.putAndFlush(getSessionAttrNameKey(attributeName), null);
 		}
 
 		private void flushImmediateIfNecessary() {
 			if (RedisOperationsSessionRepository.this.redisFlushMode == RedisFlushMode.IMMEDIATE) {
 				saveDelta();
 			}
+		}
+		
+		private void putAndFlush(String a, Object v) {
+			this.delta.put(a, v);
+			this.flushImmediateIfNecessary();
 		}
 
 		/**


### PR DESCRIPTION
Maintain standard using `this.` prefix inside the RedisSession to methods call.

Generalizing `this.delta.put` and `this.flushImmediateIfNecessary` methods to keep an unique point of maintenance.

Thanks in advance.
