### PR TITLE
Fix SessionCookieConfig.isHttpOnly

### DIFF
--- a/spring-session-core/src/main/java/org/springframework/session/config/annotation/web/http/SpringHttpSessionConfiguration.java
+++ b/spring-session-core/src/main/java/org/springframework/session/config/annotation/web/http/SpringHttpSessionConfiguration.java
@@ -187,6 +187,7 @@ public class SpringHttpSessionConfiguration implements ApplicationContextAware {
 				if (sessionCookieConfig.getMaxAge() != -1) {
 					cookieSerializer.setCookieMaxAge(sessionCookieConfig.getMaxAge());
 				}
+				cookieSerializer.setUseHttpOnlyCookie(sessionCookieConfig.isHttpOnly());
 			}
 		}
 		if (this.usesSpringSessionRememberMeServices) {

--- a/spring-session-core/src/test/java/org/springframework/session/config/annotation/web/http/SpringHttpSessionConfigurationTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/config/annotation/web/http/SpringHttpSessionConfigurationTests.java
@@ -99,6 +99,8 @@ public class SpringHttpSessionConfigurationTests {
 				.isEqualTo(600);
 		assertThat(ReflectionTestUtils.getField(cookieSerializer, "domainName"))
 				.isEqualTo("test-domain");
+		assertThat(ReflectionTestUtils.getField(cookieSerializer, "useHttpOnlyCookie"))
+				.isEqualTo(false);
 	}
 
 	@Test
@@ -149,6 +151,7 @@ public class SpringHttpSessionConfigurationTests {
 			servletContext.getSessionCookieConfig().setDomain("test-domain");
 			servletContext.getSessionCookieConfig().setPath("test-path");
 			servletContext.getSessionCookieConfig().setMaxAge(600);
+			servletContext.getSessionCookieConfig().setHttpOnly(false);
 			return servletContext;
 		}
 


### PR DESCRIPTION
Previously, SessionCookieConfig.isHttpOnly was ignored by the default
CookieSerializer.

This commit updates the default CookieSerializer to respect the
SessionCookieConfig.isHttpOnly flag.

Fixes: gh-1253