### PR TITLE
Commit Session on Include Dispatch

### DIFF
--- a/spring-session-core/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
@@ -1170,6 +1170,21 @@ public class SessionRepositoryFilterTests {
 		});
 	}
 
+	@Test
+	public void doFilterInclude() throws Exception {
+		doFilter(new DoInFilter() {
+			@Override
+			public void doFilter(HttpServletRequest wrappedRequest,
+					HttpServletResponse wrappedResponse) throws IOException, ServletException {
+				String id = wrappedRequest.getSession().getId();
+				wrappedRequest.getRequestDispatcher("/").include(wrappedRequest, wrappedResponse);
+				assertThat(
+						SessionRepositoryFilterTests.this.sessionRepository.findById(id))
+						.isNotNull();
+			}
+		});
+	}
+
 	// --- HttpSessionIdResolver
 
 	@Test


### PR DESCRIPTION
The servlet spec disallows any writing of headers after an include has
been issued.

This commit intercepts the include and commits the session, then
allowing the include to proceed.

Fixes: gh-1242