### PR TITLE
Replace put of IMap [Hazelcast]

### DIFF
--- a/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/config/annotation/web/http/EnableHazelcastHttpSessionEventsTests.java
+++ b/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/config/annotation/web/http/EnableHazelcastHttpSessionEventsTests.java
@@ -120,6 +120,8 @@ public class EnableHazelcastHttpSessionEventsTests<S extends Session> {
 		assertThat(this.registry.receivedEvent(sessionToSave.getId())).isTrue();
 		assertThat(this.registry.<SessionExpiredEvent>getEvent(sessionToSave.getId()))
 				.isInstanceOf(SessionExpiredEvent.class);
+		assertThat(this.registry.<SessionExpiredEvent>getEvent(sessionToSave.getId()).<Session>getSession())
+				.isNotNull();
 
 		assertThat(this.repository.<Session>findById(sessionToSave.getId())).isNull();
 	}
@@ -140,6 +142,8 @@ public class EnableHazelcastHttpSessionEventsTests<S extends Session> {
 		assertThat(this.registry.receivedEvent(sessionToSave.getId())).isTrue();
 		assertThat(this.registry.<SessionDeletedEvent>getEvent(sessionToSave.getId()))
 				.isInstanceOf(SessionDeletedEvent.class);
+		assertThat(this.registry.<SessionDeletedEvent>getEvent(sessionToSave.getId()).<Session>getSession())
+				.isNotNull();
 
 		assertThat(this.repository.findById(sessionToSave.getId())).isNull();
 	}

--- a/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/config/annotation/web/http/EnableHazelcastOptimizedSaveDeleteHttpSessionEventsTests.java
+++ b/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/config/annotation/web/http/EnableHazelcastOptimizedSaveDeleteHttpSessionEventsTests.java
@@ -1,0 +1,146 @@
+package org.springframework.session.hazelcast.config.annotation.web.http;
+
+import com.hazelcast.core.HazelcastInstance;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.session.FindByIndexNameSessionRepository;
+import org.springframework.session.Session;
+import org.springframework.session.SessionRepository;
+import org.springframework.session.events.SessionCreatedEvent;
+import org.springframework.session.events.SessionDeletedEvent;
+import org.springframework.session.events.SessionExpiredEvent;
+import org.springframework.session.hazelcast.HazelcastITestUtils;
+import org.springframework.session.hazelcast.SessionEventRegistry;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Ensure that optimized save and delete do not break events contract
+ *
+ * @author Vishal Dhawani
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(
+        classes = EnableHazelcastOptimizedSaveDeleteHttpSessionEventsTests.HazelcastSessionOptimizedConfig.class
+)
+@WebAppConfiguration
+public class EnableHazelcastOptimizedSaveDeleteHttpSessionEventsTests<S extends Session> {
+
+    private final static int MAX_INACTIVE_INTERVAL_IN_SECONDS = 1;
+
+    @Autowired
+    private SessionRepository<S> repository;
+
+    @Autowired
+    private SessionEventRegistry registry;
+
+    @Before
+    public void setup() {
+        this.registry.clear();
+    }
+
+    @Test
+    public void saveSessionTest() throws InterruptedException {
+        String username = "saves-" + System.currentTimeMillis();
+
+        S sessionToSave = this.repository.createSession();
+
+        String expectedAttributeName = "a";
+        String expectedAttributeValue = "b";
+        sessionToSave.setAttribute(expectedAttributeName, expectedAttributeValue);
+        Authentication toSaveToken = new UsernamePasswordAuthenticationToken(username,
+                "password", AuthorityUtils.createAuthorityList("ROLE_USER"));
+        SecurityContext toSaveContext = SecurityContextHolder.createEmptyContext();
+        toSaveContext.setAuthentication(toSaveToken);
+        sessionToSave.setAttribute("SPRING_SECURITY_CONTEXT", toSaveContext);
+        sessionToSave.setAttribute(
+                FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME, username);
+
+        this.repository.save(sessionToSave);
+
+        assertThat(this.registry.receivedEvent(sessionToSave.getId())).isTrue();
+        assertThat(this.registry.<SessionCreatedEvent>getEvent(sessionToSave.getId()))
+                .isInstanceOf(SessionCreatedEvent.class);
+
+        Session session = this.repository.findById(sessionToSave.getId());
+
+        assertThat(session.getId()).isEqualTo(sessionToSave.getId());
+        assertThat(session.getAttributeNames())
+                .isEqualTo(sessionToSave.getAttributeNames());
+        assertThat(session.<String>getAttribute(expectedAttributeName))
+                .isEqualTo(sessionToSave.getAttribute(expectedAttributeName));
+    }
+
+    @Test
+    public void expiredSessionTest() throws InterruptedException {
+        S sessionToSave = this.repository.createSession();
+
+        this.repository.save(sessionToSave);
+
+        assertThat(this.registry.receivedEvent(sessionToSave.getId())).isTrue();
+        assertThat(this.registry.<SessionCreatedEvent>getEvent(sessionToSave.getId()))
+                .isInstanceOf(SessionCreatedEvent.class);
+        this.registry.clear();
+
+        assertThat(sessionToSave.getMaxInactiveInterval())
+                .isEqualTo(Duration.ofSeconds(MAX_INACTIVE_INTERVAL_IN_SECONDS));
+
+        assertThat(this.registry.receivedEvent(sessionToSave.getId())).isTrue();
+        assertThat(this.registry.<SessionExpiredEvent>getEvent(sessionToSave.getId()))
+                .isInstanceOf(SessionExpiredEvent.class);
+        assertThat(this.registry.<SessionExpiredEvent>getEvent(sessionToSave.getId()).<Session>getSession())
+                .isNull();
+
+        assertThat(this.repository.<Session>findById(sessionToSave.getId())).isNull();
+    }
+
+    @Test
+    public void deletedSessionTest() throws InterruptedException {
+        S sessionToSave = this.repository.createSession();
+
+        this.repository.save(sessionToSave);
+
+        assertThat(this.registry.receivedEvent(sessionToSave.getId())).isTrue();
+        assertThat(this.registry.<SessionCreatedEvent>getEvent(sessionToSave.getId()))
+                .isInstanceOf(SessionCreatedEvent.class);
+        this.registry.clear();
+
+        this.repository.deleteById(sessionToSave.getId());
+
+        assertThat(this.registry.receivedEvent(sessionToSave.getId())).isTrue();
+        assertThat(this.registry.<SessionDeletedEvent>getEvent(sessionToSave.getId()))
+                .isInstanceOf(SessionDeletedEvent.class);
+        assertThat(this.registry.<SessionDeletedEvent>getEvent(sessionToSave.getId()).<Session>getSession())
+                .isNull();
+
+        assertThat(this.repository.findById(sessionToSave.getId())).isNull();
+    }
+
+    @Configuration
+    @EnableHazelcastHttpSession(maxInactiveIntervalInSeconds = MAX_INACTIVE_INTERVAL_IN_SECONDS, optimizeDelete = true, optimizeSave = true)
+    static class HazelcastSessionOptimizedConfig {
+        @Bean
+        public HazelcastInstance embeddedHazelcast() {
+            return HazelcastITestUtils.embeddedHazelcastServer();
+        }
+
+        @Bean
+        public SessionEventRegistry sessionEventRegistry() {
+            return new SessionEventRegistry();
+        }
+    }
+}

