### PR TITLE
Look at all cookies instead just the first

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/web/http/CookieHttpSessionStrategy.java
+++ b/spring-session/src/main/java/org/springframework/session/web/http/CookieHttpSessionStrategy.java
@@ -136,6 +136,7 @@ import org.springframework.util.Assert;
  *
  *
  * @author Rob Winch
+ * @author Eddú Meléndez
  * @since 1.0
  */
 public final class CookieHttpSessionStrategy
@@ -335,22 +336,21 @@ public final class CookieHttpSessionStrategy
 
 	public Map<String, String> getSessionIds(HttpServletRequest request) {
 		List<String> cookieValues = this.cookieSerializer.readCookieValues(request);
-		String sessionCookieValue = cookieValues.isEmpty() ? ""
-				: cookieValues.iterator().next();
 		Map<String, String> result = new LinkedHashMap<String, String>();
-		StringTokenizer tokens = new StringTokenizer(sessionCookieValue,
-				this.deserializationDelimiter);
-		if (tokens.countTokens() == 1) {
-			result.put(DEFAULT_ALIAS, tokens.nextToken());
-			return result;
-		}
-		while (tokens.hasMoreTokens()) {
-			String alias = tokens.nextToken();
-			if (!tokens.hasMoreTokens()) {
-				break;
+		for (String cookieValue : cookieValues) {
+			StringTokenizer tokens = new StringTokenizer(cookieValue, this.deserializationDelimiter);
+			if (tokens.countTokens() == 1) {
+				result.put(DEFAULT_ALIAS, tokens.nextToken());
+				return result;
 			}
-			String id = tokens.nextToken();
-			result.put(alias, id);
+			while (tokens.hasMoreTokens()) {
+				String alias = tokens.nextToken();
+				if (!tokens.hasMoreTokens()) {
+					break;
+				}
+				String id = tokens.nextToken();
+				result.put(alias, id);
+			}
 		}
 		return result;
 	}

--- a/spring-session/src/test/java/org/springframework/session/web/http/CookieHttpSessionStrategyTests.java
+++ b/spring-session/src/test/java/org/springframework/session/web/http/CookieHttpSessionStrategyTests.java
@@ -561,6 +561,17 @@ public class CookieHttpSessionStrategyTests {
 		assertThat(sessionIds.get("1")).isEqualTo("b");
 	}
 
+	@Test
+	public void getSessionIdsMultiCookies() {
+		setSessionCookies(new Cookie(this.cookieName, "0 a"),
+				new Cookie("OTHER_COOKIE", "1 b"), new Cookie(this.cookieName, "2 c"));
+
+		Map<String, String> sessionIds = this.strategy.getSessionIds(this.request);
+		assertThat(sessionIds.size()).isEqualTo(2);
+		assertThat(sessionIds.get("0")).isEqualTo("a");
+		assertThat(sessionIds.get("2")).isEqualTo("c");
+	}
+
 	// --- helper
 
 	@Test
@@ -733,6 +744,10 @@ public class CookieHttpSessionStrategyTests {
 
 	public void setSessionCookie(String value) {
 		this.request.setCookies(new Cookie(this.cookieName, value));
+	}
+
+	public void setSessionCookies(Cookie... cookies) {
+		this.request.setCookies(cookies);
 	}
 
 	public String getSessionId() {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

Previous to this commit, just the first cookie is considered. Now, all
cookies are considered to look for SESSION cookie.

See gh-275

Initial draft
