### PR TITLE
Adapt to changes in Spring Data Redis API

### DIFF
--- a/docs/src/test/java/docs/http/AbstractHttpSessionListenerTests.java
+++ b/docs/src/test/java/docs/http/AbstractHttpSessionListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package docs.http;
 
+import java.util.Properties;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -31,11 +33,13 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 /**
  * @author Rob Winch
+ * @author Mark Paluch
  * @since 1.2
  */
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -63,6 +67,7 @@ public abstract class AbstractHttpSessionListenerTests {
 		RedisConnection connection = mock(RedisConnection.class);
 
 		given(factory.getConnection()).willReturn(connection);
+		given(connection.getConfig(anyString())).willReturn(new Properties());
 		return factory;
 	}
 

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/ConfigureNotifyKeyspaceEventsAction.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/ConfigureNotifyKeyspaceEventsAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.session.data.redis.config;
 
-import java.util.List;
+import java.util.Properties;
 
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.redis.connection.RedisConnection;
@@ -38,6 +38,7 @@ import org.springframework.data.redis.connection.RedisConnection;
  * </p>
  *
  * @author Rob Winch
+ * @author Mark Paluch
  * @since 1.0.1
  */
 public class ConfigureNotifyKeyspaceEventsAction implements ConfigureRedisAction {
@@ -71,11 +72,11 @@ public class ConfigureNotifyKeyspaceEventsAction implements ConfigureRedisAction
 
 	private String getNotifyOptions(RedisConnection connection) {
 		try {
-			List<String> config = connection.getConfig(CONFIG_NOTIFY_KEYSPACE_EVENTS);
-			if (config.size() < 2) {
+			Properties config = connection.getConfig(CONFIG_NOTIFY_KEYSPACE_EVENTS);
+			if (config.isEmpty()) {
 				return "";
 			}
-			return config.get(1);
+			return config.getProperty(config.stringPropertyNames().iterator().next());
 		}
 		catch (InvalidDataAccessApiUsageException e) {
 			throw new IllegalStateException(

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/EnableRedisKeyspaceNotificationsInitializerTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/EnableRedisKeyspaceNotificationsInitializerTests.java
@@ -16,7 +16,7 @@
 
 package org.springframework.session.data.redis.config.annotation.web.http;
 
-import java.util.Arrays;
+import java.util.Properties;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -167,7 +167,9 @@ public class EnableRedisKeyspaceNotificationsInitializerTests {
 	}
 
 	private void setConfigNotification(String value) {
+		Properties properties = new Properties();
+		properties.setProperty(CONFIG_NOTIFY_KEYSPACE_EVENTS, value);
 		given(this.connection.getConfig(CONFIG_NOTIFY_KEYSPACE_EVENTS))
-				.willReturn(Arrays.asList(CONFIG_NOTIFY_KEYSPACE_EVENTS, value));
+				.willReturn(properties);
 	}
 }

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationClassPathXmlApplicationContextTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationClassPathXmlApplicationContextTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.session.data.redis.config.annotation.web.http;
 
+import java.util.Properties;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -24,11 +26,13 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 /**
  * @author Rob Winch
+ * @author Mark Paluch
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -44,6 +48,7 @@ public class RedisHttpSessionConfigurationClassPathXmlApplicationContextTests {
 		RedisConnectionFactory factory = mock(RedisConnectionFactory.class);
 		RedisConnection connection = mock(RedisConnection.class);
 		given(factory.getConnection()).willReturn(connection);
+		given(connection.getConfig(anyString())).willReturn(new Properties());
 
 		return factory;
 	}

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationOverrideDefaultSerializerTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationOverrideDefaultSerializerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.session.data.redis.config.annotation.web.http;
 
+import java.util.Properties;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -31,11 +33,13 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 /**
  * @author Rob Winch
+ * @author Mark Paluch
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -69,6 +73,7 @@ public class RedisHttpSessionConfigurationOverrideDefaultSerializerTests {
 			RedisConnectionFactory factory = mock(RedisConnectionFactory.class);
 			RedisConnection connection = mock(RedisConnection.class);
 			given(factory.getConnection()).willReturn(connection);
+			given(connection.getConfig(anyString())).willReturn(new Properties());
 
 			return factory;
 		}

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationOverrideSessionTaskExecutor.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationOverrideSessionTaskExecutor.java
@@ -16,6 +16,7 @@
 
 package org.springframework.session.data.redis.config.annotation.web.http;
 
+import java.util.Properties;
 import java.util.concurrent.Executor;
 
 import org.junit.Test;
@@ -33,6 +34,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -72,6 +74,7 @@ public class RedisHttpSessionConfigurationOverrideSessionTaskExecutor {
 			RedisConnectionFactory factory = mock(RedisConnectionFactory.class);
 			RedisConnection connection = mock(RedisConnection.class);
 			given(factory.getConnection()).willReturn(connection);
+			given(connection.getConfig(anyString())).willReturn(new Properties());
 
 			return factory;
 		}

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationOverrideSessionTaskExecutors.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationOverrideSessionTaskExecutors.java
@@ -16,6 +16,7 @@
 
 package org.springframework.session.data.redis.config.annotation.web.http;
 
+import java.util.Properties;
 import java.util.concurrent.Executor;
 
 import org.junit.Test;
@@ -33,6 +34,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -41,6 +43,7 @@ import static org.mockito.Mockito.verify;
 
 /**
  * @author Vladimir Tsanev
+ * @author Mark Paluch
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -82,6 +85,7 @@ public class RedisHttpSessionConfigurationOverrideSessionTaskExecutors {
 			RedisConnectionFactory factory = mock(RedisConnectionFactory.class);
 			RedisConnection connection = mock(RedisConnection.class);
 			given(factory.getConnection()).willReturn(connection);
+			given(connection.getConfig(anyString())).willReturn(new Properties());
 
 			return factory;
 		}

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.session.data.redis.config.annotation.web.http;
 
+import java.util.Properties;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,11 +32,13 @@ import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 /**
  * @author Eddú Meléndez
+ * @author Mark Paluch
  */
 public class RedisHttpSessionConfigurationTests {
 
@@ -88,7 +92,9 @@ public class RedisHttpSessionConfigurationTests {
 		@Bean
 		public RedisConnectionFactory redisConnectionFactory() {
 			RedisConnectionFactory connectionFactory = mock(RedisConnectionFactory.class);
-			given(connectionFactory.getConnection()).willReturn(mock(RedisConnection.class));
+			RedisConnection connection = mock(RedisConnection.class);
+			given(connectionFactory.getConnection()).willReturn(connection);
+			given(connection.getConfig(anyString())).willReturn(new Properties());
 			return connectionFactory;
 		}
 

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationXmlCustomExpireTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationXmlCustomExpireTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.session.data.redis.config.annotation.web.http;
 
+import java.util.Properties;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -25,6 +27,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -41,6 +44,7 @@ public class RedisHttpSessionConfigurationXmlCustomExpireTests {
 		RedisConnectionFactory factory = mock(RedisConnectionFactory.class);
 		RedisConnection connection = mock(RedisConnection.class);
 		given(factory.getConnection()).willReturn(connection);
+		given(connection.getConfig(anyString())).willReturn(new Properties());
 
 		return factory;
 	}

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationXmlTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationXmlTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.session.data.redis.config.annotation.web.http;
 
+import java.util.Properties;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -25,6 +27,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -41,6 +44,7 @@ public class RedisHttpSessionConfigurationXmlTests {
 		RedisConnectionFactory factory = mock(RedisConnectionFactory.class);
 		RedisConnection connection = mock(RedisConnection.class);
 		given(factory.getConnection()).willReturn(connection);
+		given(connection.getConfig(anyString())).willReturn(new Properties());
 
 		return factory;
 	}

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/gh109/Gh109Tests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/gh109/Gh109Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.session.data.redis.config.annotation.web.http.gh109;
 
+import java.util.Properties;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -31,6 +33,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -38,6 +41,7 @@ import static org.mockito.Mockito.mock;
  * This test must be in a different package than RedisHttpSessionConfiguration.
  *
  * @author Rob Winch
+ * @author Mark Paluch
  * @since 1.0.2
  */
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -73,8 +77,8 @@ public class Gh109Tests {
 		public RedisConnectionFactory redisConnectionFactory() {
 			RedisConnectionFactory factory = mock(RedisConnectionFactory.class);
 			RedisConnection connection = mock(RedisConnection.class);
-
 			given(factory.getConnection()).willReturn(connection);
+			given(connection.getConfig(anyString())).willReturn(new Properties());
 			return factory;
 		}
 	}


### PR DESCRIPTION
Adaopt to changed `RedisConnection.getConfig(…)` return type from `List<String>` to `Properties`.

---

Samples are still broken. Leaving untouched because they are pinned to Boot 2.0 M2.