### PR TITLE
Update Samples and Guides to use Lettuce

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 				"org.springframework:spring-test:$springVersion",
 				"org.assertj:assertj-core:$assertjVersion",
 				"com.hazelcast:hazelcast:$hazelcastVersion",
-				"redis.clients:jedis:2.4.1",
+				"biz.paluch.redis:lettuce:$lettuceVersion",
 				"javax.servlet:javax.servlet-api:$servletApiVersion"
 }
 
@@ -58,6 +58,7 @@ asciidoctor {
 			'download-url' : "https://github.com/spring-projects/spring-session/archive/${ghTag}.zip",
 			'spring-session-version' : version,
 			'spring-version' : springVersion,
+			'lettuce-version' : lettuceVersion,
 			'hazelcast-version' : hazelcastVersion,
 			'docs-itest-dir' : rootProject.projectDir.path + '/docs/src/integration-test/java/',
 			'docs-test-dir' : rootProject.projectDir.path + '/docs/src/test/java/',

--- a/docs/src/docs/asciidoc/guides/custom-cookie.adoc
+++ b/docs/src/docs/asciidoc/guides/custom-cookie.adoc
@@ -79,7 +79,7 @@ You can run the sample by obtaining the {download-url}[source code] and invoking
 [NOTE]
 ====
 For the sample to work, you must http://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
-Alternatively, you can update the `JedisConnectionFactory` to point to a Redis server.
+Alternatively, you can update the `LettuceConnectionFactory` to point to a Redis server.
 ====
 
 ----

--- a/docs/src/docs/asciidoc/guides/httpsession-xml.adoc
+++ b/docs/src/docs/asciidoc/guides/httpsession-xml.adoc
@@ -24,6 +24,11 @@ If you are using Maven, ensure to add the following dependencies:
 		<type>pom</type>
 	</dependency>
 	<dependency>
+		<groupId>biz.paluch.redis</groupId>
+		<artifactId>lettuce</artifactId>
+		<version>{lettuce-version}</version>
+	</dependency>
+	<dependency>
 		<groupId>org.springframework</groupId>
 		<artifactId>spring-web</artifactId>
 		<version>{spring-version}</version>
@@ -129,7 +134,7 @@ You can run the sample by obtaining the {download-url}[source code] and invoking
 [NOTE]
 ====
 For the sample to work, you must http://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
-Alternatively, you can update the `JedisConnectionFactory` to point to a Redis server.
+Alternatively, you can update the `LettuceConnectionFactory` to point to a Redis server.
 ====
 
 ----

--- a/docs/src/docs/asciidoc/guides/httpsession.adoc
+++ b/docs/src/docs/asciidoc/guides/httpsession.adoc
@@ -24,6 +24,11 @@ If you are using Maven, ensure to add the following dependencies:
 		<type>pom</type>
 	</dependency>
 	<dependency>
+		<groupId>biz.paluch.redis</groupId>
+		<artifactId>lettuce</artifactId>
+		<version>{lettuce-version}</version>
+	</dependency>
+	<dependency>
 		<groupId>org.springframework</groupId>
 		<artifactId>spring-web</artifactId>
 		<version>{spring-version}</version>
@@ -121,7 +126,7 @@ You can run the sample by obtaining the {download-url}[source code] and invoking
 [NOTE]
 ====
 For the sample to work, you must http://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
-Alternatively, you can update the `JedisConnectionFactory` to point to a Redis server.
+Alternatively, you can update the `LettuceConnectionFactory` to point to a Redis server.
 ====
 
 ----

--- a/docs/src/docs/asciidoc/guides/rest.adoc
+++ b/docs/src/docs/asciidoc/guides/rest.adoc
@@ -24,6 +24,11 @@ If you are using Maven, ensure to add the following dependencies:
 		<type>pom</type>
 	</dependency>
 	<dependency>
+		<groupId>biz.paluch.redis</groupId>
+		<artifactId>lettuce</artifactId>
+		<version>{lettuce-version}</version>
+	</dependency>
+	<dependency>
 		<groupId>org.springframework</groupId>
 		<artifactId>spring-web</artifactId>
 		<version>{spring-version}</version>
@@ -122,7 +127,7 @@ You can run the sample by obtaining the {download-url}[source code] and invoking
 [NOTE]
 ====
 For the sample to work, you must http://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
-Alternatively, you can update the `JedisConnectionFactory` to point to a Redis server.
+Alternatively, you can update the `LettuceConnectionFactory` to point to a Redis server.
 ====
 
 ----

--- a/docs/src/docs/asciidoc/guides/security.adoc
+++ b/docs/src/docs/asciidoc/guides/security.adoc
@@ -19,15 +19,20 @@ If you are using Maven, ensure to add the following dependencies:
 	<!-- ... -->
 
 	<dependency>
-	<groupId>org.springframework.session</groupId>
-	<artifactId>spring-session-data-redis</artifactId>
-	<version>{spring-session-version}</version>
-	<type>pom</type>
+		<groupId>org.springframework.session</groupId>
+		<artifactId>spring-session-data-redis</artifactId>
+		<version>{spring-session-version}</version>
+		<type>pom</type>
 	</dependency>
 	<dependency>
-	<groupId>org.springframework</groupId>
-	<artifactId>spring-web</artifactId>
-	<version>{spring-version}</version>
+		<groupId>biz.paluch.redis</groupId>
+		<artifactId>lettuce</artifactId>
+		<version>{lettuce-version}</version>
+	</dependency>
+	<dependency>
+		<groupId>org.springframework</groupId>
+		<artifactId>spring-web</artifactId>
+		<version>{spring-version}</version>
 	</dependency>
 </dependencies>
 ----
@@ -126,7 +131,7 @@ You can run the sample by obtaining the {download-url}[source code] and invoking
 [NOTE]
 ====
 For the sample to work, you must http://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
-Alternatively, you can update the `JedisConnectionFactory` to point to a Redis server.
+Alternatively, you can update the `LettuceConnectionFactory` to point to a Redis server.
 ====
 
 ----

--- a/docs/src/docs/asciidoc/guides/users.adoc
+++ b/docs/src/docs/asciidoc/guides/users.adoc
@@ -20,7 +20,7 @@ You can run the sample by obtaining the {download-url}[source code] and invoking
 [NOTE]
 ====
 For the sample to work, you must http://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
-Alternatively, you can update the `JedisConnectionFactory` to point to a Redis server.
+Alternatively, you can update the `LettuceConnectionFactory` to point to a Redis server.
 ====
 
 ----

--- a/docs/src/docs/asciidoc/guides/websocket.adoc
+++ b/docs/src/docs/asciidoc/guides/websocket.adoc
@@ -85,7 +85,7 @@ include::{samples-dir}websocket/src/main/java/sample/config/WebSecurityConfig.ja
 [NOTE]
 ====
 For the sample to work, you must http://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
-Alternatively, you can update the `JedisConnectionFactory` to point to a Redis server.
+Alternatively, you can update the `LettuceConnectionFactory` to point to a Redis server.
 ====
 
 ----

--- a/docs/src/test/java/docs/IndexDocTests.java
+++ b/docs/src/test/java/docs/IndexDocTests.java
@@ -22,7 +22,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import org.junit.Test;
 
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.mock.web.MockServletContext;
@@ -110,7 +110,7 @@ public class IndexDocTests {
 	@SuppressWarnings("unused")
 	public void newRedisOperationsSessionRepository() {
 		// tag::new-redisoperationssessionrepository[]
-		JedisConnectionFactory factory = new JedisConnectionFactory();
+		LettuceConnectionFactory factory = new LettuceConnectionFactory();
 		SessionRepository<? extends ExpiringSession> repository = new RedisOperationsSessionRepository(
 				factory);
 		// end::new-redisoperationssessionrepository[]

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ servletApiVersion=3.0.1
 jstlelVersion=1.2.5
 version=1.3.0.BUILD-SNAPSHOT
 springDataRedisVersion=1.7.1.RELEASE
+lettuceVersion=3.5.0.Final
 html5ShivVersion=3.7.3
 commonsLoggingVersion=1.2
 junitVersion=4.12

--- a/samples/custom-cookie/build.gradle
+++ b/samples/custom-cookie/build.gradle
@@ -3,8 +3,11 @@ apply from: TOMCAT_7_GRADLE
 apply from: SAMPLE_GRADLE
 
 dependencies {
-	compile project(':spring-session-data-redis'),
-			"org.springframework:spring-web:$springVersion",
+	compile(project(':spring-session-data-redis')) {
+		exclude module: 'jedis'
+	}
+	compile "org.springframework:spring-web:$springVersion",
+			"biz.paluch.redis:lettuce:$lettuceVersion",
 			"org.webjars:bootstrap:$bootstrapVersion",
 			"org.webjars:webjars-taglib:$webjarsTaglibVersion",
 			jstlDependencies

--- a/samples/custom-cookie/src/main/java/sample/Config.java
+++ b/samples/custom-cookie/src/main/java/sample/Config.java
@@ -17,7 +17,7 @@
 package sample;
 
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.session.web.http.CookieSerializer;
 import org.springframework.session.web.http.DefaultCookieSerializer;
@@ -26,8 +26,8 @@ import org.springframework.session.web.http.DefaultCookieSerializer;
 public class Config {
 
 	@Bean
-	public JedisConnectionFactory connectionFactory() {
-		return new JedisConnectionFactory();
+	public LettuceConnectionFactory connectionFactory() {
+		return new LettuceConnectionFactory();
 	}
 
 	// tag::cookie-serializer[]

--- a/samples/httpsession-redis-json/build.gradle
+++ b/samples/httpsession-redis-json/build.gradle
@@ -25,6 +25,7 @@ dependencies {
             "org.springframework.boot:spring-boot-starter-web",
             "org.springframework.boot:spring-boot-starter-thymeleaf",
             "nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect",
+            "biz.paluch.redis:lettuce:$lettuceVersion",
             "org.springframework.security:spring-security-web:$springSecurityVersion",
             "org.springframework.security:spring-security-core:$springSecurityVersion",
             "org.springframework.security:spring-security-config:$springSecurityVersion",

--- a/samples/httpsession-redis-json/src/main/java/sample/config/SessionConfig.java
+++ b/samples/httpsession-redis-json/src/main/java/sample/config/SessionConfig.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.security.jackson2.SecurityJacksonModules;
@@ -39,8 +39,8 @@ public class SessionConfig implements BeanClassLoaderAware {
 	}
 
 	@Bean
-	public JedisConnectionFactory connectionFactory() {
-		return new JedisConnectionFactory();
+	public LettuceConnectionFactory connectionFactory() {
+		return new LettuceConnectionFactory();
 	}
 
 	/**

--- a/samples/httpsession-xml/build.gradle
+++ b/samples/httpsession-xml/build.gradle
@@ -3,8 +3,11 @@ apply from: TOMCAT_7_GRADLE
 apply from: SAMPLE_GRADLE
 
 dependencies {
-	compile project(':spring-session-data-redis'),
-			"org.springframework:spring-web:$springVersion",
+	compile(project(':spring-session-data-redis')) {
+		exclude module: 'jedis'
+	}
+	compile "org.springframework:spring-web:$springVersion",
+			"biz.paluch.redis:lettuce:$lettuceVersion",
 			"org.webjars:bootstrap:$bootstrapVersion",
 			"org.webjars:webjars-taglib:$webjarsTaglibVersion",
 			jstlDependencies

--- a/samples/httpsession-xml/src/main/webapp/WEB-INF/spring/session.xml
+++ b/samples/httpsession-xml/src/main/webapp/WEB-INF/spring/session.xml
@@ -13,6 +13,6 @@
 	<bean class="org.springframework.session.data.redis.config.annotation.web.http.RedisHttpSessionConfiguration"/>
 
 	<!--2-->
-	<bean class="org.springframework.data.redis.connection.jedis.JedisConnectionFactory"/>
+	<bean class="org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory"/>
 	<!-- end::beans[] -->
 </beans>

--- a/samples/httpsession/build.gradle
+++ b/samples/httpsession/build.gradle
@@ -3,8 +3,11 @@ apply from: TOMCAT_7_GRADLE
 apply from: SAMPLE_GRADLE
 
 dependencies {
-	compile project(':spring-session-data-redis'),
-			"org.springframework:spring-web:$springVersion",
+	compile(project(':spring-session-data-redis')) {
+		exclude module: 'jedis'
+	}
+	compile "org.springframework:spring-web:$springVersion",
+			"biz.paluch.redis:lettuce:$lettuceVersion",
 			"org.webjars:bootstrap:$bootstrapVersion",
 			"org.webjars:webjars-taglib:$webjarsTaglibVersion",
 			jstlDependencies

--- a/samples/httpsession/src/main/java/sample/Config.java
+++ b/samples/httpsession/src/main/java/sample/Config.java
@@ -17,7 +17,7 @@
 package sample;
 
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 // tag::class[]
@@ -25,8 +25,8 @@ import org.springframework.session.data.redis.config.annotation.web.http.EnableR
 public class Config {
 
 	@Bean
-	public JedisConnectionFactory connectionFactory() {
-		return new JedisConnectionFactory(); // <2>
+	public LettuceConnectionFactory connectionFactory() {
+		return new LettuceConnectionFactory(); // <2>
 	}
 }
 // end::class[]

--- a/samples/rest/build.gradle
+++ b/samples/rest/build.gradle
@@ -3,7 +3,10 @@ apply from: TOMCAT_7_GRADLE
 apply from: SAMPLE_GRADLE
 
 dependencies {
-	compile project(':spring-session-data-redis'),
+	compile(project(':spring-session-data-redis')) {
+		exclude module: 'jedis'
+	}
+	compile "biz.paluch.redis:lettuce:$lettuceVersion",
 			"org.springframework:spring-webmvc:$springVersion",
 			"org.springframework.security:spring-security-config:$springSecurityVersion",
 			"org.springframework.security:spring-security-web:$springSecurityVersion",

--- a/samples/rest/src/main/java/sample/HttpSessionConfig.java
+++ b/samples/rest/src/main/java/sample/HttpSessionConfig.java
@@ -18,7 +18,7 @@ package sample;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.session.web.http.HeaderHttpSessionStrategy;
 import org.springframework.session.web.http.HttpSessionStrategy;
@@ -29,8 +29,8 @@ import org.springframework.session.web.http.HttpSessionStrategy;
 public class HttpSessionConfig {
 
 	@Bean
-	public JedisConnectionFactory connectionFactory() {
-		return new JedisConnectionFactory(); // <2>
+	public LettuceConnectionFactory connectionFactory() {
+		return new LettuceConnectionFactory(); // <2>
 	}
 
 	@Bean

--- a/samples/security/build.gradle
+++ b/samples/security/build.gradle
@@ -3,10 +3,13 @@ apply from: TOMCAT_7_GRADLE
 apply from: SAMPLE_GRADLE
 
 dependencies {
-	compile project(':spring-session-data-redis'),
-			"org.springframework:spring-web:$springVersion",
+	compile(project(':spring-session-data-redis')) {
+		exclude module: 'jedis'
+	}
+	compile "org.springframework:spring-web:$springVersion",
 			"org.springframework.security:spring-security-config:$springSecurityVersion",
 			"org.springframework.security:spring-security-web:$springSecurityVersion",
+			"biz.paluch.redis:lettuce:$lettuceVersion",
 			"org.webjars:bootstrap:$bootstrapVersion",
 			"org.webjars:webjars-taglib:$webjarsTaglibVersion",
 			jstlDependencies

--- a/samples/security/src/main/java/sample/Config.java
+++ b/samples/security/src/main/java/sample/Config.java
@@ -18,7 +18,7 @@ package sample;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 // tag::class[]
@@ -27,8 +27,8 @@ import org.springframework.session.data.redis.config.annotation.web.http.EnableR
 public class Config {
 
 	@Bean
-	public JedisConnectionFactory connectionFactory() {
-		return new JedisConnectionFactory(); // <2>
+	public LettuceConnectionFactory connectionFactory() {
+		return new LettuceConnectionFactory(); // <2>
 	}
 }
 // end::class[]

--- a/samples/users/build.gradle
+++ b/samples/users/build.gradle
@@ -3,9 +3,12 @@ apply from: TOMCAT_7_GRADLE
 apply from: SAMPLE_GRADLE
 
 dependencies {
-	compile project(':spring-session-data-redis'),
-			"org.springframework:spring-web:$springVersion",
-			"org.webjars:bootstrap:3.3.6",
+	compile(project(':spring-session-data-redis')) {
+		exclude module: 'jedis'
+	}
+	compile "org.springframework:spring-web:$springVersion",
+			"biz.paluch.redis:lettuce:$lettuceVersion",
+			"org.webjars:bootstrap:$bootstrapVersion",
 			"org.webjars:webjars-taglib:$webjarsTaglibVersion",
 			jstlDependencies
 

--- a/samples/users/src/main/java/sample/Config.java
+++ b/samples/users/src/main/java/sample/Config.java
@@ -18,7 +18,7 @@ package sample;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
 /**
@@ -31,8 +31,8 @@ import org.springframework.session.data.redis.config.annotation.web.http.EnableR
 public class Config {
 
 	@Bean
-	public JedisConnectionFactory connectionFactory() {
-		return new JedisConnectionFactory();
+	public LettuceConnectionFactory connectionFactory() {
+		return new LettuceConnectionFactory();
 	}
 }
 // end::class[]

--- a/samples/websocket/build.gradle
+++ b/samples/websocket/build.gradle
@@ -16,8 +16,10 @@ apply from: SAMPLE_GRADLE
 group = 'samples'
 
 dependencies {
-	compile project(':spring-session-data-redis'),
-			"org.springframework.boot:spring-boot-starter-web",
+	compile(project(':spring-session-data-redis')) {
+		exclude module: 'jedis'
+	}
+	compile "org.springframework.boot:spring-boot-starter-web",
 			"org.springframework.boot:spring-boot-starter-data-jpa",
 			"org.springframework.boot:spring-boot-starter-thymeleaf",
 			"org.springframework.boot:spring-boot-starter-websocket",
@@ -25,6 +27,7 @@ dependencies {
 			"org.springframework.data:spring-data-jpa",
 			"nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect",
 			"org.thymeleaf.extras:thymeleaf-extras-conditionalcomments",
+			"biz.paluch.redis:lettuce:$lettuceVersion",
 			"org.webjars:bootstrap:$bootstrapVersion",
 			"org.webjars:html5shiv:$html5ShivVersion",
 			"org.webjars:knockout:2.3.0",

--- a/samples/websocket/src/main/java/sample/config/DataSourceConfig.java
+++ b/samples/websocket/src/main/java/sample/config/DataSourceConfig.java
@@ -20,7 +20,7 @@ import javax.sql.DataSource;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
@@ -34,7 +34,7 @@ public class DataSourceConfig {
 	}
 
 	@Bean
-	public JedisConnectionFactory connectionFactory() {
-		return new JedisConnectionFactory();
+	public LettuceConnectionFactory connectionFactory() {
+		return new LettuceConnectionFactory();
 	}
 }


### PR DESCRIPTION
Favor lettuce because of multiplexing and improved scalability. Using lettuce requires a fixed number of connections hence using lettuce improves application scalability.

---

Leaving out Spring Boot samples as lettuce is not yet supported by Spring Boot with auto-configuration.
