### PR TITLE
Parameterize `SpringSessionBackedSessionRegistry`

### DIFF
--- a/docs/src/test/java/docs/security/SecurityConfiguration.java
+++ b/docs/src/test/java/docs/security/SecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,20 +33,23 @@ import org.springframework.session.security.SpringSessionBackedSessionRegistry;
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 	@Autowired
-	FindByIndexNameSessionRepository<ExpiringSession> sessionRepository;
+	private FindByIndexNameSessionRepository<ExpiringSession> sessionRepository;
 
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
+		// @formatter:off
 		http
 			// other config goes here...
 			.sessionManagement()
 				.maximumSessions(2)
 				.sessionRegistry(sessionRegistry());
+		// @formatter:on
 	}
 
 	@Bean
 	SpringSessionBackedSessionRegistry sessionRegistry() {
-		return new SpringSessionBackedSessionRegistry(this.sessionRepository);
+		return new SpringSessionBackedSessionRegistry<ExpiringSession>(
+				this.sessionRepository);
 	}
 }
 // end::class[]

--- a/spring-session/src/main/java/org/springframework/session/security/SpringSessionBackedSessionRegistry.java
+++ b/spring-session/src/main/java/org/springframework/session/security/SpringSessionBackedSessionRegistry.java
@@ -29,47 +29,59 @@ import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.util.Assert;
 
 /**
- * A {@link SessionRegistry} that retrieves session information from Spring Session, rather than maintaining it itself.
- * This allows concurrent session management with Spring Security in a clustered environment.
+ * A {@link SessionRegistry} that retrieves session information from Spring Session,
+ * rather than maintaining it itself. This allows concurrent session management with
+ * Spring Security in a clustered environment.
  * <p>
- * Relies on being able to derive the same String-based representation of the principal given to
- * {@link #getAllSessions(Object, boolean)} as used by Spring Session in order to look up the user's sessions.
+ * Relies on being able to derive the same String-based representation of the principal
+ * given to {@link #getAllSessions(Object, boolean)} as used by Spring Session in order to
+ * look up the user's sessions.
  * <p>
  * Does not support {@link #getAllPrincipals()}, since that information is not available.
  *
+ * @param <S> the {@link ExpiringSession} type.
  * @author Joris Kuipers
+ * @author Vedran Pavic
  * @since 1.3
  */
-public class SpringSessionBackedSessionRegistry implements SessionRegistry {
+public class SpringSessionBackedSessionRegistry<S extends ExpiringSession>
+		implements SessionRegistry {
 
-	private final FindByIndexNameSessionRepository<ExpiringSession> sessionRepository;
+	private final FindByIndexNameSessionRepository<S> sessionRepository;
 
-	public SpringSessionBackedSessionRegistry(FindByIndexNameSessionRepository<ExpiringSession> sessionRepository) {
+	public SpringSessionBackedSessionRegistry(
+			FindByIndexNameSessionRepository<S> sessionRepository) {
 		Assert.notNull(sessionRepository, "sessionRepository cannot be null");
 		this.sessionRepository = sessionRepository;
 	}
 
 	public List<Object> getAllPrincipals() {
-		throw new UnsupportedOperationException("SpringSessionBackedSessionRegistry does not support retrieving all principals, " +
-				"since Spring Session provides no way to obtain that information");
+		throw new UnsupportedOperationException("SpringSessionBackedSessionRegistry does "
+				+ "not support retrieving all principals, since Spring Session provides "
+				+ "no way to obtain that information");
 	}
 
-	public List<SessionInformation> getAllSessions(Object principal, boolean includeExpiredSessions) {
-		Collection<ExpiringSession> sessions =
-			this.sessionRepository.findByIndexNameAndIndexValue(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME, name(principal)).values();
+	public List<SessionInformation> getAllSessions(Object principal,
+			boolean includeExpiredSessions) {
+		Collection<S> sessions = this.sessionRepository.findByIndexNameAndIndexValue(
+				FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME,
+				name(principal)).values();
 		List<SessionInformation> infos = new ArrayList<>();
-		for (ExpiringSession session : sessions) {
-			if (includeExpiredSessions || !Boolean.TRUE.equals(session.getAttribute(SpringSessionBackedSessionInformation.EXPIRED_ATTR))) {
-				infos.add(new SpringSessionBackedSessionInformation(session, this.sessionRepository));
+		for (S session : sessions) {
+			if (includeExpiredSessions || !Boolean.TRUE.equals(session
+					.getAttribute(SpringSessionBackedSessionInformation.EXPIRED_ATTR))) {
+				infos.add(new SpringSessionBackedSessionInformation<S>(session,
+						this.sessionRepository));
 			}
 		}
 		return infos;
 	}
 
 	public SessionInformation getSessionInformation(String sessionId) {
-		ExpiringSession session = this.sessionRepository.getSession(sessionId);
+		S session = this.sessionRepository.getSession(sessionId);
 		if (session != null) {
-			return new SpringSessionBackedSessionInformation(session, this.sessionRepository);
+			return new SpringSessionBackedSessionInformation<S>(session,
+					this.sessionRepository);
 		}
 		return null;
 	}
@@ -96,7 +108,8 @@ public class SpringSessionBackedSessionRegistry implements SessionRegistry {
 	 * Derives a String name for the given principal.
 	 *
 	 * @param principal as provided by Spring Security
-	 * @return name of the principal, or its {@code toString()} representation if no name could be derived
+	 * @return name of the principal, or its {@code toString()} representation if no name
+	 * could be derived
 	 */
 	protected String name(Object principal) {
 		if (principal instanceof UserDetails) {
@@ -107,4 +120,5 @@ public class SpringSessionBackedSessionRegistry implements SessionRegistry {
 		}
 		return principal.toString();
 	}
+
 }


### PR DESCRIPTION
Since `SpringSessionBackedSessionRegistry` works against `FindByIndexNameSessionRepository`, it should be parameterized with the same `ExpiringSession` type as the underlying session repository (similarly to `SessionRepositoryFilter`).

The original motivation for this change is the fact that `SpringSessionBackedSessionRegistry` currently cannot be constructed using `FindByIndexNameSessionRepository<? extends ExpiringSession>` since its constructor expects `FindByIndexNameSessionRepository<ExpiringSession>`. This is a problem since one typically needs to use `FindByIndexNameSessionRepository<? extends ExpiringSession>` in order to inject session repository.

This was originally reported in [this SO question](http://stackoverflow.com/q/41498183/3944191).