### PR TITLE
Skip Redis getConnection() if ConfigureRedisAction.NO_OP

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfiguration.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfiguration.java
@@ -230,6 +230,9 @@ public class RedisHttpSessionConfiguration extends SpringHttpSessionConfiguratio
 		}
 
 		public void afterPropertiesSet() throws Exception {
+			if (this.configure == ConfigureRedisAction.NO_OP) {
+				return;
+			}
 			RedisConnection connection = this.connectionFactory.getConnection();
 			this.configure.configure(connection);
 		}


### PR DESCRIPTION
Temporary errors with Redis (like SocketTimeoutException) should not prevent application startup, especially if nothing needs to be done with that connection. 

Issue: gh-653
