### PR TITLE
Optimize save operation in HazelcastSessionRepository (#516)

### DIFF
--- a/spring-session/src/integration-test/java/org/springframework/session/hazelcast/AbstractHazelcastRepositoryITests.java
+++ b/spring-session/src/integration-test/java/org/springframework/session/hazelcast/AbstractHazelcastRepositoryITests.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.session.MapSession;
+import org.springframework.session.hazelcast.HazelcastSessionRepository.HazelcastSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,7 +42,7 @@ public abstract class AbstractHazelcastRepositoryITests {
 
 	@Test
 	public void createAndDestroySession() {
-		MapSession sessionToSave = this.repository.createSession();
+		HazelcastSession sessionToSave = this.repository.createSession();
 		String sessionId = sessionToSave.getId();
 
 		IMap<String, MapSession> hazelcastMap = this.hazelcast.getMap(

--- a/spring-session/src/main/java/org/springframework/session/hazelcast/HazelcastFlushMode.java
+++ b/spring-session/src/main/java/org/springframework/session/hazelcast/HazelcastFlushMode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.hazelcast;
+
+import org.springframework.session.SessionRepository;
+
+/**
+ * Specifies when to write to the backing Hazelcast instance.
+ *
+ * @author Aleksandar Stojsavljevic
+ * @since 1.3
+ */
+public enum HazelcastFlushMode {
+	/**
+	 * Only writes to Hazelcast when
+	 * {@link SessionRepository#save(org.springframework.session.Session)} is invoked. In
+	 * a web environment this is typically done as soon as the HTTP response is committed.
+	 */
+	ON_SAVE,
+
+	/**
+	 * Writes to Hazelcast as soon as possible. For example
+	 * {@link SessionRepository#createSession()} will write the session to Hazelcast. Another
+	 * example is that setting an attribute on the session will also write to Hazelcast
+	 * immediately.
+	 */
+	IMMEDIATE
+}

--- a/spring-session/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/EnableHazelcastHttpSession.java
+++ b/spring-session/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/EnableHazelcastHttpSession.java
@@ -23,7 +23,9 @@ import java.lang.annotation.Target;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.session.MapSession;
+import org.springframework.session.SessionRepository;
 import org.springframework.session.config.annotation.web.http.EnableSpringHttpSession;
+import org.springframework.session.hazelcast.HazelcastFlushMode;
 
 /**
  * Add this annotation to a {@code @Configuration} class to expose the
@@ -48,6 +50,7 @@ import org.springframework.session.config.annotation.web.http.EnableSpringHttpSe
  * instead.
  *
  * @author Tommy Ludwig
+ * @author Aleksandar Stojsavljevic
  * @since 1.1
  * @see EnableSpringHttpSession
  */
@@ -72,5 +75,22 @@ public @interface EnableHazelcastHttpSession {
 	 * @return the name of the Map to store the sessions in Hazelcast
 	 */
 	String sessionMapName() default HazelcastHttpSessionConfiguration.DEFAULT_SESSION_MAP_NAME;
+
+	/**
+	 * <p>
+	 * Sets the flush mode for the Hazelcast sessions. The default is ON_SAVE which only
+	 * updates the backing Hazelcast when
+	 * {@link SessionRepository#save(org.springframework.session.Session)} is invoked. In
+	 * a web environment this happens just before the HTTP response is committed.
+	 * </p>
+	 * <p>
+	 * Setting the value to IMMEDIATE will ensure that the any updates to the Session are
+	 * immediately written to the Hazelcast instance.
+	 * </p>
+	 *
+	 * @return the {@link HazelcastFlushMode} to use
+	 * @since 1.3
+	 */
+	HazelcastFlushMode hazelcastFlushMode() default HazelcastFlushMode.ON_SAVE;
 
 }

--- a/spring-session/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfiguration.java
+++ b/spring-session/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.session.MapSession;
 import org.springframework.session.config.annotation.web.http.SpringHttpSessionConfiguration;
+import org.springframework.session.hazelcast.HazelcastFlushMode;
 import org.springframework.session.hazelcast.HazelcastSessionRepository;
 import org.springframework.session.web.http.SessionRepositoryFilter;
 
@@ -52,6 +53,8 @@ public class HazelcastHttpSessionConfiguration extends SpringHttpSessionConfigur
 
 	private String sessionMapName = DEFAULT_SESSION_MAP_NAME;
 
+	private HazelcastFlushMode hazelcastFlushMode = HazelcastFlushMode.ON_SAVE;
+
 	@Bean
 	public HazelcastSessionRepository sessionRepository(
 			HazelcastInstance hazelcastInstance,
@@ -63,6 +66,7 @@ public class HazelcastHttpSessionConfiguration extends SpringHttpSessionConfigur
 		sessionRepository.setApplicationEventPublisher(eventPublisher);
 		sessionRepository.setDefaultMaxInactiveInterval(
 				this.maxInactiveIntervalInSeconds);
+		sessionRepository.setHazelcastFlushMode(this.hazelcastFlushMode);
 		return sessionRepository;
 	}
 
@@ -73,6 +77,7 @@ public class HazelcastHttpSessionConfiguration extends SpringHttpSessionConfigur
 		setMaxInactiveIntervalInSeconds(
 				(Integer) enableAttrs.getNumber("maxInactiveIntervalInSeconds"));
 		setSessionMapName(enableAttrs.getString("sessionMapName"));
+		setHazelcastFlushMode((HazelcastFlushMode) enableAttrs.getEnum("hazelcastFlushMode"));
 	}
 
 	public void setMaxInactiveIntervalInSeconds(int maxInactiveIntervalInSeconds) {
@@ -83,4 +88,7 @@ public class HazelcastHttpSessionConfiguration extends SpringHttpSessionConfigur
 		this.sessionMapName = sessionMapName;
 	}
 
+	public void setHazelcastFlushMode(HazelcastFlushMode hazelcastFlushMode) {
+		this.hazelcastFlushMode = hazelcastFlushMode;
+	}
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

This resolves #516:
- improves saving of sessions to only execute save operation if something has been changed.
- introduces configurable flush mode that specifies when to write to the backing Hazelcast instance. It can be 'on save' (default) or 'immediate'.