--- a/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/EnableHazelcastHttpSession.java
+++ b/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/EnableHazelcastHttpSession.java
@@ -25,6 +25,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.session.MapSession;
 import org.springframework.session.SessionRepository;
 import org.springframework.session.config.annotation.web.http.EnableSpringHttpSession;
+import org.springframework.session.events.SessionDeletedEvent;
+import org.springframework.session.events.SessionDestroyedEvent;
 import org.springframework.session.hazelcast.HazelcastFlushMode;
 
 /**
@@ -89,4 +91,21 @@ public @interface EnableHazelcastHttpSession {
 	 */
 	HazelcastFlushMode hazelcastFlushMode() default HazelcastFlushMode.ON_SAVE;
 
+	/**
+	 * If turned on {@link com.hazelcast.core.IMap#set(Object, Object, long, java.util.concurrent.TimeUnit)} is
+	 * used instead of {@link com.hazelcast.core.IMap#put(Object, Object, long, java.util.concurrent.TimeUnit)}.
+	 * Please note that {@link com.hazelcast.core.EntryEvent#getOldValue()} will return null, if it is turned on.
+	 * You should be worried about this only if you are directly binding to Hazelcast events.
+	 * @return the method to use on {@link com.hazelcast.core.IMap}
+	 */
+	boolean optimizeSave() default false;
+
+	/**
+	 * If turned on {@link com.hazelcast.core.IMap#delete(Object)} is used
+	 * instead of {@link com.hazelcast.core.IMap#remove(Object)}.
+	 * Please note that {@link com.hazelcast.core.EntryEvent#getOldValue()} will return null, if it is turned on.
+	 * Also, {@link SessionDeletedEvent#getSession()} & {@link SessionDestroyedEvent#getSession()} will also return null.
+	 * @return the method to use on {@link com.hazelcast.core.IMap}
+	 */
+	boolean optimizeDelete() default false;
 }

