### PR TITLE
Initialize SessionRepository lazy to avoid circular dependcies

### DIFF
--- a/spring-session-core/src/main/java/org/springframework/session/web/socket/config/annotation/AbstractSessionWebSocketMessageBrokerConfigurer.java
+++ b/spring-session-core/src/main/java/org/springframework/session/web/socket/config/annotation/AbstractSessionWebSocketMessageBrokerConfigurer.java
@@ -19,6 +19,7 @@ package org.springframework.session.web.socket.config.annotation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.session.Session;
 import org.springframework.session.SessionRepository;
@@ -78,6 +79,7 @@ public abstract class AbstractSessionWebSocketMessageBrokerConfigurer<S extends 
 		extends AbstractWebSocketMessageBrokerConfigurer {
 
 	@Autowired
+	@Lazy
 	@SuppressWarnings("rawtypes")
 	private SessionRepository sessionRepository;
 


### PR DESCRIPTION
Hi,

I got a circular dependency issue using the `AbstractSessionWebSocketMessageBrokerConfigurer` together with Spring-Session-jdbc:

```
┌─────┐
|  entityManagerFactory
↑     ↓
|  webSocketBrokerConfig (field private org.springframework.session.SessionRepository org.springframework.session.web.socket.config.annotation.AbstractSessionWebSocketMessageBrokerConfigurer.sessionRepository)
↑     ↓
|  sessionRepository defined in class path resource [org/springframework/boot/autoconfigure/session/JdbcSessionConfiguration$SpringBootJdbcHttpSessionConfiguration.class]
↑     ↓
|  transactionManager defined in class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfiguration.class]
↑     ↓
|  webSocketRegistryListener
└─────┘
```

Initializing the `SessionRepository` lazy fixed the problem for me.