### PR TITLE
Provide `SessionRepository` implementations discovery

### DIFF
--- a/spring-session-data-redis/src/main/resources/META-INF/spring.factories
+++ b/spring-session-data-redis/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.session.config.annotation.web.http.EnableSpringHttpSession=\
+org.springframework.session.data.redis.config.annotation.web.http.RedisHttpSessionConfiguration

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.session.data.redis.config.annotation.web.http;
 
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,9 +26,11 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.core.io.support.SpringFactoriesLoader;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.mock.env.MockEnvironment;
+import org.springframework.session.config.annotation.web.http.EnableSpringHttpSession;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,7 +38,10 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 /**
+ * Tests for {@link RedisHttpSessionConfiguration}.
+ *
  * @author Eddú Meléndez
+ * @author Vedran Pavic
  */
 public class RedisHttpSessionConfigurationTests {
 
@@ -65,6 +72,14 @@ public class RedisHttpSessionConfigurationTests {
 		registerAndRefresh(RedisConfig.class, PropertySourceConfiguration.class, CustomRedisHttpSessionConfiguration2.class);
 		RedisHttpSessionConfiguration configuration = this.context.getBean(RedisHttpSessionConfiguration.class);
 		assertThat(ReflectionTestUtils.getField(configuration, "redisNamespace")).isEqualTo("customRedisNamespace");
+	}
+
+	@Test
+	public void discoverConfigurationClass() {
+		List<String> factoryNames = SpringFactoriesLoader.loadFactoryNames(
+				EnableSpringHttpSession.class, getClass().getClassLoader());
+		assertThat(factoryNames).hasSize(1);
+		assertThat(factoryNames).contains(RedisHttpSessionConfiguration.class.getName());
 	}
 
 	private void registerAndRefresh(Class<?>... annotatedClasses) {

--- a/spring-session-hazelcast/src/main/resources/META-INF/spring.factories
+++ b/spring-session-hazelcast/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.session.config.annotation.web.http.EnableSpringHttpSession=\
+org.springframework.session.hazelcast.config.annotation.web.http.HazelcastHttpSessionConfiguration

--- a/spring-session-hazelcast/src/test/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfigurationTests.java
+++ b/spring-session-hazelcast/src/test/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfigurationTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.session.hazelcast.config.annotation.web.http;
 
+import java.util.List;
+
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import org.junit.After;
@@ -31,6 +33,8 @@ import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.support.SpringFactoriesLoader;
+import org.springframework.session.config.annotation.web.http.EnableSpringHttpSession;
 import org.springframework.session.hazelcast.HazelcastFlushMode;
 import org.springframework.session.hazelcast.HazelcastSessionRepository;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -164,6 +168,15 @@ public class HazelcastHttpSessionConfigurationTests {
 		assertThat(repository).isNotNull();
 		assertThat(ReflectionTestUtils.getField(repository, "hazelcastFlushMode"))
 				.isEqualTo(HazelcastFlushMode.IMMEDIATE);
+	}
+
+	@Test
+	public void discoverConfigurationClass() {
+		List<String> factoryNames = SpringFactoriesLoader.loadFactoryNames(
+				EnableSpringHttpSession.class, getClass().getClassLoader());
+		assertThat(factoryNames).hasSize(1);
+		assertThat(factoryNames)
+				.contains(HazelcastHttpSessionConfiguration.class.getName());
 	}
 
 	private void registerAndRefresh(Class<?>... annotatedClasses) {

--- a/spring-session-jdbc/src/main/resources/META-INF/spring.factories
+++ b/spring-session-jdbc/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.session.config.annotation.web.http.EnableSpringHttpSession=\
+org.springframework.session.jdbc.config.annotation.web.http.JdbcHttpSessionConfiguration

--- a/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfigurationTests.java
+++ b/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.session.jdbc.config.annotation.web.http;
 
+import java.util.List;
+
 import javax.sql.DataSource;
 
 import org.junit.After;
@@ -29,8 +31,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.convert.ConversionService;
+import org.springframework.core.io.support.SpringFactoriesLoader;
 import org.springframework.jdbc.support.lob.LobHandler;
 import org.springframework.mock.env.MockEnvironment;
+import org.springframework.session.config.annotation.web.http.EnableSpringHttpSession;
 import org.springframework.session.jdbc.JdbcOperationsSessionRepository;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -179,6 +183,14 @@ public class JdbcHttpSessionConfigurationTests {
 		registerAndRefresh(CustomJdbcHttpSessionConfiguration.class);
 		JdbcHttpSessionConfiguration configuration = this.context.getBean(JdbcHttpSessionConfiguration.class);
 		assertThat(ReflectionTestUtils.getField(configuration, "tableName")).isEqualTo("custom_session_table");
+	}
+
+	@Test
+	public void discoverConfigurationClass() {
+		List<String> factoryNames = SpringFactoriesLoader.loadFactoryNames(
+				EnableSpringHttpSession.class, getClass().getClassLoader());
+		assertThat(factoryNames).hasSize(1);
+		assertThat(factoryNames).contains(JdbcHttpSessionConfiguration.class.getName());
 	}
 
 	private void registerAndRefresh(Class<?>... annotatedClasses) {


### PR DESCRIPTION
This PR provides discovery of `SessionRepository` implementations using `spring.factories` to help improve Spring Boot auto-configuration for Spring Session, as suggested in spring-projects/spring-boot#9683.

Once `ReactorSessionRepository` implementations become available, we should add a separate key for that as well.