### PR TITLE
Provide a way to disable/control cleanup cron

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -837,7 +837,6 @@ Short of using distributed locks (which would kill our performance) there is no 
 By simply accessing the key, we ensure that the key is only removed if the TTL on that key is expired.
 ====
 
-
 [[api-redisoperationssessionrepository-sessiondestroyedevent]]
 ==== SessionDeletedEvent and SessionExpiredEvent
 
@@ -875,6 +874,18 @@ XML Configuration can use the following:
 ----
 include::{docs-test-resources-dir}docs/HttpSessionConfigurationNoOpConfigureRedisActionXmlTests-context.xml[tags=configure-redis-action]
 ----
+
+[[api-redisoperationssessionrepository-disablebackgroundtask]]
+==== Disable background task
+
+When you have many web servers, multiple background task will be fired at same time.
+If you want to stop it, set `cleanupCron` as `DISABLED_CLEANUP_CRON`.
+
+[NOTE]
+====
+If you disable `cleanupCron`, neither `SessionDeletedEvent` nor `SessionExpiredEvent` may not be fired.
+For example, your WebSocket connection belong to expired session may not be automatically closed.
+====
 
 [[api-redisoperationssessionrepository-sessioncreatedevent]]
 ==== SessionCreatedEvent

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/EnableRedisHttpSession.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/EnableRedisHttpSession.java
@@ -99,9 +99,15 @@ public @interface EnableRedisHttpSession {
 
 	/**
 	 * The cron expression for expired session cleanup job. By default runs every minute.
+	 * To disable cleanup job, set {@link #DISABLED_CLEANUP_CRON}.
 	 * @return the session cleanup cron expression
 	 * @since 2.0.0
 	 */
 	String cleanupCron() default RedisHttpSessionConfiguration.DEFAULT_CLEANUP_CRON;
 
+	/**
+	 * Special {@link #cleanupCron} value to disable session cleanup job.
+	 * @since 2.1.0
+	 */
+	String DISABLED_CLEANUP_CRON = RedisHttpSessionConfiguration.DISABLED_CLEANUP_CRON;
 }

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfiguration.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfiguration.java
@@ -239,7 +239,8 @@ public class RedisHttpSessionConfiguration extends SpringHttpSessionConfiguratio
 		this.redisFlushMode = attributes.getEnum("redisFlushMode");
 		String cleanupCron = attributes.getString("cleanupCron");
 		if (StringUtils.hasText(cleanupCron)) {
-			this.cleanupCron = cleanupCron;
+			this.cleanupCron = this.embeddedValueResolver
+					.resolveStringValue(cleanupCron);
 		}
 	}
 

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfiguration.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfiguration.java
@@ -76,6 +76,12 @@ public class RedisHttpSessionConfiguration extends SpringHttpSessionConfiguratio
 
 	static final String DEFAULT_CLEANUP_CRON = "0 * * * * *";
 
+	/**
+	 * Special {@link #setCleanupCron} value to disable session cleanup job.
+	 * @since 2.1.0
+	 */
+	public static final String DISABLED_CLEANUP_CRON = "disabled";
+
 	private Integer maxInactiveIntervalInSeconds = MapSession.DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS;
 
 	private String redisNamespace = RedisOperationsSessionRepository.DEFAULT_NAMESPACE;
@@ -239,8 +245,14 @@ public class RedisHttpSessionConfiguration extends SpringHttpSessionConfiguratio
 
 	@Override
 	public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
