### PR TITLE
Refactor Hazelcast configuration

### DIFF
--- a/docs/src/test/java/docs/IndexDocTests.java
+++ b/docs/src/test/java/docs/IndexDocTests.java
@@ -22,7 +22,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
 import org.junit.Test;
 
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -155,11 +154,8 @@ public class IndexDocTests {
 
 		HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(config);
 
-		IMap<String, MapSession> sessions = hazelcastInstance
-				.getMap("spring:session:sessions");
-
 		HazelcastSessionRepository repository =
-				new HazelcastSessionRepository(sessions);
+				new HazelcastSessionRepository(hazelcastInstance);
 		// end::new-hazelcastsessionrepository[]
 	}
 

--- a/docs/src/test/java/docs/http/HazelcastHttpSessionConfig.java
+++ b/docs/src/test/java/docs/http/HazelcastHttpSessionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public class HazelcastHttpSessionConfig {
 
 		Config config = new Config();
 
-		config.getMapConfig("spring:session:sessions") // <2>
+		config.getMapConfig(HazelcastSessionRepository.DEFAULT_SESSION_MAP_NAME) // <2>
 				.addMapAttributeConfig(attributeConfig)
 				.addMapIndexConfig(new MapIndexConfig(
 						HazelcastSessionRepository.PRINCIPAL_NAME_ATTRIBUTE, false));

--- a/samples/javaconfig/hazelcast/src/main/java/sample/SessionConfig.java
+++ b/samples/javaconfig/hazelcast/src/main/java/sample/SessionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ public class SessionConfig {
 				.setName(HazelcastSessionRepository.PRINCIPAL_NAME_ATTRIBUTE)
 				.setExtractor(PrincipalNameExtractor.class.getName());
 
-		config.getMapConfig("spring:session:sessions")
+		config.getMapConfig(HazelcastSessionRepository.DEFAULT_SESSION_MAP_NAME)
 				.addMapAttributeConfig(attributeConfig)
 				.addMapIndexConfig(new MapIndexConfig(
 						HazelcastSessionRepository.PRINCIPAL_NAME_ATTRIBUTE, false));

--- a/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/AbstractHazelcastRepositoryITests.java
+++ b/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/AbstractHazelcastRepositoryITests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,8 +45,8 @@ public abstract class AbstractHazelcastRepositoryITests {
 		HazelcastSession sessionToSave = this.repository.createSession();
 		String sessionId = sessionToSave.getId();
 
-		IMap<String, MapSession> hazelcastMap = this.hazelcast.getMap(
-				"spring:session:sessions");
+		IMap<String, MapSession> hazelcastMap = this.hazelcast
+				.getMap(HazelcastSessionRepository.DEFAULT_SESSION_MAP_NAME);
 
 		assertThat(hazelcastMap.size()).isEqualTo(0);
 
@@ -80,9 +80,11 @@ public abstract class AbstractHazelcastRepositoryITests {
 
 		assertThat(this.repository.findById(originalFindById)).isNull();
 
-		HazelcastSession findByChangeSessionId = this.repository.findById(changeSessionId);
+		HazelcastSession findByChangeSessionId = this.repository
+				.findById(changeSessionId);
 
-		assertThat(findByChangeSessionId.<String>getAttribute(attrName)).isEqualTo(attrValue);
+		assertThat(findByChangeSessionId.<String>getAttribute(attrName))
+				.isEqualTo(attrValue);
 
 		this.repository.deleteById(changeSessionId);
 	}
@@ -126,9 +128,11 @@ public abstract class AbstractHazelcastRepositoryITests {
 
 		assertThat(this.repository.findById(originalFindById)).isNull();
 
-		HazelcastSession findByChangeSessionId = this.repository.findById(changeSessionId);
+		HazelcastSession findByChangeSessionId = this.repository
+				.findById(changeSessionId);
 
-		assertThat(findByChangeSessionId.<String>getAttribute(attrName)).isEqualTo(attrValue);
+		assertThat(findByChangeSessionId.<String>getAttribute(attrName))
+				.isEqualTo(attrValue);
 
 		this.repository.deleteById(changeSessionId);
 	}

--- a/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/HazelcastITestUtils.java
+++ b/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/HazelcastITestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public final class HazelcastITestUtils {
 		config.getNetworkConfig()
 				.setPort(port);
 
-		config.getMapConfig("spring:session:sessions")
+		config.getMapConfig(HazelcastSessionRepository.DEFAULT_SESSION_MAP_NAME)
 				.addMapAttributeConfig(attributeConfig)
 				.addMapIndexConfig(new MapIndexConfig(
 						HazelcastSessionRepository.PRINCIPAL_NAME_ATTRIBUTE, false));

--- a/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/EnableHazelcastHttpSession.java
+++ b/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/EnableHazelcastHttpSession.java
@@ -31,6 +31,7 @@ import org.springframework.session.Session;
 import org.springframework.session.SessionRepository;
 import org.springframework.session.config.annotation.web.http.EnableSpringHttpSession;
 import org.springframework.session.hazelcast.HazelcastFlushMode;
+import org.springframework.session.hazelcast.HazelcastSessionRepository;
 import org.springframework.session.web.http.SessionRepositoryFilter;
 
 /**
@@ -58,6 +59,7 @@ import org.springframework.session.web.http.SessionRepositoryFilter;
  *
  * @author Tommy Ludwig
  * @author Aleksandar Stojsavljevic
+ * @author Vedran Pavic
  * @since 1.1
  * @see EnableSpringHttpSession
  */
@@ -78,10 +80,10 @@ public @interface EnableHazelcastHttpSession {
 	/**
 	 * This is the name of the Map that will be used in Hazelcast to store the session
 	 * data. Default is
-	 * {@link HazelcastHttpSessionConfiguration#DEFAULT_SESSION_MAP_NAME}.
+	 * {@link HazelcastSessionRepository#DEFAULT_SESSION_MAP_NAME}.
 	 * @return the name of the Map to store the sessions in Hazelcast
 	 */
-	String sessionMapName() default HazelcastHttpSessionConfiguration.DEFAULT_SESSION_MAP_NAME;
+	String sessionMapName() default HazelcastSessionRepository.DEFAULT_SESSION_MAP_NAME;
 
 	/**
 	 * Flush mode for the Hazelcast sessions. The default is {@code ON_SAVE} which only

--- a/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfiguration.java
+++ b/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfiguration.java
@@ -19,7 +19,6 @@ package org.springframework.session.hazelcast.config.annotation.web.http;
 import java.util.Map;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,11 +50,9 @@ import org.springframework.util.StringUtils;
 public class HazelcastHttpSessionConfiguration extends SpringHttpSessionConfiguration
 		implements ImportAware {
 
-	static final String DEFAULT_SESSION_MAP_NAME = "spring:session:sessions";
+	private Integer maxInactiveIntervalInSeconds = MapSession.DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS;
 
-	private Integer maxInactiveIntervalInSeconds;
-
-	private String sessionMapName = DEFAULT_SESSION_MAP_NAME;
+	private String sessionMapName = HazelcastSessionRepository.DEFAULT_SESSION_MAP_NAME;
 
 	private HazelcastFlushMode hazelcastFlushMode = HazelcastFlushMode.ON_SAVE;
 
@@ -65,11 +62,12 @@ public class HazelcastHttpSessionConfiguration extends SpringHttpSessionConfigur
 
 	@Bean
 	public HazelcastSessionRepository sessionRepository() {
-		IMap<String, MapSession> sessions = this.hazelcastInstance
-				.getMap(this.sessionMapName);
 		HazelcastSessionRepository sessionRepository = new HazelcastSessionRepository(
-				sessions);
+				this.hazelcastInstance);
 		sessionRepository.setApplicationEventPublisher(this.applicationEventPublisher);
+		if (StringUtils.hasText(this.sessionMapName)) {
+			sessionRepository.setSessionMapName(this.sessionMapName);
+		}
 		sessionRepository
 				.setDefaultMaxInactiveInterval(this.maxInactiveIntervalInSeconds);
 		sessionRepository.setHazelcastFlushMode(this.hazelcastFlushMode);


### PR DESCRIPTION
This PR changes `HazelcastSessionRepository` constructor to take `HazelcastInstance` instead of `IMap` - this change ensures that if we at any point in the future want to introduce a new feature or an improvement to `HazelcastSessionRepository` that would require use of other Hazelcast's distributed structures or advanced features we can do so without breaking backwards compatibility. The `2.0` gives us a chance to make such change now.