### PR TITLE
Refactor Redis configuration

### DIFF
--- a/docs/src/test/java/docs/IndexDocTests.java
+++ b/docs/src/test/java/docs/IndexDocTests.java
@@ -25,7 +25,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import org.junit.Test;
 
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.mock.web.MockServletContext;
@@ -112,9 +112,12 @@ public class IndexDocTests {
 	@SuppressWarnings("unused")
 	public void newRedisOperationsSessionRepository() {
 		// tag::new-redisoperationssessionrepository[]
-		LettuceConnectionFactory factory = new LettuceConnectionFactory();
-		SessionRepository<? extends Session> repository = new RedisOperationsSessionRepository(
-				factory);
+		RedisTemplate<Object, Object> redisTemplate = new RedisTemplate<>();
+
+		// ... configure redisTemplate ...
+
+		SessionRepository<? extends Session> repository =
+				new RedisOperationsSessionRepository(redisTemplate);
 		// end::new-redisoperationssessionrepository[]
 	}
 

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
@@ -30,13 +30,10 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.BoundHashOperations;
 import org.springframework.data.redis.core.RedisOperations;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.session.FindByIndexNameSessionRepository;
@@ -63,9 +60,12 @@ import org.springframework.util.Assert;
  * A typical example of how to create a new instance can be seen below:
  *
  * <pre>
- * LettuceConnectionFactory factory = new LettuceConnectionFactory();
+ * RedisTemplate&lt;Object, Object&gt; redisTemplate = new RedisTemplate();
  *
- * RedisOperationsSessionRepository redisSessionRepository = new RedisOperationsSessionRepository(factory);
+ * // ... configure redisTemplate ...
+ *
+ * RedisOperationsSessionRepository redisSessionRepository =
+ *         new RedisOperationsSessionRepository(redisTemplate);
  * </pre>
  *
  * <p>
@@ -312,17 +312,6 @@ public class RedisOperationsSessionRepository implements
 	private RedisSerializer<Object> defaultSerializer = new JdkSerializationRedisSerializer();
 
 	private RedisFlushMode redisFlushMode = RedisFlushMode.ON_SAVE;
-
-	/**
-	 * Allows creating an instance and uses a default {@link RedisOperations} for both
-	 * managing the session and the expirations.
-	 *
-	 * @param redisConnectionFactory the {@link RedisConnectionFactory} to use.
-	 */
-	public RedisOperationsSessionRepository(
-			RedisConnectionFactory redisConnectionFactory) {
-		this(createDefaultTemplate(redisConnectionFactory));
-	}
 
 	/**
 	 * Creates a new instance. For an example, refer to the class level javadoc.
@@ -653,17 +642,6 @@ public class RedisOperationsSessionRepository implements
 	 */
 	static String getSessionAttrNameKey(String attributeName) {
 		return SESSION_ATTR_PREFIX + attributeName;
-	}
-
-	private static RedisTemplate<Object, Object> createDefaultTemplate(
-			RedisConnectionFactory connectionFactory) {
-		Assert.notNull(connectionFactory, "connectionFactory cannot be null");
-		RedisTemplate<Object, Object> template = new RedisTemplate<>();
-		template.setKeySerializer(new StringRedisSerializer());
-		template.setHashKeySerializer(new StringRedisSerializer());
-		template.setConnectionFactory(connectionFactory);
-		template.afterPropertiesSet();
-		return template;
 	}
 
 	/**

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisOperationsSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisOperationsSessionRepositoryTests.java
@@ -111,24 +111,8 @@ public class RedisOperationsSessionRepositoryTests {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void constructorNullConnectionFactory() {
-		new RedisOperationsSessionRepository((RedisConnectionFactory) null);
-	}
-
-	@Test(expected = IllegalArgumentException.class)
 	public void setApplicationEventPublisherNull() {
 		this.redisRepository.setApplicationEventPublisher(null);
-	}
-
-	// gh-61
-	@Test
-	public void constructorConnectionFactory() {
-		this.redisRepository = new RedisOperationsSessionRepository(this.factory);
-		RedisSession session = this.redisRepository.createSession();
-
-		given(this.factory.getConnection()).willReturn(this.connection);
-
-		this.redisRepository.save(session);
 	}
 
 	@Test


### PR DESCRIPTION
Both and `RedisHttpSessionConfiguration` and `RedisOperationsSessionRepository` currently contain helper methods for creating `RedisTemplate` which presents an unnecessary code duplication - we should consider making this solely a responsibility of `RedisHttpSessionConfiguration`.