-		taskRegistrar.addCronTask(() -> sessionRepository().cleanupExpiredSessions(),
-				this.cleanupCron);
+		if (this.isCleanupCronEnabled()) {
+			taskRegistrar.addCronTask(() -> sessionRepository().cleanupExpiredSessions(),
+					this.cleanupCron);
+		}
+	}
+
+	protected boolean isCleanupCronEnabled() {
+		return !(DISABLED_CLEANUP_CRON.equalsIgnoreCase(this.cleanupCron));
 	}
 
 	private RedisTemplate<Object, Object> createRedisTemplate() {

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationTests.java
@@ -98,6 +98,7 @@ public class RedisHttpSessionConfigurationTests {
 		assertThat(configuration).isNotNull();
 		assertThat(ReflectionTestUtils.getField(configuration, "cleanupCron"))
 				.isEqualTo(CLEANUP_CRON_EXPRESSION);
+		assertThat(configuration.isCleanupCronEnabled()).isTrue();
 	}
 
 	@Test
@@ -110,6 +111,33 @@ public class RedisHttpSessionConfigurationTests {
 		assertThat(configuration).isNotNull();
 		assertThat(ReflectionTestUtils.getField(configuration, "cleanupCron"))
 				.isEqualTo(CLEANUP_CRON_EXPRESSION);
+		assertThat(configuration.isCleanupCronEnabled()).isTrue();
+	}
+
+	@Test
+	public void disabledCleanupCronAnnotation() {
+		registerAndRefresh(RedisConfig.class,
+				DisabledCleanupCronExpressionAnnotationConfiguration.class);
+
+		RedisHttpSessionConfiguration configuration = this.context
+				.getBean(RedisHttpSessionConfiguration.class);
+		assertThat(configuration).isNotNull();
+		assertThat(ReflectionTestUtils.getField(configuration, "cleanupCron"))
+				.isEqualTo(RedisHttpSessionConfiguration.DISABLED_CLEANUP_CRON);
+		assertThat(configuration.isCleanupCronEnabled()).isFalse();
+	}
+
+	@Test
+	public void disabledCleanupCronSetter() {
+		registerAndRefresh(RedisConfig.class,
+				DisabledCleanupCronExpressionSetterConfiguration.class);
+
+		RedisHttpSessionConfiguration configuration = this.context
+				.getBean(RedisHttpSessionConfiguration.class);
+		assertThat(configuration).isNotNull();
+		assertThat(ReflectionTestUtils.getField(configuration, "cleanupCron"))
+				.isEqualTo(RedisHttpSessionConfiguration.DISABLED_CLEANUP_CRON);
+		assertThat(configuration.isCleanupCronEnabled()).isFalse();
 	}
 
 	@Test
@@ -234,6 +262,21 @@ public class RedisHttpSessionConfigurationTests {
 
 		CustomCleanupCronExpressionSetterConfiguration() {
 			setCleanupCron(CLEANUP_CRON_EXPRESSION);
+		}
+
+	}
+
+	@EnableRedisHttpSession(cleanupCron = EnableRedisHttpSession.DISABLED_CLEANUP_CRON)
+	static class DisabledCleanupCronExpressionAnnotationConfiguration {
+
+	}
+
+	@Configuration
+	static class DisabledCleanupCronExpressionSetterConfiguration
+			extends RedisHttpSessionConfiguration {
+
+		DisabledCleanupCronExpressionSetterConfiguration() {
+			setCleanupCron(DISABLED_CLEANUP_CRON);
 		}
 
 	}

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationTests.java
@@ -74,18 +74,23 @@ public class RedisHttpSessionConfigurationTests {
 				.getBean(RedisHttpSessionConfiguration.class);
 		assertThat(ReflectionTestUtils.getField(configuration, "redisNamespace"))
 				.isEqualTo("myRedisNamespace");
+		assertThat(ReflectionTestUtils.getField(configuration, "cleanupCron"))
+				.isEqualTo(CLEANUP_CRON_EXPRESSION);
 	}
 
 	@Test
 	public void resolveValueByPlaceholder() {
 		this.context.setEnvironment(new MockEnvironment()
-				.withProperty("session.redis.namespace", "customRedisNamespace"));
+				.withProperty("session.redis.namespace", "customRedisNamespace")
+				.withProperty("session.redis.cleanupCron", CLEANUP_CRON_EXPRESSION));
 		registerAndRefresh(RedisConfig.class, PropertySourceConfiguration.class,
 				CustomRedisHttpSessionConfiguration2.class);
 		RedisHttpSessionConfiguration configuration = this.context
 				.getBean(RedisHttpSessionConfiguration.class);
 		assertThat(ReflectionTestUtils.getField(configuration, "redisNamespace"))
 				.isEqualTo("customRedisNamespace");
+		assertThat(ReflectionTestUtils.getField(configuration, "cleanupCron"))
+				.isEqualTo(CLEANUP_CRON_EXPRESSION);
 	}
 
 	@Test
