### PR TITLE
backport gh-1077 to 1.3.x. Fix NullPointerException in entryRemoved.

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/hazelcast/HazelcastSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/hazelcast/HazelcastSessionRepository.java
@@ -16,16 +16,6 @@
 
 package org.springframework.session.hazelcast;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.listener.EntryAddedListener;
@@ -34,7 +24,6 @@ import com.hazelcast.map.listener.EntryRemovedListener;
 import com.hazelcast.query.Predicates;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.session.ExpiringSession;
@@ -46,6 +35,15 @@ import org.springframework.session.events.SessionCreatedEvent;
 import org.springframework.session.events.SessionDeletedEvent;
 import org.springframework.session.events.SessionExpiredEvent;
 import org.springframework.util.Assert;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link org.springframework.session.SessionRepository} implementation that stores
@@ -266,11 +264,13 @@ public class HazelcastSessionRepository implements
 	}
 
 	public void entryRemoved(EntryEvent<String, MapSession> event) {
-		if (logger.isDebugEnabled()) {
-			logger.debug("Session deleted with id: " + event.getOldValue().getId());
+		MapSession session = event.getOldValue();
+		if (session != null) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Session deleted with id: " + session.getId());
+			}
+			this.eventPublisher.publishEvent(new SessionDeletedEvent(this, session));
 		}
-		this.eventPublisher
-				.publishEvent(new SessionDeletedEvent(this, event.getOldValue()));
 	}
 
 	/**


### PR DESCRIPTION
backport #gh-1077 to 1.3.x. Fix NullPointerException in entryRemoved.
detected with hazelcast 3.11, spring session 1.3.4, spring boot 1.5

#gh-1077

We detected Nullpointer on session timeouts:
````
2019-01-16 13:01:00,151 ERROR [hz._hzInstance_1_xxx.event-4] ? (?:?) - [xxx.xxx.xxx.xxx]:xxxx [xxx] [3.11] hz._hzInstance_1_xxx.event-4 caught an exception while processing task:com.hazelcast.spi.impl.eventservice.impl.LocalEventDispatcher@6b58bdef
java.lang.NullPointerException
        at org.springframework.session.events.AbstractSessionEvent.<init>(AbstractSessionEvent.java:45)
        at org.springframework.session.events.SessionDestroyedEvent.<init>(SessionDestroyedEvent.java:41)
        at org.springframework.session.events.SessionDeletedEvent.<init>(SessionDeletedEvent.java:39)
        at org.springframework.session.hazelcast.HazelcastSessionRepository.entryRemoved(HazelcastSessionRepository.java:273)
        at com.hazelcast.map.impl.MapListenerAdaptors$2$1.onEvent(MapListenerAdaptors.java:87)
        at com.hazelcast.map.impl.MapListenerAdaptors$2$1.onEvent(MapListenerAdaptors.java:84)
        at com.hazelcast.map.impl.InternalMapListenerAdapter.onEvent(InternalMapListenerAdapter.java:56)
        at com.hazelcast.map.impl.InternalMapListenerAdapter.onEvent(InternalMapListenerAdapter.java:35)
        at com.hazelcast.map.impl.event.MapEventPublishingService.callListener(MapEventPublishingService.java:172)
        at com.hazelcast.map.impl.event.MapEventPublishingService.dispatchEntryEventData(MapEventPublishingService.java:184)
        at com.hazelcast.map.impl.event.MapEventPublishingService.dispatchEvent(MapEventPublishingService.java:83)
        at com.hazelcast.map.impl.event.MapEventPublishingService.dispatchEvent(MapEventPublishingService.java:47)
        at com.hazelcast.map.impl.MapService.dispatchEvent(MapService.java:106)
        at com.hazelcast.map.impl.MapService.dispatchEvent(MapService.java:77)
        at com.hazelcast.spi.impl.eventservice.impl.LocalEventDispatcher.run(LocalEventDispatcher.java:64)
        at com.hazelcast.util.executor.StripedExecutor$Worker.process(StripedExecutor.java:226)
        at com.hazelcast.util.executor.StripedExecutor$Worker.run(StripedExecutor.java:209)
````