### PR TITLE
Switch to Spring Boot 2.1.0.M1 Dependencies BOM for dependency manage…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,14 +7,20 @@ buildscript {
 		maven { url 'https://repo.spring.io/plugins-release' }
 	}
 }
+
 apply plugin: 'io.spring.convention.root'
 
 group = 'org.springframework.session'
 description = 'Spring Session'
 
+repositories {
+	maven { url "https://repo.spring.io/libs-milestone" }
+}
+
+ext['groovy.version'] = "2.4.15"
+ext['reactor-bom.version'] = "Californium-M2"
+ext['spring.version'] = "5.1.0.RC2"
 
 ext.releaseBuild = version.endsWith('RELEASE')
 ext.snapshotBuild = version.endsWith('SNAPSHOT')
 ext.milestoneBuild = !(releaseBuild || snapshotBuild)
-
-

--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -1,10 +1,6 @@
 dependencyManagement {
 	imports {
-		mavenBom 'com.fasterxml.jackson:jackson-bom:2.9.6'
-		mavenBom 'io.projectreactor:reactor-bom:Californium-M2'
-		mavenBom 'org.springframework:spring-framework-bom:5.1.0.RC2'
-		mavenBom 'org.springframework.data:spring-data-releasetrain:Lovelace-RC1'
-		mavenBom 'org.springframework.security:spring-security-bom:5.1.0.M2'
+		mavenBom "org.springframework.boot:spring-boot-dependencies:$springBootVersion"
 		mavenBom 'org.testcontainers:testcontainers-bom:1.8.1'
 	}
 


### PR DESCRIPTION
…ment.

Closes gh-1162.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
