### PR TITLE
Add Spring Session BOM module

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,5 @@
+apply plugin: 'groovy'
+
+dependencies {
+	compile gradleApi()
+}

--- a/buildSrc/src/main/groovy/MavenBomPlugin.groovy
+++ b/buildSrc/src/main/groovy/MavenBomPlugin.groovy
@@ -1,0 +1,17 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.MavenPlugin
+
+class MavenBomPlugin implements Plugin<Project> {
+	static String MAVEN_BOM_TASK_NAME = 'mavenBom'
+
+	void apply(Project project) {
+		project.plugins.apply(JavaPlugin)
+		project.plugins.apply(MavenPlugin)
+
+		project.group = project.rootProject.group
+		project.task(MAVEN_BOM_TASK_NAME, type: MavenBomTask, group: 'Generate', description: 'Configures the pom as a Maven Bill of Materials (BOM)')
+		project.install.dependsOn project.mavenBom
+	}
+}

--- a/buildSrc/src/main/groovy/MavenBomTask.groovy
+++ b/buildSrc/src/main/groovy/MavenBomTask.groovy
@@ -1,0 +1,51 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskAction
+
+class MavenBomTask extends DefaultTask {
+
+	Set<Project> projects = []
+
+	File bomFile
+
+	MavenBomTask() {
+		this.group = 'Generate'
+		this.description = 'Generates a Maven Bill of Materials (BOM). See http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies'
+		this.projects = project.subprojects
+		this.bomFile = project.file("${->project.buildDir}/maven-bom/${->project.name}-${->project.version}.txt")
+	}
+
+	@TaskAction
+	void configureBom() {
+		project.configurations.archives.artifacts.clear()
+
+		bomFile.parentFile.mkdirs()
+		bomFile.write('Maven Bill of Materials (BOM). See http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies')
+		project.artifacts {
+			// work around GRADLE-2406 by attaching text artifact
+			archives(bomFile)
+		}
+		project.install {
+			repositories.mavenInstaller {
+				pom.whenConfigured {
+					packaging = 'pom'
+					withXml {
+						asNode().children().last() + {
+							delegate.dependencyManagement {
+								delegate.dependencies {
+									projects.sort { dep -> "$dep.group:$dep.name" }.each { p ->
+										delegate.dependency {
+											delegate.groupId(p.group)
+											delegate.artifactId(p.name)
+											delegate.version(p.version)
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/maven-bom.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/maven-bom.properties
@@ -1,0 +1,1 @@
+implementation-class=MavenBomPlugin

--- a/spring-session-bom/spring-session-bom.gradle
+++ b/spring-session-bom/spring-session-bom.gradle
@@ -1,0 +1,14 @@
+import io.spring.gradle.convention.SpringMavenPlugin
+
+apply plugin: 'maven-bom'
+apply plugin: 'io.spring.convention.artifactory'
+
+description = "Spring Session Maven Bill of Materials (BOM)"
+
+sonarqube.skipProject = true
+
+project.rootProject.allprojects.each { p ->
+	p.plugins.withType(SpringMavenPlugin) {
+		project.mavenBom.projects.add(p)
+	}
+}


### PR DESCRIPTION
This PR adds Spring Session Maven Bill of Materials (BOM) module.

The approach taken in this initial version is borrowed from Spring Security's BOM module, which means BOM currently provides dependency management only for modules provided by this repo. We should extend this to support external ones, like `spring-session-data-mongodb`. I guess we can address support for that via spring-gradle-plugins/spring-build-conventions#1.

Also we should consider introducing BOM versioning theme.

