### PR TITLE
adding ReactiveFindByIndexNameSessionRepository

### DIFF
--- a/spring-session-core/src/main/java/org/springframework/session/ReactiveFindByIndexNameSessionRepository.java
+++ b/spring-session-core/src/main/java/org/springframework/session/ReactiveFindByIndexNameSessionRepository.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session;
+
+import reactor.core.publisher.Flux;
+import reactor.util.function.Tuple2;
+
+import java.util.Map;
+
+/**
+ * Extends a basic {@link SessionRepository} to allow finding sessions by the specified
+ * index name and index value.
+ *
+ * @param <S> the type of Session being managed by this
+ * {@link ReactiveFindByIndexNameSessionRepository}
+ * @author Artsiom Yudovin
+ */
+public interface ReactiveFindByIndexNameSessionRepository<S extends Session>
+		extends ReactiveSessionRepository<S> {
+
+	/**
+	 * A session index that contains the current principal name (i.e. username).
+	 * <p>
+	 * It is the responsibility of the developer to ensure the index is populated since
+	 * Spring Session is not aware of the authentication mechanism being used.
+	 *
+	 * @since 1.1
+	 */
+	String PRINCIPAL_NAME_INDEX_NAME = ReactiveFindByIndexNameSessionRepository.class.getName()
+			.concat(".PRINCIPAL_NAME_INDEX_NAME");
+
+	/**
+	 * Find a {@link Map} of the session id to the {@link Session} of all sessions that
+	 * contain the specified index name index value.
+	 *
+	 * @param indexName the name of the index (i.e.
+	 * {@link ReactiveFindByIndexNameSessionRepository#PRINCIPAL_NAME_INDEX_NAME})
+	 * @param indexValue the value of the index to search for.
+	 * @return a {@code Map} (never {@code null}) of the session id to the {@code Session}
+	 * of all sessions that contain the specified index name and index value. If no
+	 * results are found, an empty {@code Map} is returned.
+	 */
+	Flux<Tuple2<String, S>> findByIndexNameAndIndexValue(String indexName, String indexValue);
+
+	/**
+	 * Find a {@link Map} of the session id to the {@link Session} of all sessions that
+	 * contain the index with the name
+	 * {@link ReactiveFindByIndexNameSessionRepository#PRINCIPAL_NAME_INDEX_NAME} and the
+	 * specified principal name.
+	 *
+	 * @param principalName the principal name
+	 * @return a {@code Map} (never {@code null}) of the session id to the {@code Session}
+	 * of all sessions that contain the specified principal name. If no results are found,
+	 * an empty {@code Map} is returned.
+	 * @since 2.1.0
+	 */
+	default Flux<Tuple2<String, S>> findByPrincipalName(String principalName) {
+
+		return findByIndexNameAndIndexValue(PRINCIPAL_NAME_INDEX_NAME, principalName);
+
+	}
+
+}

--- a/spring-session-core/src/main/java/org/springframework/session/ReactiveFindByIndexNameSessionRepository.java
+++ b/spring-session-core/src/main/java/org/springframework/session/ReactiveFindByIndexNameSessionRepository.java
@@ -16,10 +16,10 @@
 
 package org.springframework.session;
 
+import java.util.Map;
+
 import reactor.core.publisher.Flux;
 import reactor.util.function.Tuple2;
-
-import java.util.Map;
 
 /**
  * Extends a basic {@link SessionRepository} to allow finding sessions by the specified

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisOperationsSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisOperationsSessionRepository.java
@@ -18,24 +18,24 @@ package org.springframework.session.data.redis;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
 import org.reactivestreams.Publisher;
-import org.springframework.session.FindByIndexNameSessionRepository;
-import org.springframework.session.ReactiveFindByIndexNameSessionRepository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
 
 import org.springframework.data.redis.core.ReactiveRedisOperations;
+import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.session.MapSession;
+import org.springframework.session.ReactiveFindByIndexNameSessionRepository;
 import org.springframework.session.ReactiveSessionRepository;
 import org.springframework.session.Session;
 import org.springframework.util.Assert;
-import reactor.util.function.Tuple2;
-import reactor.util.function.Tuples;
 
 /**
  * A {@link ReactiveSessionRepository} that is implemented using Spring Data's
@@ -212,8 +212,8 @@ public class ReactiveRedisOperationsSessionRepository implements
 		String principalKey = getPrincipalKey(indexValue);
 		return this.sessionRedisOperations.opsForSet()
 				.scan(principalKey)
-		        .cast(String.class)
-		        .flatMap(id -> this.findById(id).map(session -> Tuples.of(id, session)));
+				.cast(String.class)
+				.flatMap((id) -> this.findById(id).map((session) -> Tuples.of(id, session)));
 	}
 
 	/**

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisOperationsSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisOperationsSessionRepository.java
@@ -18,8 +18,8 @@ package org.springframework.session.data.redis;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.function.Function;
 

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisOperationsSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisOperationsSessionRepository.java
@@ -213,7 +213,7 @@ public class ReactiveRedisOperationsSessionRepository implements
 		return this.sessionRedisOperations.opsForSet()
 				.scan(principalKey)
 		        .cast(String.class)
-		        .flatMap(id -> findById(id).map(session -> Tuples.of(id, session)));
+		        .flatMap(id -> this.findById(id).map(session -> Tuples.of(id, session)));
 	}
 
 	/**

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/ReactiveRedisOperationsSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/ReactiveRedisOperationsSessionRepositoryTests.java
@@ -398,6 +398,7 @@ public class ReactiveRedisOperationsSessionRepositoryTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void findByIndexNameAndIndexValue() {
 		given(this.redisOperations.opsForHash()).willReturn(this.hashOperations);
 		String attribute1 = "attribute1";


### PR DESCRIPTION
A reactive equivalent to FindByIndexNameSessionRepository. This [enhancement](https://github.com/spring-projects/spring-session/issues/914) 