--- a/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfiguration.java
+++ b/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfiguration.java
@@ -55,6 +55,10 @@ public class HazelcastHttpSessionConfiguration extends SpringHttpSessionConfigur
 
 	private HazelcastFlushMode hazelcastFlushMode = HazelcastFlushMode.ON_SAVE;
 
+	private boolean optimizeSave = false;
+
+	private boolean optimizeDelete = false;
+
 	@Bean
 	public HazelcastSessionRepository sessionRepository(
 			HazelcastInstance hazelcastInstance,
@@ -67,6 +71,8 @@ public class HazelcastHttpSessionConfiguration extends SpringHttpSessionConfigur
 		sessionRepository.setDefaultMaxInactiveInterval(
 				this.maxInactiveIntervalInSeconds);
 		sessionRepository.setHazelcastFlushMode(this.hazelcastFlushMode);
+		sessionRepository.setOptimizeSave(this.optimizeSave);
+		sessionRepository.setOptimizeDelete(this.optimizeDelete);
 		return sessionRepository;
 	}
 
@@ -79,6 +85,8 @@ public class HazelcastHttpSessionConfiguration extends SpringHttpSessionConfigur
 		setSessionMapName(enableAttrs.getString("sessionMapName"));
 		setHazelcastFlushMode(
 				(HazelcastFlushMode) enableAttrs.getEnum("hazelcastFlushMode"));
+		setOptimizeSave(enableAttrs.getBoolean("optimizeSave"));
+		setOptimizeDelete(enableAttrs.getBoolean("optimizeDelete"));
 	}
 
 	public void setMaxInactiveIntervalInSeconds(int maxInactiveIntervalInSeconds) {
@@ -93,4 +101,11 @@ public class HazelcastHttpSessionConfiguration extends SpringHttpSessionConfigur
 		this.hazelcastFlushMode = hazelcastFlushMode;
 	}
 
+	public void setOptimizeSave(boolean optimizeSave) {
+		this.optimizeSave = optimizeSave;
+	}
+
+	public void setOptimizeDelete(boolean optimizeDelete) {
+		this.optimizeDelete = optimizeDelete;
+	}
 }

--- a/spring-session-hazelcast/src/test/java/org/springframework/session/hazelcast/HazelcastSessionRepositoryTests.java
+++ b/spring-session-hazelcast/src/test/java/org/springframework/session/hazelcast/HazelcastSessionRepositoryTests.java
@@ -112,6 +112,17 @@ public class HazelcastSessionRepositoryTests {
 	}
 
 	@Test
