### PR TITLE
Harmonize `ReactorSessionRepository` API

### DIFF
--- a/spring-session-core/src/main/java/org/springframework/session/MapReactorSessionRepository.java
+++ b/spring-session-core/src/main/java/org/springframework/session/MapReactorSessionRepository.java
@@ -86,11 +86,11 @@ public class MapReactorSessionRepository implements ReactorSessionRepository<Map
 		return Mono.defer(() -> Mono.justOrEmpty(this.sessions.get(id))
 				.filter(session -> !session.isExpired())
 				.map(MapSession::new)
-				.switchIfEmpty(delete(id).then(Mono.empty())));
+				.switchIfEmpty(deleteById(id).then(Mono.empty())));
 		// @formatter:on
 	}
 
-	public Mono<Void> delete(String id) {
+	public Mono<Void> deleteById(String id) {
 		return Mono.fromRunnable(() -> this.sessions.remove(id));
 	}
 

--- a/spring-session-core/src/main/java/org/springframework/session/ReactorSessionRepository.java
+++ b/spring-session-core/src/main/java/org/springframework/session/ReactorSessionRepository.java
@@ -73,5 +73,6 @@ public interface ReactorSessionRepository<S extends Session> {
 	 * @param id the {@link Session#getId()} to delete
 	 * @return indicator of operation completion
 	 */
-	Mono<Void> delete(String id);
+	Mono<Void> deleteById(String id);
+
 }

--- a/spring-session-core/src/main/java/org/springframework/session/web/server/session/SpringSessionWebSessionStore.java
+++ b/spring-session-core/src/main/java/org/springframework/session/web/server/session/SpringSessionWebSessionStore.java
@@ -97,7 +97,7 @@ public class SpringSessionWebSessionStore<S extends Session> implements WebSessi
 
 	@Override
 	public Mono<Void> removeSession(String sessionId) {
-		return this.sessions.delete(sessionId);
+		return this.sessions.deleteById(sessionId);
 	}
 
 	private SpringSessionWebSession createSession(S session) {

--- a/spring-session-core/src/test/java/org/springframework/session/web/server/session/SpringSessionWebSessionStoreTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/web/server/session/SpringSessionWebSessionStoreTests.java
@@ -273,11 +273,11 @@ public class SpringSessionWebSessionStoreTests<S extends Session> {
 	@Test
 	public void removeSessionWhenInvokedThenSessionSaved() {
 		String sessionId = "session-id";
-		given(this.sessionRepository.delete(sessionId)).willReturn(Mono.empty());
+		given(this.sessionRepository.deleteById(sessionId)).willReturn(Mono.empty());
 
 		this.webSessionStore.removeSession(sessionId).block();
 
-		verify(this.sessionRepository).delete(sessionId);
+		verify(this.sessionRepository).deleteById(sessionId);
 	}
 
 	@Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
This PR renames the `ReactorSessionRepository#delete` to `deleteById` in order to make API consistent with `SessionRepository`.
