### PR TITLE
Improve dependency management

### DIFF
--- a/samples/boot/findbyusername/spring-session-sample-boot-findbyusername.gradle
+++ b/samples/boot/findbyusername/spring-session-sample-boot-findbyusername.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compile "org.springframework.boot:spring-boot-starter-web"
 	compile "org.springframework.boot:spring-boot-starter-thymeleaf"
 	compile "org.springframework.boot:spring-boot-starter-security"
+	compile "org.springframework.boot:spring-boot-starter-data-redis"
 	compile "org.springframework.boot:spring-boot-devtools"
 	compile "nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect"
 	compile "org.thymeleaf.extras:thymeleaf-extras-java8time"

--- a/samples/boot/jdbc/spring-session-sample-boot-jdbc.gradle
+++ b/samples/boot/jdbc/spring-session-sample-boot-jdbc.gradle
@@ -14,6 +14,7 @@ dependencies {
 
 	compile project(':spring-session-hazelcast')
 	compile project(':spring-session-data-redis')
+	compile "org.springframework.boot:spring-boot-starter-data-redis"
 
 	testCompile "org.springframework.boot:spring-boot-starter-test"
 	testCompile "org.assertj:assertj-core"

--- a/samples/boot/redis-json/spring-session-sample-boot-redis-json.gradle
+++ b/samples/boot/redis-json/spring-session-sample-boot-redis-json.gradle
@@ -1,18 +1,16 @@
 apply plugin: 'io.spring.convention.spring-sample-boot'
 
 dependencies {
-	compile(project(':spring-session-data-redis')) {
-		exclude module: 'jedis'
-	}
+	compile project(':spring-session-data-redis')
 	compile "org.springframework.boot:spring-boot-starter-web"
 	compile "org.springframework.boot:spring-boot-starter-thymeleaf"
 	compile "org.springframework.boot:spring-boot-starter-security"
+	compile "org.springframework.boot:spring-boot-starter-data-redis"
 	compile "org.springframework.boot:spring-boot-devtools"
 	compile "nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect"
 	compile "org.webjars:bootstrap"
 	compile "org.webjars:html5shiv"
 	compile "org.webjars:webjars-locator"
-	compile "io.lettuce:lettuce-core"
 	compile "org.apache.httpcomponents:httpclient"
 
 	compile project(':spring-session-hazelcast')

--- a/samples/boot/redis/spring-session-sample-boot-redis.gradle
+++ b/samples/boot/redis/spring-session-sample-boot-redis.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compile "org.springframework.boot:spring-boot-starter-web"
 	compile "org.springframework.boot:spring-boot-starter-thymeleaf"
 	compile "org.springframework.boot:spring-boot-starter-security"
+	compile "org.springframework.boot:spring-boot-starter-data-redis"
 	compile "org.springframework.boot:spring-boot-devtools"
 	compile "nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect"
 	compile "org.webjars:bootstrap"

--- a/samples/boot/websocket/spring-session-sample-boot-websocket.gradle
+++ b/samples/boot/websocket/spring-session-sample-boot-websocket.gradle
@@ -1,13 +1,12 @@
 apply plugin: 'io.spring.convention.spring-sample-boot'
 
 dependencies {
-	compile(project(':spring-session-data-redis')) {
-		exclude module: 'jedis'
-	}
+	compile project(':spring-session-data-redis')
 	compile "org.springframework.boot:spring-boot-starter-web"
 	compile "org.springframework.boot:spring-boot-starter-thymeleaf"
 	compile "org.springframework.boot:spring-boot-starter-security"
 	compile "org.springframework.boot:spring-boot-starter-data-jpa"
+	compile "org.springframework.boot:spring-boot-starter-data-redis"
 	compile "org.springframework.boot:spring-boot-starter-websocket"
 	compile "org.springframework.boot:spring-boot-devtools"
 	compile "org.springframework:spring-websocket"
@@ -20,7 +19,6 @@ dependencies {
 	compile "org.webjars:sockjs-client"
 	compile "org.webjars:stomp-websocket"
 	compile "org.webjars:webjars-locator"
-	compile "io.lettuce:lettuce-core"
 	compile "com.h2database:h2"
 
 	compile project(':spring-session-hazelcast')

--- a/spring-session-core/spring-session-core.gradle
+++ b/spring-session-core/spring-session-core.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compile "org.springframework:spring-jcl"
 
 	optional "io.projectreactor:reactor-core"
+	optional "javax.servlet:javax.servlet-api"
 	optional "org.springframework:spring-context"
 	optional "org.springframework:spring-jdbc"
 	optional "org.springframework:spring-messaging"
@@ -13,8 +14,6 @@ dependencies {
 	optional "org.springframework:spring-websocket"
 	optional "org.springframework.security:spring-security-core"
 	optional "org.springframework.security:spring-security-web"
-
-	provided "javax.servlet:javax.servlet-api"
 
 	testCompile "junit:junit"
 	testCompile "org.mockito:mockito-core"

--- a/spring-session-data-redis/spring-session-data-redis.gradle
+++ b/spring-session-data-redis/spring-session-data-redis.gradle
@@ -8,10 +8,11 @@ dependencies {
 		exclude group: "org.slf4j", module: 'slf4j-api'
 		exclude group: "org.slf4j", module: 'jcl-over-slf4j'
 	}
-	compile "redis.clients:jedis"
-	compile "org.apache.commons:commons-pool2"
 
 	testCompile "javax.servlet:javax.servlet-api"
+	testCompile "org.springframework:spring-web"
 	testCompile "org.springframework.security:spring-security-core"
-	testCompile "org.springframework.security:spring-security-web"
+
+	integrationTestCompile "redis.clients:jedis"
+	integrationTestCompile "org.apache.commons:commons-pool2"
 }

--- a/spring-session-hazelcast/spring-session-hazelcast.gradle
+++ b/spring-session-hazelcast/spring-session-hazelcast.gradle
@@ -6,8 +6,8 @@ dependencies {
 	compile "org.springframework:spring-context"
 
 	testCompile "javax.servlet:javax.servlet-api"
-	testCompile "org.springframework.security:spring-security-core"
 	testCompile "org.springframework:spring-web"
+	testCompile "org.springframework.security:spring-security-core"
 
 	integrationTestCompile "com.hazelcast:hazelcast-client"
 }

--- a/spring-session-jdbc/spring-session-jdbc.gradle
+++ b/spring-session-jdbc/spring-session-jdbc.gradle
@@ -8,8 +8,8 @@ dependencies {
 	compile "org.springframework:spring-jdbc"
 
 	testCompile "javax.servlet:javax.servlet-api"
+	testCompile "org.springframework:spring-web"
 	testCompile "org.springframework.security:spring-security-core"
-	testCompile "org.springframework.security:spring-security-web"
 
 	integrationTestCompile "org.apache.derby:derby"
 	integrationTestCompile "com.h2database:h2"


### PR DESCRIPTION
This PR improves dependency management with the following changes:

 - `spring-session-core`: move `javax.servlet-api` from `provided` to `optional` configuration due to introduction of reactive support
 - `spring-session-data-redis`: remove Redis driver from `compile` configuration
 - Boot samples: delegate Redis driver choice to `spring-boot-starter-data-redis`
 - polish `test` configuration dependencies

This also resolves #802.
