### PR TITLE
Split read-only operations through their own DataSource

### DIFF
--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/SpringSessionDataSourceReadOnly.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/SpringSessionDataSourceReadOnly.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.jdbc.config.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.session.jdbc.JdbcOperationsSessionRepository;
+
+/**
+ * Qualifier annotation for a read-only {@link DataSource} to be injected in
+ * {@link JdbcOperationsSessionRepository}.
+ *
+ * @author Louis van Niekerk
+ * @since 2.0.0
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE,
+		ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier
+public @interface SpringSessionDataSourceReadOnly {
+
+}

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/SpringSessionPlatformTransactionManager.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/SpringSessionPlatformTransactionManager.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.jdbc.config.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.session.jdbc.JdbcOperationsSessionRepository;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Qualifier annotation for a {@link PlatformTransactionManager} to be injected in
+ * {@link JdbcOperationsSessionRepository}.
+ *
+ * @author Louis van Niekerk
+ * @since 2.0.0
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE,
+		ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier
+public @interface SpringSessionPlatformTransactionManager {
+
+}

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/SpringSessionPlatformTransactionManagerReadOnly.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/SpringSessionPlatformTransactionManagerReadOnly.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.jdbc.config.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.session.jdbc.JdbcOperationsSessionRepository;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Qualifier annotation for a read-only {@link PlatformTransactionManager} to be injected in
+ * {@link JdbcOperationsSessionRepository}.
+ *
+ * @author Louis van Niekerk
+ * @since 2.0.0
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE,
+		ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Qualifier
+public @interface SpringSessionPlatformTransactionManagerReadOnly {
+
+}


### PR DESCRIPTION
If specified (through new annotations), the `SELECT` SQL statements will be going through a specific `DataSource` and `PlatformTransactionManager`. 
If not, the same objects will be used for all queries.

This would release load if the traffic is split between different database nodes for read and write operations.

I only added tests around `JdbcHttpSessionConfiguration` but please let me know if you think that this is a valid pull requests and want me to extend my work.