### PR TITLE
Upgrade samples to Spring Boot 2.0.2.RELEASE

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-springBootVersion=2.0.1.RELEASE
+springBootVersion=2.0.2.RELEASE
 version=2.0.4.BUILD-SNAPSHOT


### PR DESCRIPTION
The latest version of Spring Boot is 2.0.2: https://spring.io/blog/2018/05/09/spring-boot-2-0-2