### PR TITLE
Refactor JDBC configuration

### DIFF
--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import javax.sql.DataSource;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -224,17 +222,6 @@ public class JdbcOperationsSessionRepository implements
 	private ConversionService conversionService;
 
 	private LobHandler lobHandler = new DefaultLobHandler();
-
-	/**
-	 * Create a new {@link JdbcOperationsSessionRepository} instance which uses the
-	 * default {@link JdbcOperations} to manage sessions.
-	 * @param dataSource the {@link DataSource} to use
-	 * @param transactionManager the {@link PlatformTransactionManager} to use
-	 */
-	public JdbcOperationsSessionRepository(DataSource dataSource,
-			PlatformTransactionManager transactionManager) {
-		this(createDefaultJdbcTemplate(dataSource), transactionManager);
-	}
 
 	/**
 	 * Create a new {@link JdbcOperationsSessionRepository} instance which uses the
@@ -543,12 +530,6 @@ public class JdbcOperationsSessionRepository implements
 		if (logger.isDebugEnabled()) {
 			logger.debug("Cleaned up " + deletedCount + " expired sessions");
 		}
-	}
-
-	private static JdbcTemplate createDefaultJdbcTemplate(DataSource dataSource) {
-		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-		jdbcTemplate.afterPropertiesSet();
-		return jdbcTemplate;
 	}
 
 	private static TransactionTemplate createTransactionTemplate(

--- a/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryTests.java
+++ b/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryTests.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.session.jdbc;
 
 import java.time.Duration;
@@ -21,8 +22,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import javax.sql.DataSource;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -43,7 +42,6 @@ import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.session.MapSession;
 import org.springframework.session.Session;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 
@@ -76,9 +74,6 @@ public class JdbcOperationsSessionRepositoryTests {
 	public ExpectedException thrown = ExpectedException.none();
 
 	@Mock
-	private DataSource dataSource;
-
-	@Mock
 	private JdbcOperations jdbcOperations;
 
 	@Mock
@@ -90,23 +85,6 @@ public class JdbcOperationsSessionRepositoryTests {
 	public void setUp() {
 		this.repository = new JdbcOperationsSessionRepository(
 				this.jdbcOperations, this.transactionManager);
-	}
-
-	@Test
-	public void constructorDataSource() {
-		JdbcOperationsSessionRepository repository = new JdbcOperationsSessionRepository(
-				this.dataSource, this.transactionManager);
-
-		assertThat(ReflectionTestUtils.getField(repository, "jdbcOperations"))
-				.isNotNull();
-	}
-
-	@Test
-	public void constructorNullDataSource() {
-		this.thrown.expect(IllegalArgumentException.class);
-		this.thrown.expectMessage("Property 'dataSource' is required");
-
-		new JdbcOperationsSessionRepository((DataSource) null, this.transactionManager);
 	}
 
 	@Test


### PR DESCRIPTION
We should consider making creation of `JdbcTemplate` used by `JdbcOperationsSessionRepository` a responsibility of `JdbcHttpSessionConfiguration` rather than `JdbcOperationsSessionRepository` itself.