### PR TITLE
Improve Redis configuration

### DIFF
--- a/samples/boot/redis-json/src/integration-test/java/sample/RedisSerializerTest.java
+++ b/samples/boot/redis-json/src/integration-test/java/sample/RedisSerializerTest.java
@@ -21,13 +21,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.GenericContainer;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.session.data.redis.config.annotation.web.http.SpringSessionRedisOperations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -48,7 +48,7 @@ public class RedisSerializerTest {
 	public static GenericContainer redisContainer = new GenericContainer(DOCKER_IMAGE)
 			.withExposedPorts(6379);
 
-	@Autowired
+	@SpringSessionRedisOperations
 	private RedisTemplate<Object, Object> sessionRedisTemplate;
 
 	@Test

--- a/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/RedisOperationsSessionRepositoryITests.java
+++ b/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/RedisOperationsSessionRepositoryITests.java
@@ -38,6 +38,7 @@ import org.springframework.session.Session;
 import org.springframework.session.data.SessionEventRegistry;
 import org.springframework.session.data.redis.RedisOperationsSessionRepository.RedisSession;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+import org.springframework.session.data.redis.config.annotation.web.http.SpringSessionRedisOperations;
 import org.springframework.session.events.SessionCreatedEvent;
 import org.springframework.session.events.SessionDestroyedEvent;
 import org.springframework.test.context.ContextConfiguration;
@@ -61,7 +62,7 @@ public class RedisOperationsSessionRepositoryITests extends AbstractRedisITests 
 	@Autowired
 	private SessionEventRegistry registry;
 
-	@Autowired
+	@SpringSessionRedisOperations
 	private RedisOperations<Object, Object> redis;
 
 	private SecurityContext context;

--- a/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/taskexecutor/RedisListenerContainerTaskExecutorITests.java
+++ b/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/taskexecutor/RedisListenerContainerTaskExecutorITests.java
@@ -32,6 +32,7 @@ import org.springframework.data.redis.core.BoundSetOperations;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.session.data.redis.AbstractRedisITests;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+import org.springframework.session.data.redis.config.annotation.web.http.SpringSessionRedisOperations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -49,7 +50,7 @@ public class RedisListenerContainerTaskExecutorITests extends AbstractRedisITest
 	@Autowired
 	private SessionTaskExecutor executor;
 
-	@Autowired
+	@SpringSessionRedisOperations
 	private RedisOperations<Object, Object> redis;
 
 	@Test

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
@@ -385,6 +385,10 @@ public class RedisOperationsSessionRepository implements
 		this.redisFlushMode = redisFlushMode;
 	}
 
+	public RedisOperations<Object, Object> getSessionRedisOperations() {
+		return this.sessionRedisOperations;
+	}
+
 	public void save(RedisSession session) {
 		session.saveDelta();
 		if (session.isNew()) {

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/SpringSessionRedisConnectionFactory.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/SpringSessionRedisConnectionFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.data.redis.config.annotation.web.http;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.session.data.redis.RedisOperationsSessionRepository;
+
+/**
+ * Qualifier annotation for a {@link RedisConnectionFactory} to be injected in
+ * {@link RedisOperationsSessionRepository}.
+ *
+ * @author Vedran Pavic
+ * @since 2.0.0
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE,
+		ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier
+public @interface SpringSessionRedisConnectionFactory {
+
+}

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/SpringSessionRedisOperations.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/SpringSessionRedisOperations.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.data.redis.config.annotation.web.http;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.session.data.redis.RedisOperationsSessionRepository;
+
+/**
+ * Annotation used to inject the {@link RedisOperations} instance used by Spring Session's
+ * {@link RedisOperationsSessionRepository}.
+ *
+ * @author Vedran Pavic
+ * @since 2.0.0
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER,
+		ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Value("#{sessionRepository.sessionRedisOperations}")
+public @interface SpringSessionRedisOperations {
+
+}

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationOverrideDefaultSerializerTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationOverrideDefaultSerializerTests.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.mock;
 @WebAppConfiguration
 public class RedisHttpSessionConfigurationOverrideDefaultSerializerTests {
 
-	@Autowired
+	@SpringSessionRedisOperations
 	RedisTemplate<Object, Object> template;
 
 	@Autowired

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/gh109/Gh109Tests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/gh109/Gh109Tests.java
@@ -63,7 +63,6 @@ public class Gh109Tests {
 		 * override sessionRepository construction to set the custom session-timeout
 		 */
 		@Bean
-		@Override
 		public RedisOperationsSessionRepository sessionRepository(
 				RedisOperations<Object, Object> sessionRedisTemplate,
 				ApplicationEventPublisher applicationEventPublisher) {


### PR DESCRIPTION
This PR improves Redis configuration by introducing `@SpringSessionRedisConnectionFactory` qualifier for explicitly declaring a `RedisConnectionFactory` to be used by Spring Session. This is in particular useful in scenarios with multiple `RedisConnectionFactory` beans present in the application context.

Redis configuration is simplified and no longer registers a Spring Session specific `RedisOperations<Object,Object>` bean with the application context.

Users are however able to obtain `RedisOperations<Object,Object>` instance used by Spring Session using newly introduced `@SpringSessionRedisOperations` annotation.

This resolves #864.