### PR TITLE
Don't set delta to updated if already set to added

### DIFF
--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
@@ -733,7 +733,12 @@ public class JdbcOperationsSessionRepository implements
 		@Override
 		public void setAttribute(String attributeName, Object attributeValue) {
 			if (attributeValue == null) {
-				this.delta.put(attributeName, DeltaValue.REMOVED);
+				if (this.delta.get(attributeName) == DeltaValue.ADDED) {
+					this.delta.remove(attributeName);
+				}
+				else {
+					this.delta.put(attributeName, DeltaValue.REMOVED);
+				}
 			}
 			else if (this.delta.get(attributeName) != DeltaValue.ADDED && this.delegate.getAttribute(attributeName) != null) {
 				this.delta.put(attributeName, DeltaValue.UPDATED);

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
@@ -735,7 +735,7 @@ public class JdbcOperationsSessionRepository implements
 			if (attributeValue == null) {
 				this.delta.put(attributeName, DeltaValue.REMOVED);
 			}
-			else if (this.delegate.getAttribute(attributeName) != null) {
+			else if (this.delta.get(attributeName) != DeltaValue.ADDED && this.delegate.getAttribute(attributeName) != null) {
 				this.delta.put(attributeName, DeltaValue.UPDATED);
 			}
 			else {

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
@@ -744,7 +744,12 @@ public class JdbcOperationsSessionRepository implements
 				this.delta.put(attributeName, DeltaValue.UPDATED);
 			}
 			else {
-				this.delta.put(attributeName, DeltaValue.ADDED);
+				if (this.delta.get(attributeName) == DeltaValue.REMOVED) {
+					this.delta.put(attributeName, DeltaValue.UPDATED);
+				}
+				else {
+					this.delta.put(attributeName, DeltaValue.ADDED);
+				}
 			}
 			this.delegate.setAttribute(attributeName, attributeValue);
 			if (PRINCIPAL_NAME_INDEX_NAME.equals(attributeName) ||

--- a/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryTests.java
+++ b/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryTests.java
@@ -468,6 +468,25 @@ public class JdbcOperationsSessionRepositoryTests {
 	}
 
 	@Test
+	public void saveUpdatedRemoveThenModifySingleAttribute() {
+		JdbcOperationsSessionRepository.JdbcSession session = this.repository.new JdbcSession("primaryKey",
+				new MapSession());
+		session.setAttribute("testName", "testValue");
+		session.clearChangeFlags();
+		session.removeAttribute("testName");
+		session.setAttribute("testName", "testValueModifed");
+
+		this.repository.save(session);
+
+		assertThat(session.isNew()).isFalse();
+		assertPropagationRequiresNew();
+		verify(this.jdbcOperations, times(1)).update(
+				startsWith("UPDATE SPRING_SESSION_ATTRIBUTES SET"),
+				isA(PreparedStatementSetter.class));
+		verifyZeroInteractions(this.jdbcOperations);
+	}
+
+	@Test
 	public void saveUpdatedLastAccessedTime() {
 		JdbcOperationsSessionRepository.JdbcSession session = this.repository.new JdbcSession("primaryKey",
 				new MapSession());

--- a/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryTests.java
+++ b/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryTests.java
@@ -43,12 +43,14 @@ import org.springframework.transaction.TransactionDefinition;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -445,6 +447,23 @@ public class JdbcOperationsSessionRepositoryTests {
 		verify(this.jdbcOperations, times(1)).batchUpdate(
 				startsWith("DELETE FROM SPRING_SESSION_ATTRIBUTES WHERE"),
 				isA(BatchPreparedStatementSetter.class));
+		verifyZeroInteractions(this.jdbcOperations);
+	}
+
+	@Test
+	public void saveUpdatedAddThenRemoveSingleAttribute() {
+		JdbcOperationsSessionRepository.JdbcSession session = this.repository.new JdbcSession("primaryKey",
+				new MapSession());
+		session.setAttribute("testName", "testValue");
+		session.removeAttribute("testName");
+
+		this.repository.save(session);
+
+		assertThat(session.isNew()).isFalse();
+		assertPropagationRequiresNew();
+		verify(this.jdbcOperations, never()).update(
+				anyString(),
+				isA(PreparedStatementSetter.class));
 		verifyZeroInteractions(this.jdbcOperations);
 	}
 

--- a/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryTests.java
+++ b/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryTests.java
@@ -339,6 +339,23 @@ public class JdbcOperationsSessionRepositoryTests {
 	}
 
 	@Test
+	public void saveUpdatedAddSingleAttributeSetTwice() {
+		JdbcOperationsSessionRepository.JdbcSession session = this.repository.new JdbcSession("primaryKey",
+				new MapSession());
+		session.setAttribute("testName", "testValue");
+		session.setAttribute("testName", "testValue");
+
+		this.repository.save(session);
+
+		assertThat(session.isNew()).isFalse();
+		assertPropagationRequiresNew();
+		verify(this.jdbcOperations, times(1)).update(
+				startsWith("INSERT INTO SPRING_SESSION_ATTRIBUTES("),
+				isA(PreparedStatementSetter.class));
+		verifyZeroInteractions(this.jdbcOperations);
+	}
+
+	@Test
 	public void saveUpdatedAddMultipleAttributes() {
 		JdbcOperationsSessionRepository.JdbcSession session = this.repository.new JdbcSession("primaryKey",
 				new MapSession());

--- a/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryTests.java
+++ b/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcOperationsSessionRepositoryTests.java
@@ -468,6 +468,25 @@ public class JdbcOperationsSessionRepositoryTests {
 	}
 
 	@Test
+	public void saveUpdatedModifyThenRemoveSingleAttribute() {
+		JdbcOperationsSessionRepository.JdbcSession session = this.repository.new JdbcSession("primaryKey",
+				new MapSession());
+		session.setAttribute("testName", "testValue");
+		session.clearChangeFlags();
+		session.setAttribute("testName", "testValueModifed");
+		session.removeAttribute("testName");
+
+		this.repository.save(session);
+
+		assertThat(session.isNew()).isFalse();
+		assertPropagationRequiresNew();
+		verify(this.jdbcOperations, times(1)).update(
+				startsWith("DELETE FROM SPRING_SESSION_ATTRIBUTES WHERE"),
+				isA(PreparedStatementSetter.class));
+		verifyZeroInteractions(this.jdbcOperations);
+	}
+
+	@Test
 	public void saveUpdatedRemoveThenModifySingleAttribute() {
 		JdbcOperationsSessionRepository.JdbcSession session = this.repository.new JdbcSession("primaryKey",
 				new MapSession());


### PR DESCRIPTION
When using JDBC, setting a new attribute multiple times results in an SQL UPDATE not an INSERT. Because there is no row to update, the session attribute is not actually saved to the table.

For example, in a request handler (a Spring MVC controller, servlet, filter, etc):
```
Assert.isTrue(request.getSession().getAttribute("test")==null);
request.getSession().setAttribute("test", "someValue");
request.getSession().setAttribute("test", "someValue");
```

I would expect a row to be added to the `SPRING_SESSION_ATTRIBUTES` table with the `ATTRIBUTE_NAME` of "test" and the `ATTRIBUTE_VALUE` of "someValue"

However, what actually happens is that an UPDATE statement is executed resulted in no row being added to `SPRING_SESSION_ATTRIBUTES`.

The problem appears to be at https://github.com/spring-projects/spring-session/blob/2.0.3.RELEASE/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java#L738 - I believe the line should be:
```
else if (this.delta.get(attributeName) != DeltaValue.ADDED && this.delegate.getAttribute(attributeName) != null) {
```