### PR TITLE
Add support for configuring default `CookieSerializer` using `SessionCookieConfig`

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/config/annotation/web/http/SpringHttpSessionConfiguration.java
+++ b/spring-session/src/main/java/org/springframework/session/config/annotation/web/http/SpringHttpSessionConfiguration.java
@@ -21,7 +21,11 @@ import java.util.List;
 
 import javax.annotation.PostConstruct;
 import javax.servlet.ServletContext;
+import javax.servlet.SessionCookieConfig;
 import javax.servlet.http.HttpSessionListener;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -91,6 +95,8 @@ import org.springframework.util.ObjectUtils;
 @Configuration
 public class SpringHttpSessionConfiguration implements ApplicationContextAware {
 
+	private final Log logger = LogFactory.getLog(getClass());
+
 	private CookieHttpSessionStrategy defaultHttpSessionStrategy = new CookieHttpSessionStrategy();
 
 	private boolean usesSpringSessionRememberMeServices;
@@ -105,15 +111,9 @@ public class SpringHttpSessionConfiguration implements ApplicationContextAware {
 
 	@PostConstruct
 	public void init() {
-		if (this.cookieSerializer != null) {
-			this.defaultHttpSessionStrategy.setCookieSerializer(this.cookieSerializer);
-		}
-		else if (this.usesSpringSessionRememberMeServices) {
-			DefaultCookieSerializer cookieSerializer = new DefaultCookieSerializer();
-			cookieSerializer.setRememberMeRequestAttribute(
-					SpringSessionRememberMeServices.REMEMBER_ME_LOGIN_ATTR);
-			this.defaultHttpSessionStrategy.setCookieSerializer(cookieSerializer);
-		}
+		CookieSerializer cookieSerializer = this.cookieSerializer != null
+				? this.cookieSerializer : createDefaultCookieSerializer();
+		this.defaultHttpSessionStrategy.setCookieSerializer(cookieSerializer);
 	}
 
 	@Bean
@@ -166,6 +166,39 @@ public class SpringHttpSessionConfiguration implements ApplicationContextAware {
 	@Autowired(required = false)
 	public void setHttpSessionListeners(List<HttpSessionListener> listeners) {
 		this.httpSessionListeners = listeners;
+	}
+
+	private CookieSerializer createDefaultCookieSerializer() {
+		DefaultCookieSerializer cookieSerializer = new DefaultCookieSerializer();
+		if (this.servletContext != null) {
+			SessionCookieConfig sessionCookieConfig = null;
+			try {
+				sessionCookieConfig = this.servletContext.getSessionCookieConfig();
+			}
+			catch (UnsupportedOperationException e) {
+				this.logger
+						.warn("Unable to obtain SessionCookieConfig: " + e.getMessage());
+			}
+			if (sessionCookieConfig != null) {
+				if (sessionCookieConfig.getName() != null) {
+					cookieSerializer.setCookieName(sessionCookieConfig.getName());
+				}
+				if (sessionCookieConfig.getDomain() != null) {
+					cookieSerializer.setDomainName(sessionCookieConfig.getDomain());
+				}
+				if (sessionCookieConfig.getPath() != null) {
+					cookieSerializer.setCookiePath(sessionCookieConfig.getPath());
+				}
+				if (sessionCookieConfig.getMaxAge() != -1) {
+					cookieSerializer.setCookieMaxAge(sessionCookieConfig.getMaxAge());
+				}
+			}
+		}
+		if (this.usesSpringSessionRememberMeServices) {
+			cookieSerializer.setRememberMeRequestAttribute(
+					SpringSessionRememberMeServices.REMEMBER_ME_LOGIN_ATTR);
+		}
+		return cookieSerializer;
 	}
 
 }


### PR DESCRIPTION
This resolves #87.

The proposed solution doesn't map two attributes from `SessionCookieConfig`:

- `secure`: `DefaultCookieSerializer#useSecureCookie` defaults to `null` and relies on `ServletRequest#isSecure` which means mapping a value from `SessionCookieConfig` would override our default (since `secure` is a primitive `boolean` over there and typically defaults to `false`)
- `httpOnly`: `DefaultCookieSerializer#useHttpOnlyCookie` defaults to `true` in Servlet 3.0+ environments which means our default would be overridden in `httpOnly` typically defaults to `false`

~~Other than that integration tests in Boot based samples needed to be updated with explicit `MockServletContext` due to `MockSessionCookieConfig#maxAge` defaulting to `0` instead of `-1`. I've opened [SPR-15142](https://jira.spring.io/browse/SPR-15142) to address that.~~