### PR TITLE
Remove `MapSessionRepository` default constructor

### DIFF
--- a/docs/src/test/java/docs/IndexDocTests.java
+++ b/docs/src/test/java/docs/IndexDocTests.java
@@ -17,6 +17,7 @@
 package docs;
 
 import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
@@ -51,7 +52,7 @@ public class IndexDocTests {
 	@Test
 	public void repositoryDemo() {
 		RepositoryDemo<MapSession> demo = new RepositoryDemo<>();
-		demo.repository = new MapSessionRepository();
+		demo.repository = new MapSessionRepository(new ConcurrentHashMap<>());
 
 		demo.demo();
 	}
@@ -83,7 +84,7 @@ public class IndexDocTests {
 	@Test
 	public void expireRepositoryDemo() {
 		ExpiringRepositoryDemo<MapSession> demo = new ExpiringRepositoryDemo<>();
-		demo.repository = new MapSessionRepository();
+		demo.repository = new MapSessionRepository(new ConcurrentHashMap<>());
 
 		demo.demo();
 	}
@@ -121,7 +122,8 @@ public class IndexDocTests {
 	@SuppressWarnings("unused")
 	public void mapRepository() {
 		// tag::new-mapsessionrepository[]
-		SessionRepository<? extends Session> repository = new MapSessionRepository();
+		SessionRepository<? extends Session> repository = new MapSessionRepository(
+				new ConcurrentHashMap<>());
 		// end::new-mapsessionrepository[]
 	}
 

--- a/docs/src/test/java/docs/SpringHttpSessionConfig.java
+++ b/docs/src/test/java/docs/SpringHttpSessionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package docs;
 
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.session.MapSessionRepository;
@@ -27,7 +29,7 @@ import org.springframework.session.config.annotation.web.http.EnableSpringHttpSe
 public class SpringHttpSessionConfig {
 	@Bean
 	public MapSessionRepository sessionRepository() {
-		return new MapSessionRepository();
+		return new MapSessionRepository(new ConcurrentHashMap<>());
 	}
 }
 // end::class[]

--- a/docs/src/test/java/docs/security/RememberMeSecurityConfiguration.java
+++ b/docs/src/test/java/docs/security/RememberMeSecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package docs.security;
+
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -73,7 +75,7 @@ public class RememberMeSecurityConfiguration extends WebSecurityConfigurerAdapte
 
 	@Bean
 	MapSessionRepository sessionRepository() {
-		return new MapSessionRepository();
+		return new MapSessionRepository(new ConcurrentHashMap<>());
 	}
 }
 // end::class[]

--- a/docs/src/test/resources/docs/security/RememberMeSecurityConfigurationXmlTests-context.xml
+++ b/docs/src/test/resources/docs/security/RememberMeSecurityConfigurationXmlTests-context.xml
@@ -24,5 +24,9 @@
 	</security:user-service>
 
 	<bean class="org.springframework.session.config.annotation.web.http.SpringHttpSessionConfiguration"/>
-	<bean id="springSessionRepository" class="org.springframework.session.MapSessionRepository"/>
+	<bean id="springSessionRepository" class="org.springframework.session.MapSessionRepository">
+		<constructor-arg>
+			<bean class="java.util.concurrent.ConcurrentHashMap"/>
+		</constructor-arg>
+	</bean>
 </beans>

--- a/spring-session-core/src/main/java/org/springframework/session/MapSessionRepository.java
+++ b/spring-session-core/src/main/java/org/springframework/session/MapSessionRepository.java
@@ -18,16 +18,15 @@ package org.springframework.session;
 
 import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.session.events.SessionDeletedEvent;
 import org.springframework.session.events.SessionExpiredEvent;
 
 /**
  * A {@link SessionRepository} backed by a {@link java.util.Map} and that uses a
- * {@link MapSession}. By default a {@link java.util.concurrent.ConcurrentHashMap} is
- * used, but a custom {@link java.util.Map} can be injected to use distributed maps
- * provided by NoSQL stores like Redis and Hazelcast.
+ * {@link MapSession}. The injected {@link java.util.Map} can be backed by a distributed
+ * NoSQL store like Hazelcast, for instance. Note that the supplied map itself is
+ * responsible for purging the expired sessions.
  *
  * <p>
  * The implementation does NOT support firing {@link SessionDeletedEvent} or
@@ -38,6 +37,7 @@ import org.springframework.session.events.SessionExpiredEvent;
  * @since 1.0
  */
 public class MapSessionRepository implements SessionRepository<MapSession> {
+
 	/**
 	 * If non-null, this value is used to override
 	 * {@link Session#setMaxInactiveInterval(Duration)}.
@@ -45,13 +45,6 @@ public class MapSessionRepository implements SessionRepository<MapSession> {
 	private Integer defaultMaxInactiveInterval;
 
 	private final Map<String, Session> sessions;
-
-	/**
-	 * Creates an instance backed by a {@link java.util.concurrent.ConcurrentHashMap}.
-	 */
-	public MapSessionRepository() {
-		this(new ConcurrentHashMap<>());
-	}
 
 	/**
 	 * Creates a new instance backed by the provided {@link java.util.Map}. This allows
@@ -108,4 +101,5 @@ public class MapSessionRepository implements SessionRepository<MapSession> {
 		}
 		return result;
 	}
+
 }

--- a/spring-session-core/src/test/java/org/springframework/session/MapSessionRepositoryTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/MapSessionRepositoryTests.java
@@ -19,20 +19,25 @@ package org.springframework.session;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests for {@link MapSessionRepository}.
+ */
 public class MapSessionRepositoryTests {
-	MapSessionRepository repository;
 
-	MapSession session;
+	private MapSessionRepository repository;
+
+	private MapSession session;
 
 	@Before
 	public void setup() {
-		this.repository = new MapSessionRepository();
+		this.repository = new MapSessionRepository(new ConcurrentHashMap<>());
 		this.session = new MapSession();
 	}
 
@@ -94,4 +99,5 @@ public class MapSessionRepositoryTests {
 		assertThat(this.repository.findById(originalId)).isNull();
 		assertThat(this.repository.findById(createSession.getId())).isNotNull();
 	}
+
 }

--- a/spring-session-core/src/test/java/org/springframework/session/config/annotation/web/http/EnableSpringHttpSessionCustomCookieSerializerTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/config/annotation/web/http/EnableSpringHttpSessionCustomCookieSerializerTests.java
@@ -18,6 +18,7 @@ package org.springframework.session.config.annotation.web.http;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
@@ -50,25 +51,29 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 /**
- * @author Rob Winch
+ * Tests for {@link SpringHttpSessionConfiguration} using a custom
+ * {@link CookieSerializer}.
  *
+ * @author Rob Winch
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 @WebAppConfiguration
 public class EnableSpringHttpSessionCustomCookieSerializerTests {
-	@Autowired
-	MockHttpServletRequest request;
-	@Autowired
-	MockHttpServletResponse response;
-
-	MockFilterChain chain;
 
 	@Autowired
-	SessionRepositoryFilter<? extends Session> sessionRepositoryFilter;
+	private MockHttpServletRequest request;
 
 	@Autowired
-	CookieSerializer cookieSerializer;
+	private MockHttpServletResponse response;
+
+	private MockFilterChain chain;
+
+	@Autowired
+	private SessionRepositoryFilter<? extends Session> sessionRepositoryFilter;
+
+	@Autowired
+	private CookieSerializer cookieSerializer;
 
 	@Before
 	public void setup() {
@@ -109,14 +114,17 @@ public class EnableSpringHttpSessionCustomCookieSerializerTests {
 	@EnableSpringHttpSession
 	@Configuration
 	static class Config {
+
 		@Bean
 		public MapSessionRepository mapSessionRepository() {
-			return new MapSessionRepository();
+			return new MapSessionRepository(new ConcurrentHashMap<>());
 		}
 
 		@Bean
 		public CookieSerializer cookieSerializer() {
 			return mock(CookieSerializer.class);
 		}
+
 	}
+
 }

--- a/spring-session-core/src/test/java/org/springframework/session/config/annotation/web/http/EnableSpringHttpSessionCustomMultiHttpSessionStrategyTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/config/annotation/web/http/EnableSpringHttpSessionCustomMultiHttpSessionStrategyTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.session.config.annotation.web.http;
 
+import java.util.concurrent.ConcurrentHashMap;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -43,25 +45,29 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 /**
- * @author Rob Winch
+ * Tests for {@link SpringHttpSessionConfiguration} using a custom
+ * {@link MultiHttpSessionStrategy}.
  *
+ * @author Rob Winch
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 @WebAppConfiguration
 public class EnableSpringHttpSessionCustomMultiHttpSessionStrategyTests {
-	@Autowired
-	MockHttpServletRequest request;
-	@Autowired
-	MockHttpServletResponse response;
-
-	MockFilterChain chain;
 
 	@Autowired
-	SessionRepositoryFilter<? extends Session> sessionRepositoryFilter;
+	private MockHttpServletRequest request;
 
 	@Autowired
-	MultiHttpSessionStrategy strategy;
+	private MockHttpServletResponse response;
+
+	private MockFilterChain chain;
+
+	@Autowired
+	private SessionRepositoryFilter<? extends Session> sessionRepositoryFilter;
+
+	@Autowired
+	private MultiHttpSessionStrategy strategy;
 
 	@Before
 	public void setup() {
@@ -86,14 +92,17 @@ public class EnableSpringHttpSessionCustomMultiHttpSessionStrategyTests {
 	@EnableSpringHttpSession
 	@Configuration
 	static class Config {
+
 		@Bean
 		public MapSessionRepository mapSessionRepository() {
-			return new MapSessionRepository();
+			return new MapSessionRepository(new ConcurrentHashMap<>());
 		}
 
 		@Bean
 		public MultiHttpSessionStrategy strategy() {
 			return mock(MultiHttpSessionStrategy.class);
 		}
+
 	}
+
 }

--- a/spring-session-core/src/test/java/org/springframework/session/config/annotation/web/http/SpringHttpSessionConfigurationTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/config/annotation/web/http/SpringHttpSessionConfigurationTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.session.config.annotation.web.http;
 
+import java.util.concurrent.ConcurrentHashMap;
+
 import javax.servlet.ServletContext;
 
 import org.junit.After;
@@ -134,7 +136,7 @@ public class SpringHttpSessionConfigurationTests {
 
 		@Bean
 		public MapSessionRepository sessionRepository() {
-			return new MapSessionRepository();
+			return new MapSessionRepository(new ConcurrentHashMap<>());
 		}
 
 	}

--- a/spring-session-core/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import javax.servlet.FilterChain;
@@ -68,9 +69,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
+/**
+ * Tests for {@link SessionRepositoryFilter}.
+ */
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("deprecation")
 public class SessionRepositoryFilterTests {
+
 	@Mock
 	private HttpSessionStrategy strategy;
 
@@ -420,7 +425,7 @@ public class SessionRepositoryFilterTests {
 
 	@Test
 	public void doFilterSetsCookieIfChanged() throws Exception {
-		this.sessionRepository = new MapSessionRepository() {
+		this.sessionRepository = new MapSessionRepository(new ConcurrentHashMap<>()) {
 			@Override
 			public MapSession findById(String id) {
 				return createSession();
@@ -1256,7 +1261,8 @@ public class SessionRepositoryFilterTests {
 	@SuppressWarnings("unchecked")
 	public void doFilterRequestSessionNoRequestSessionNoSessionRepositoryInteractions()
 			throws Exception {
-		SessionRepository<MapSession> sessionRepository = spy(new MapSessionRepository());
+		SessionRepository<MapSession> sessionRepository = spy(
+				new MapSessionRepository(new ConcurrentHashMap<>()));
 
 		this.filter = new SessionRepositoryFilter<>(sessionRepository);
 
@@ -1283,7 +1289,8 @@ public class SessionRepositoryFilterTests {
 
 	@Test
 	public void doFilterLazySessionCreation() throws Exception {
-		SessionRepository<MapSession> sessionRepository = spy(new MapSessionRepository());
+		SessionRepository<MapSession> sessionRepository = spy(
+				new MapSessionRepository(new ConcurrentHashMap<>()));
 
 		this.filter = new SessionRepositoryFilter<>(sessionRepository);
 
@@ -1480,4 +1487,5 @@ public class SessionRepositoryFilterTests {
 			return SessionRepositoryFilter.DEFAULT_ORDER;
 		}
 	}
+
 }


### PR DESCRIPTION
This PR removes the default `MapSessionRepository` so that the users are required to explicitly supply the `Map` used to store the sessions.

The current default does not handle purging of expired sessions which is an important aspect of the `SessionRepository` implementation.