@@ -346,13 +351,13 @@ public class RedisHttpSessionConfigurationTests {
 	}
 
 	@Configuration
-	@EnableRedisHttpSession(redisNamespace = "myRedisNamespace")
+	@EnableRedisHttpSession(redisNamespace = "myRedisNamespace", cleanupCron = CLEANUP_CRON_EXPRESSION)
 	static class CustomRedisHttpSessionConfiguration {
 
 	}
 
 	@Configuration
-	@EnableRedisHttpSession(redisNamespace = "${session.redis.namespace}")
+	@EnableRedisHttpSession(redisNamespace = "${session.redis.namespace}", cleanupCron = "${session.redis.cleanupCron}")
 	static class CustomRedisHttpSessionConfiguration2 {
 
 	}

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/EnableJdbcHttpSession.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/EnableJdbcHttpSession.java
@@ -91,9 +91,15 @@ public @interface EnableJdbcHttpSession {
 
 	/**
 	 * The cron expression for expired session cleanup job. By default runs every minute.
+	 * To disable cleanup job, set {@link #DISABLED_CLEANUP_CRON}.
 	 * @return the session cleanup cron expression
 	 * @since 2.0.0
 	 */
 	String cleanupCron() default JdbcHttpSessionConfiguration.DEFAULT_CLEANUP_CRON;
 
+	/**
+	 * Special {@link #cleanupCron} value to disable session cleanup job.
+	 * @since 2.1.0
+	 */
+	String DISABLED_CLEANUP_CRON = JdbcHttpSessionConfiguration.DISABLED_CLEANUP_CRON;
 }

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfiguration.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfiguration.java
@@ -191,7 +191,8 @@ public class JdbcHttpSessionConfiguration extends SpringHttpSessionConfiguration
 		}
 		String cleanupCron = attributes.getString("cleanupCron");
 		if (StringUtils.hasText(cleanupCron)) {
-			this.cleanupCron = cleanupCron;
+			this.cleanupCron = this.embeddedValueResolver
+					.resolveStringValue(cleanupCron);
 		}
 	}
 

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfiguration.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfiguration.java
@@ -69,6 +69,12 @@ public class JdbcHttpSessionConfiguration extends SpringHttpSessionConfiguration
 
 	static final String DEFAULT_CLEANUP_CRON = "0 * * * * *";
 
+	/**
+	 * Special {@link #setCleanupCron} value to disable session cleanup job.
+	 * @since 2.1.0
+	 */
+	public static final String DISABLED_CLEANUP_CRON = "disabled";
+
 	private Integer maxInactiveIntervalInSeconds = MapSession.DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS;
 
 	private String tableName = JdbcOperationsSessionRepository.DEFAULT_TABLE_NAME;
@@ -191,8 +197,14 @@ public class JdbcHttpSessionConfiguration extends SpringHttpSessionConfiguration
 
 	@Override
 	public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