+	public void saveOptimized() {
+		this.repository.setOptimizeSave(true);
+		HazelcastSession session = this.repository.createSession();
+		verifyZeroInteractions(this.sessions);
+
+		this.repository.save(session);
+		verify(this.sessions, times(1)).set(eq(session.getId()), eq(session.getDelegate()),
+				isA(Long.class), eq(TimeUnit.SECONDS));
+	}
+
+	@Test
 	public void saveNewFlushModeImmediate() {
 		this.repository.setHazelcastFlushMode(HazelcastFlushMode.IMMEDIATE);
 
@@ -283,6 +294,16 @@ public class HazelcastSessionRepositoryTests {
 		this.repository.deleteById(sessionId);
 
 		verify(this.sessions, times(1)).remove(eq(sessionId));
+	}
+
+	@Test
+	public void deleteOptimized() {
+		this.repository.setOptimizeDelete(true);
+		String sessionId = "testSessionId";
+
+		this.repository.deleteById(sessionId);
+
+		verify(this.sessions, times(1)).delete(eq(sessionId));
 	}
 
 	@Test

--- a/spring-session-hazelcast/src/test/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfigurationTests.java
+++ b/spring-session-hazelcast/src/test/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfigurationTests.java
@@ -89,8 +89,16 @@ public class HazelcastHttpSessionConfigurationTests {
 	public void defaultConfiguration() {
 		registerAndRefresh(DefaultConfiguration.class);
 
-		assertThat(this.context.getBean(HazelcastSessionRepository.class))
-				.isNotNull();
+		HazelcastSessionRepository repository = this.context
+				.getBean(HazelcastSessionRepository.class);
+		HazelcastHttpSessionConfiguration configuration = this.context
+				.getBean(HazelcastHttpSessionConfiguration.class);
+		assertThat(repository).isNotNull();
+
+		assertThat(ReflectionTestUtils.getField(configuration, "optimizeSave"))
+				.isEqualTo(false);
+		assertThat(ReflectionTestUtils.getField(configuration, "optimizeDelete"))
+				.isEqualTo(false);
 	}
 
 	@Test
@@ -166,6 +174,72 @@ public class HazelcastHttpSessionConfigurationTests {
 				.isEqualTo(HazelcastFlushMode.IMMEDIATE);
 	}
 
+	@Test
+	public void customOptimizeSave() {
+		registerAndRefresh(CustomOptimizeSaveConfiguration.class);
+
+		HazelcastSessionRepository repository = this.context
+				.getBean(HazelcastSessionRepository.class);
+		HazelcastHttpSessionConfiguration configuration = this.context
+				.getBean(HazelcastHttpSessionConfiguration.class);
+
+		assertThat(repository).isNotNull();
+		assertThat(ReflectionTestUtils.getField(configuration, "optimizeSave"))
+				.isEqualTo(true);
+		assertThat(ReflectionTestUtils.getField(repository, "optimizeSave"))
+				.isEqualTo(true);
+	}
+
+	@Test
+	public void setOptimizeSave() {
+		registerAndRefresh(BaseConfiguration.class,
+				CustomOptimizeSaveSetConfiguration.class);
+
+		HazelcastSessionRepository repository = this.context
+				.getBean(HazelcastSessionRepository.class);
+		HazelcastHttpSessionConfiguration configuration = this.context
+				.getBean(HazelcastHttpSessionConfiguration.class);
+
+		assertThat(repository).isNotNull();
+		assertThat(ReflectionTestUtils.getField(configuration, "optimizeSave"))
+				.isEqualTo(true);
+		assertThat(ReflectionTestUtils.getField(repository, "optimizeSave"))
+				.isEqualTo(true);
+	}
+
+	@Test
+	public void customOptimizeDelete() {
+		registerAndRefresh(CustomOptimizeDeleteConfiguration.class);
+
+		HazelcastSessionRepository repository = this.context
+				.getBean(HazelcastSessionRepository.class);
+		HazelcastHttpSessionConfiguration configuration = this.context
+				.getBean(HazelcastHttpSessionConfiguration.class);
+
+		assertThat(repository).isNotNull();
+		assertThat(ReflectionTestUtils.getField(configuration, "optimizeDelete"))
+				.isEqualTo(true);
+		assertThat(ReflectionTestUtils.getField(repository, "optimizeDelete"))
+				.isEqualTo(true);
+	}
+
+	@Test
+	public void setOptimizeDelete() {
+		registerAndRefresh(BaseConfiguration.class,
+				CustomOptimizeDeleteSetConfiguration.class);
+
+		HazelcastSessionRepository repository = this.context
+				.getBean(HazelcastSessionRepository.class);
+		HazelcastHttpSessionConfiguration configuration = this.context
+				.getBean(HazelcastHttpSessionConfiguration.class);
+
+		assertThat(repository).isNotNull();
+		assertThat(ReflectionTestUtils.getField(configuration, "optimizeDelete"))
+				.isEqualTo(true);
+		assertThat(ReflectionTestUtils.getField(repository, "optimizeDelete"))
+				.isEqualTo(true);
+	}
+
 	private void registerAndRefresh(Class<?>... annotatedClasses) {
 		this.context.register(annotatedClasses);
 		this.context.refresh();
@@ -235,6 +309,36 @@ public class HazelcastHttpSessionConfigurationTests {
 	@EnableHazelcastHttpSession(hazelcastFlushMode = HazelcastFlushMode.IMMEDIATE)
 	static class CustomFlushImmediatelyConfiguration
 			extends BaseConfiguration {
+	}
+
+	@Configuration
+	@EnableHazelcastHttpSession(optimizeSave = true)
+	static class CustomOptimizeSaveConfiguration extends BaseConfiguration {
+	}
+
+	@Configuration
+	static class CustomOptimizeSaveSetConfiguration
+			extends HazelcastHttpSessionConfiguration {
+
+		CustomOptimizeSaveSetConfiguration() {
+			setOptimizeSave(true);
+		}
+
+	}
+
+	@Configuration
+	@EnableHazelcastHttpSession(optimizeDelete = true)
+	static class CustomOptimizeDeleteConfiguration extends BaseConfiguration {
+	}
+
+	@Configuration
+	static class CustomOptimizeDeleteSetConfiguration
+			extends HazelcastHttpSessionConfiguration {
+
+		CustomOptimizeDeleteSetConfiguration() {
+			setOptimizeDelete(true);
+		}
+
 	}
 
 }


### PR DESCRIPTION
Based on [article](https://blog.hazelcast.com/performance-top-5-1-map-put-vs-map-set), replace put with set to avoid serialisation and de-serialisation of entires.