### PR TITLE
Add a link to Spring Session OrientDB project

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -1158,6 +1158,10 @@ We appreciate https://help.github.com/articles/using-pull-requests/[Pull Request
 
 Spring Session is Open Source software released under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache 2.0 license].
 
+[[community-extensions]]
+=== Community Extensions
+https://github.com/maseev/spring-session-orientdb[Spring Session OrientDB]
+
 [[minimum-requirements]]
 == Minimum Requirements
 


### PR DESCRIPTION
Added a link to [Spring Session OrientDB](https://github.com/maseev/spring-session-orientdb) in a newly created Community Extensions documentation section.