-		taskRegistrar.addCronTask(() -> sessionRepository().cleanUpExpiredSessions(),
-				this.cleanupCron);
+		if (this.isCleanupCronEnabled()) {
+			taskRegistrar.addCronTask(() -> sessionRepository().cleanUpExpiredSessions(),
+					this.cleanupCron);
+		}
+	}
+
+	protected boolean isCleanupCronEnabled() {
+		return !(DISABLED_CLEANUP_CRON.equalsIgnoreCase(this.cleanupCron));
 	}
 
 	private static JdbcTemplate createJdbcTemplate(DataSource dataSource) {

--- a/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfigurationTests.java
+++ b/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfigurationTests.java
@@ -290,15 +290,18 @@ public class JdbcHttpSessionConfigurationTests {
 	}
 
 	@Test
-	public void resolveTableNameByPropertyPlaceholder() {
+	public void resolveValuesByPropertyPlaceholder() {
 		this.context.setEnvironment(new MockEnvironment()
-				.withProperty("session.jdbc.tableName", "custom_session_table"));
+				.withProperty("session.jdbc.tableName", "custom_session_table")
+				.withProperty("session.jdbc.cleanupCron", CLEANUP_CRON_EXPRESSION));
 		registerAndRefresh(DataSourceConfiguration.class,
 				CustomJdbcHttpSessionConfiguration.class);
 		JdbcHttpSessionConfiguration configuration = this.context
 				.getBean(JdbcHttpSessionConfiguration.class);
 		assertThat(ReflectionTestUtils.getField(configuration, "tableName"))
 				.isEqualTo("custom_session_table");
+		assertThat(ReflectionTestUtils.getField(configuration, "cleanupCron"))
+				.isEqualTo(CLEANUP_CRON_EXPRESSION);
 	}
 
 	private void registerAndRefresh(Class<?>... annotatedClasses) {
@@ -469,7 +472,7 @@ public class JdbcHttpSessionConfigurationTests {
 
 	}
 
-	@EnableJdbcHttpSession(tableName = "${session.jdbc.tableName}")
+	@EnableJdbcHttpSession(tableName = "${session.jdbc.tableName}", cleanupCron = "${session.jdbc.cleanupCron}")
 	static class CustomJdbcHttpSessionConfiguration {
 
 		@Bean

--- a/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfigurationTests.java
+++ b/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfigurationTests.java
@@ -137,6 +137,7 @@ public class JdbcHttpSessionConfigurationTests {
 		assertThat(configuration).isNotNull();
 		assertThat(ReflectionTestUtils.getField(configuration, "cleanupCron"))
 				.isEqualTo(CLEANUP_CRON_EXPRESSION);
+		assertThat(configuration.isCleanupCronEnabled()).isTrue();
 	}
 
 	@Test
@@ -149,6 +150,34 @@ public class JdbcHttpSessionConfigurationTests {
 		assertThat(configuration).isNotNull();
 		assertThat(ReflectionTestUtils.getField(configuration, "cleanupCron"))
 				.isEqualTo(CLEANUP_CRON_EXPRESSION);
+		assertThat(configuration.isCleanupCronEnabled()).isTrue();
+	}
+
+
+	@Test
+	public void disabledCleanupCronAnnotation() {
+		registerAndRefresh(DataSourceConfiguration.class,
+				DisabledCleanupCronExpressionAnnotationConfiguration.class);
+
+		JdbcHttpSessionConfiguration configuration = this.context
+				.getBean(JdbcHttpSessionConfiguration.class);
+		assertThat(configuration).isNotNull();
+		assertThat(ReflectionTestUtils.getField(configuration, "cleanupCron"))
+				.isEqualTo(JdbcHttpSessionConfiguration.DISABLED_CLEANUP_CRON);
+		assertThat(configuration.isCleanupCronEnabled()).isFalse();
+	}
+
+	@Test
+	public void disabledCleanupCronSetter() {
+		registerAndRefresh(DataSourceConfiguration.class,
+				DisabledCleanupCronExpressionSetterConfiguration.class);
+
+		JdbcHttpSessionConfiguration configuration = this.context
+				.getBean(JdbcHttpSessionConfiguration.class);
+		assertThat(configuration).isNotNull();
+		assertThat(ReflectionTestUtils.getField(configuration, "cleanupCron"))
+				.isEqualTo(JdbcHttpSessionConfiguration.DISABLED_CLEANUP_CRON);
+		assertThat(configuration.isCleanupCronEnabled()).isFalse();
 	}
 
 	@Test
@@ -342,6 +371,21 @@ public class JdbcHttpSessionConfigurationTests {
 
 		CustomCleanupCronExpressionSetterConfiguration() {
 			setCleanupCron(CLEANUP_CRON_EXPRESSION);
+		}
+
+	}
+
+	@EnableJdbcHttpSession(cleanupCron = EnableJdbcHttpSession.DISABLED_CLEANUP_CRON)
+	static class DisabledCleanupCronExpressionAnnotationConfiguration {
+
+	}
+
+	@Configuration
+	static class DisabledCleanupCronExpressionSetterConfiguration
+			extends JdbcHttpSessionConfiguration {
+
+		DisabledCleanupCronExpressionSetterConfiguration() {
+			setCleanupCron(DISABLED_CLEANUP_CRON);
 		}
 
 	}


### PR DESCRIPTION
Provide following features on Redis and JDBC backend (discussed in #1159).

- Way to stop cleanup cron (set `cleanupCron = "disabled"`)
- Enable to use property placeholder within `cleanupCron` attribute

This resolves #1159.