### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -10,8 +10,8 @@ By participating, you  are expected to uphold this code. Please report unaccepta
 == Using GitHub issues
 
 We use GitHub issues to track bugs and enhancements. If you have a general usage question
-please ask on http://stackoverflow.com[Stack Overflow]. The Spring Session team and the
-broader community monitor the http://stackoverflow.com/tags/spring-session[`spring-session`]
+please ask on https://stackoverflow.com[Stack Overflow]. The Spring Session team and the
+broader community monitor the https://stackoverflow.com/tags/spring-session[`spring-session`]
 tag.
 
 If you are reporting a bug, please help to speed up problem diagnosis by providing as much

--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@ By participating, you  are expected to uphold this code. Please report unaccepta
 
 = Spring Session Project Site
 
-You can find the documentation, issue management, support, samples, and guides for using Spring Session at http://projects.spring.io/spring-session/
+You can find the documentation, issue management, support, samples, and guides for using Spring Session at https://projects.spring.io/spring-session/
 
 = License
 

--- a/docs/src/docs/asciidoc/guides/boot.adoc
+++ b/docs/src/docs/asciidoc/guides/boot.adoc
@@ -93,7 +93,7 @@ spring.redis.password=secret
 spring.redis.port=6379
 ----
 
-For more information, refer to http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-connecting-to-redis[Connecting to Redis] portion of the Spring Boot documentation.
+For more information, refer to https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-connecting-to-redis[Connecting to Redis] portion of the Spring Boot documentation.
 
 [[boot-servlet-configuration]]
 == Servlet Container Initialization
@@ -117,7 +117,7 @@ You can run the sample by obtaining the {download-url}[source code] and invoking
 
 [NOTE]
 ====
-For the sample to work, you must http://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
+For the sample to work, you must https://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
 Alternatively, you can update the `JedisConnectionFactory` to point to a Redis server.
 ====
 
@@ -153,7 +153,7 @@ If you like, you can easily remove the session using redis-cli. For example, on 
 
 	$ redis-cli keys '*' | xargs redis-cli del
 
-TIP: The Redis documentation has instructions for http://redis.io/topics/quickstart[installing redis-cli].
+TIP: The Redis documentation has instructions for https://redis.io/topics/quickstart[installing redis-cli].
 
 Alternatively, you can also delete the explicit key. Enter the following into your terminal ensuring to replace `7e8383a4-082c-4ffe-a4bc-c40fd3363c5e` with the value of your SESSION cookie:
 

--- a/docs/src/docs/asciidoc/guides/custom-cookie.adoc
+++ b/docs/src/docs/asciidoc/guides/custom-cookie.adoc
@@ -27,7 +27,7 @@ This allows sharing a session across domains and applications.
 If the regular expression does not match, no domain is set and the existing domain will be used.
 If the regular expression matches, the first https://docs.oracle.com/javase/tutorial/essential/regex/groups.html[grouping] will be used as the domain.
 This means that a request to https://child.example.com will set the domain to example.com.
-However, a request to http://localhost:8080/ or http://192.168.1.100:8080/ will leave the cookie unset and thus still work in development without any changes necessary for production.
+However, a request to http://localhost:8080/ or https://192.168.1.100:8080/ will leave the cookie unset and thus still work in development without any changes necessary for production.
 
 [WARNING]
 ====
@@ -78,7 +78,7 @@ You can run the sample by obtaining the {download-url}[source code] and invoking
 
 [NOTE]
 ====
-For the sample to work, you must http://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
+For the sample to work, you must https://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
 Alternatively, you can update the `LettuceConnectionFactory` to point to a Redis server.
 ====
 

--- a/docs/src/docs/asciidoc/guides/findbyusername.adoc
+++ b/docs/src/docs/asciidoc/guides/findbyusername.adoc
@@ -108,7 +108,7 @@ You can run the sample by obtaining the {download-url}[source code] and invoking
 
 [NOTE]
 ====
-For the sample to work, you must http://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
+For the sample to work, you must https://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
 Alternatively, you can update the `JedisConnectionFactory` to point to a Redis server.
 ====
 

--- a/docs/src/docs/asciidoc/guides/grails3.adoc
+++ b/docs/src/docs/asciidoc/guides/grails3.adoc
@@ -70,7 +70,7 @@ spring:
     port: 6397
 ----
 
-For more information, refer to http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-connecting-to-redis[Connecting to Redis] portion of the Spring Boot documentation.
+For more information, refer to https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-connecting-to-redis[Connecting to Redis] portion of the Spring Boot documentation.
 
 [[grails3-sample]]
 == Grails 3 Sample Application
@@ -84,7 +84,7 @@ You can run the sample by obtaining the {download-url}[source code] and invoking
 
 [NOTE]
 ====
-For the sample to work, you must http://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
+For the sample to work, you must https://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
 Alternatively, you can update the `JedisConnectionFactory` to point to a Redis server.
 ====
 
@@ -120,7 +120,7 @@ If you like, you can easily remove the session using redis-cli. For example, on 
 
 	$ redis-cli keys '*' | xargs redis-cli del
 
-TIP: The Redis documentation has instructions for http://redis.io/topics/quickstart[installing redis-cli].
+TIP: The Redis documentation has instructions for https://redis.io/topics/quickstart[installing redis-cli].
 
 Alternatively, you can also delete the explicit key. Enter the following into your terminal ensuring to replace `7e8383a4-082c-4ffe-a4bc-c40fd3363c5e` with the value of your SESSION cookie:
 

--- a/docs/src/docs/asciidoc/guides/hazelcast-spring.adoc
+++ b/docs/src/docs/asciidoc/guides/hazelcast-spring.adoc
@@ -85,7 +85,7 @@ In this instance Spring Session is backed by Hazelcast.
 Spring Session provides `PrincipalNameExtractor` for this purpose.
 <3> We create a `HazelcastInstance` that connects Spring Session to Hazelcast.
 By default, an embedded instance of Hazelcast is started and connected to by the application.
-For more information on configuring Hazelcast, refer to the http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#hazelcast-configuration[reference documentation].
+For more information on configuring Hazelcast, refer to the https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#hazelcast-configuration[reference documentation].
 
 == Servlet Container Initialization
 
@@ -130,7 +130,7 @@ You can run the sample by obtaining the {download-url}[source code] and invoking
 ====
 Hazelcast will run in embedded mode with your application by default, but if you want to connect
 to a stand alone instance instead, you can configure it by following the instructions in the
-http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#hazelcast-configuration[reference documentation].
+https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#hazelcast-configuration[reference documentation].
 ====
 
 ----
@@ -161,9 +161,9 @@ Go ahead and view the cookies (click for help with https://developer.chrome.com/
 
 === Interact with the data store
 
-If you like, you can remove the session using http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#hazelcast-java-client[a Java client],
-http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#other-client-implementations[one of the other clients], or the
-http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#management-center[management center].
+If you like, you can remove the session using https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#hazelcast-java-client[a Java client],
+https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#other-client-implementations[one of the other clients], or the
+https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#management-center[management center].
 
 ==== Using the console
 
@@ -172,7 +172,7 @@ For example, using the management center console after connecting to your Hazelc
 	default> ns spring:session:sessions
 	spring:session:sessions> m.clear
 
-TIP: The Hazelcast documentation has instructions for http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#executing-console-commands[the console].
+TIP: The Hazelcast documentation has instructions for https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#executing-console-commands[the console].
 
 Alternatively, you can also delete the explicit key. Enter the following into the console ensuring to replace `7e8383a4-082c-4ffe-a4bc-c40fd3363c5e` with the value of your SESSION cookie:
 
@@ -183,7 +183,7 @@ Now visit the application at http://localhost:8080/ and observe that we are no l
 ==== Using the REST API
 
 As described in the other clients section of the documentation, there is a 
-http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#rest-client[REST API]
+https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#rest-client[REST API]
 provided by the Hazelcast node(s).
 
 For example, you could delete an individual key as follows (replacing `7e8383a4-082c-4ffe-a4bc-c40fd3363c5e` with the value of your SESSION cookie):

--- a/docs/src/docs/asciidoc/guides/httpsession-gemfire-boot.adoc
+++ b/docs/src/docs/asciidoc/guides/httpsession-gemfire-boot.adoc
@@ -95,7 +95,7 @@ and managed by GemFire.  As well, we have specified an arbitrary expiration attr
 for when the Session will timeout, which is triggered by a GemFire Region entry expiration event that also invalidates
 the Session object in the Region.
 <2> Next, we define a few `Properties` that allow us to configure certain aspects of the GemFire Server using
-http://gemfire.docs.pivotal.io/docs-gemfire/latest/reference/topics/gemfire_properties.html[GemFire's System properties].
+https://gemfire.docs.pivotal.io/docs-gemfire/latest/reference/topics/gemfire_properties.html[GemFire's System properties].
 <3> Then, we create an instance of the GemFire `Cache` using our defined `Properties`.
 <4> Finally, we configure and start a `CacheServer` running in the GemFire Server to listen for connections
 from cache clients.  The `CacheServer's` `Socket` will be used to connect our GemFire cache client,
@@ -149,22 +149,22 @@ TIP: In typical GemFire deployments, where the cluster includes potentially hund
 (servers), it is more common for clients to connect to one or more GemFire Locators running in the cluster.  A Locator
 passes meta-data to clients about the servers available, their load and which servers have the client's data of interest,
 which is particularly important in direct, single-hop data access and latency-sensitive operations.  See more details
-about the http://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/cs_configuration/chapter_overview.html[Client/Server Topology in GemFire's User Guide].
+about the https://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/cs_configuration/chapter_overview.html[Client/Server Topology in GemFire's User Guide].
 
-NOTE: For more information on configuring _Spring Data GemFire_, refer to the http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[reference guide].
+NOTE: For more information on configuring _Spring Data GemFire_, refer to the https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[reference guide].
 
 The `@EnableGemFireHttpSession` annotation enables a developer to configure certain aspects of both _Spring Session_
 and GemFire out-of-the-box using the following attributes:
 
 * `maxInactiveIntervalInSeconds` - controls _HttpSession_ idle-timeout expiration (defaults to **30 minutes**).
 * `regionName` - specifies the name of the GemFire Region used to store `HttpSession` state (defaults is "*ClusteredSpringSessions*").
-* `clientRegionShort` - specifies GemFire's http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/management_all_region_types/chapter_overview.html[data management policy]
-with a GemFire http://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/client/ClientRegionShortcut.html[ClientRegionShortcut]
+* `clientRegionShort` - specifies GemFire's https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/management_all_region_types/chapter_overview.html[data management policy]
+with a GemFire https://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/client/ClientRegionShortcut.html[ClientRegionShortcut]
 (default is `PROXY`).  This attribute is only used when configuring client Region.
 * `poolName` - name of the dedicated GemFire Pool used to connect a client to the cluster of servers.  The attribute
 is only used when the application is a GemFire cache client.  Defaults to `gemfirePool`.
-* `serverRegionShort` - specifies GemFire's http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/management_all_region_types/chapter_overview.html[data management policy]
-using a GemFire http://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/RegionShortcut.html[RegionShortcut]
+* `serverRegionShort` - specifies GemFire's https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/management_all_region_types/chapter_overview.html[data management policy]
+using a GemFire https://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/RegionShortcut.html[RegionShortcut]
 (default is `PARTITION`).  This attribute is only used when configuring server Regions, or when a p2p topology is employed.
 
 NOTE: It is important to remember that the GemFire client Region name must match a server Region by the same name if
@@ -230,7 +230,7 @@ Go ahead and view the cookies (click for help with https://developer.chrome.com/
 or https://getfirebug.com/wiki/index.php/Cookies_Panel#Cookies_List[Firefox]).
 
 NOTE: The following instructions assume you have a local GemFire installation.  For more information on installation,
-see http://gemfire.docs.pivotal.io/docs-gemfire/getting_started/installation/install_intro.html[Installing Pivotal GemFire].
+see https://gemfire.docs.pivotal.io/docs-gemfire/getting_started/installation/install_intro.html[Installing Pivotal GemFire].
 
 NOTE: In order to run the following, you must uncomment the lines in the `GemFireServer` class, `gemfireProperties` bean
 for the following GemFire System properties: `jmx-manager` and `jmx-manager-start`.
@@ -262,7 +262,7 @@ NEXT_STEP_NAME : END
 gfsh>remove --region=/ClusteredSpringSessions --key="70002719-3c54-4c20-82c3-e7faa6b718f3"
 ....
 
-NOTE: The _GemFire User Guide_ has more detailed instructions on using http://gemfire.docs.pivotal.io/docs-gemfire/latest/tools_modules/gfsh/chapter_overview.html[gfsh].
+NOTE: The _GemFire User Guide_ has more detailed instructions on using https://gemfire.docs.pivotal.io/docs-gemfire/latest/tools_modules/gfsh/chapter_overview.html[gfsh].
 
 Now visit the application at http://localhost:8080/ again and observe that the attribute we added is no longer displayed.
 

--- a/docs/src/docs/asciidoc/guides/httpsession-gemfire-clientserver-xml.adoc
+++ b/docs/src/docs/asciidoc/guides/httpsession-gemfire-clientserver-xml.adoc
@@ -92,7 +92,7 @@ bean to replace placeholders in the Spring XML configuration meta-data with the 
 at the designated host/port is running and listening for client connections, blocking client startup until
 the server is available and ready.
 <4> Next, we include a `Properties` bean to configure certain aspects of the GemFire client cache using
-http://gemfire.docs.pivotal.io/docs-gemfire/latest/reference/topics/gemfire_properties.html[GemFire's System Properties].
+https://gemfire.docs.pivotal.io/docs-gemfire/latest/reference/topics/gemfire_properties.html[GemFire's System Properties].
 In this case, we are just setting GemFire's `log-level` from a application-specific System property, defaulting
 to `warning` if unspecified.
 <5> Then we create a instance of a GemFire `ClientCache` initialized with our `gemfireProperties`.
@@ -104,9 +104,9 @@ has been configured to connect directly to a server.
 TIP: In typical GemFire deployments, where the cluster includes potentially hundreds of GemFire data nodes (servers),
 it is more common for clients to connect to one or more GemFire Locators running in the cluster. A Locator passes meta-data
 to clients about the servers available, load and which servers have the client's data of interest, which is particularly
-important for single-hop, direct data access.  See more details about the http://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/cs_configuration/chapter_overview.html[Client/Server Topology in GemFire's User Guide].
+important for single-hop, direct data access.  See more details about the https://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/cs_configuration/chapter_overview.html[Client/Server Topology in GemFire's User Guide].
 
-NOTE: For more information on configuring _Spring Data GemFire_, refer to the http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[reference guide].
+NOTE: For more information on configuring _Spring Data GemFire_, refer to the https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[reference guide].
 
 === Server Configuration
 
@@ -167,7 +167,7 @@ include::{samples-dir}httpsession-gemfire-clientserver-xml/src/main/webapp/WEB-I
 include::{samples-dir}httpsession-gemfire-clientserver-xml/src/main/webapp/WEB-INF/web.xml[tags=listeners]
 ----
 
-The http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#context-create[ContextLoaderListener]
+The https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#context-create[ContextLoaderListener]
 reads the `contextConfigLocation` context parameter value and picks up our _session-client.xml_ configuration file.
 
 Finally, we need to ensure that our Servlet Container (i.e. Tomcat) uses our `springSessionRepositoryFilter`
@@ -181,7 +181,7 @@ The following snippet performs this last step for us:
 include::{samples-dir}httpsession-gemfire-clientserver-xml/src/main/webapp/WEB-INF/web.xml[tags=springSessionRepositoryFilter]
 ----
 
-The http://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html[DelegatingFilterProxy]
+The https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html[DelegatingFilterProxy]
 will look up a bean by the name of `springSessionRepositoryFilter` and cast it to a `Filter`. For every request that `DelegatingFilterProxy`
 is invoked, the `springSessionRepositoryFilter` will be invoked.
 // end::config[]
@@ -263,7 +263,7 @@ NEXT_STEP_NAME : END
 gfsh>remove --region=/ClusteredSpringSessions --key="70002719-3c54-4c20-82c3-e7faa6b718f3"
 ....
 
-NOTE: The _GemFire User Guide_ has more detailed instructions on using http://gemfire.docs.pivotal.io/docs-gemfire/latest/tools_modules/gfsh/chapter_overview.html[gfsh].
+NOTE: The _GemFire User Guide_ has more detailed instructions on using https://gemfire.docs.pivotal.io/docs-gemfire/latest/tools_modules/gfsh/chapter_overview.html[gfsh].
 
 Now visit the application at http://localhost:8080/ again and observe that the attribute we added is no longer displayed.
 

--- a/docs/src/docs/asciidoc/guides/httpsession-gemfire-clientserver.adoc
+++ b/docs/src/docs/asciidoc/guides/httpsession-gemfire-clientserver.adoc
@@ -87,12 +87,12 @@ include::{samples-dir}httpsession-gemfire-clientserver/src/main/java/sample/Clie
 implements `Filter`. The filter is what replaces the `HttpSession` with an implementation backed by Spring Session
 and GemFire.
 <2> Next, we register a `Properties` bean that allows us to configure certain aspects of the GemFire client cache
-using http://gemfire.docs.pivotal.io/docs-gemfire/latest/reference/topics/gemfire_properties.html[GemFire's System properties].
+using https://gemfire.docs.pivotal.io/docs-gemfire/latest/reference/topics/gemfire_properties.html[GemFire's System properties].
 <3> We use the `Properties` to configure an instance of a GemFire `ClientCache`.
 <4> Then, we configure a `Pool` of client connections to talk to the GemFire Server in our Client/Server topology. In our
 configuration, we have used sensible settings for timeouts, number of connections and so on. Also, the `Pool` has been
 configured to connect directly to a server. Learn more about various `Pool` configuration settings from the
-http://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/client/PoolFactory.html[PoolFactory API].
+https://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/client/PoolFactory.html[PoolFactory API].
 <56> Finally, we include a Spring `BeanPostProcessor` to block the client until our GemFire Server is up and running,
 listening for and accepting client connections.
 
@@ -108,22 +108,22 @@ the listener releases the latch that the `BeanPostProcessor` will wait on (up to
 TIP: In typical GemFire deployments, where the cluster includes potentially hundreds of GemFire data nodes (servers),
 it is more common for clients to connect to one or more GemFire Locators running in the cluster. A Locator passes meta-data
 to clients about the servers available, load and which servers have the client's data of interest, which is particularly
-important for single-hop, direct data access.  See more details about the http://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/cs_configuration/chapter_overview.html[Client/Server Topology in GemFire's User Guide].
+important for single-hop, direct data access.  See more details about the https://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/cs_configuration/chapter_overview.html[Client/Server Topology in GemFire's User Guide].
 
-NOTE: For more information on configuring _Spring Data GemFire_, refer to the http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[reference guide].
+NOTE: For more information on configuring _Spring Data GemFire_, refer to the https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[reference guide].
 
 The `@EnableGemFireHttpSession` annotation enables a developer to configure certain aspects of both Spring Session
 and GemFire out-of-the-box using the following attributes:
 
 * `maxInactiveIntervalInSeconds` - controls _HttpSession_ idle-timeout expiration (defaults to **30 minutes**).
 * `regionName` - specifies the name of the GemFire Region used to store `HttpSession` state (defaults is "*ClusteredSpringSessions*").
-* `clientRegionShort` - specifies GemFire's http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/management_all_region_types/chapter_overview.html[data management policy]
+* `clientRegionShort` - specifies GemFire's https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/management_all_region_types/chapter_overview.html[data management policy]
 with a GemFire https://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/client/ClientRegionShortcut.html[ClientRegionShortcut]
 (default is `PROXY`).  This attribute is only used when configuring client Region.
 * `poolName` - name of the dedicated GemFire Pool used to connect a client to the cluster of servers.  The attribute
 is only used when the application is a GemFire cache client.  Defaults to `gemfirePool`.
-* `serverRegionShort` - specifies GemFire's http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/management_all_region_types/chapter_overview.html[data management policy]
-using a GemFire http://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/RegionShortcut.html[RegionShortcut]
+* `serverRegionShort` - specifies GemFire's https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/management_all_region_types/chapter_overview.html[data management policy]
+using a GemFire https://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/RegionShortcut.html[RegionShortcut]
 (default is `PARTITION`).  This attribute is only used when configuring server Regions, or when a p2p topology is employed.
 
 NOTE: It is important to note that the GemFire client Region name must match a server Region by the same name if
@@ -262,7 +262,7 @@ NEXT_STEP_NAME : END
 gfsh>remove --region=/ClusteredSpringSessions --key="70002719-3c54-4c20-82c3-e7faa6b718f3"
 ....
 
-NOTE: The _GemFire User Guide_ has more detailed instructions on using http://gemfire.docs.pivotal.io/docs-gemfire/latest/tools_modules/gfsh/chapter_overview.html[gfsh].
+NOTE: The _GemFire User Guide_ has more detailed instructions on using https://gemfire.docs.pivotal.io/docs-gemfire/latest/tools_modules/gfsh/chapter_overview.html[gfsh].
 
 Now visit the application at http://localhost:8080/ again and observe that the attribute we added is no longer displayed.
 

--- a/docs/src/docs/asciidoc/guides/httpsession-gemfire-p2p-xml.adoc
+++ b/docs/src/docs/asciidoc/guides/httpsession-gemfire-p2p-xml.adoc
@@ -100,7 +100,7 @@ Spring Session sample application.
 TIP: Additionally, we have configured this data node (server) as a GemFire Manager as well using GemFire-specific
 JMX System properties that enable JMX client (e.g. _Gfsh_) to connect to this running data node.
 
-NOTE: For more information on configuring _Spring Data GemFire_, refer to the http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[reference guide].
+NOTE: For more information on configuring _Spring Data GemFire_, refer to the https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[reference guide].
 
 == XML Servlet Container Initialization
 
@@ -118,7 +118,7 @@ include::{samples-dir}httpsession-gemfire-p2p-xml/src/main/webapp/WEB-INF/web.xm
 include::{samples-dir}httpsession-gemfire-p2p-xml/src/main/webapp/WEB-INF/web.xml[tags=listeners]
 ----
 
-The http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#context-create[ContextLoaderListener]
+The https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#context-create[ContextLoaderListener]
 reads the `contextConfigLocation` context parameter value and picks up our _session.xml_ configuration file.
 
 Finally, we need to ensure that our Servlet Container (i.e. Tomcat) uses our `springSessionRepositoryFilter`
@@ -132,7 +132,7 @@ The following snippet performs this last step for us:
 include::{samples-dir}httpsession-gemfire-p2p-xml/src/main/webapp/WEB-INF/web.xml[tags=springSessionRepositoryFilter]
 ----
 
-The http://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html[DelegatingFilterProxy]
+The https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html[DelegatingFilterProxy]
 will look up a bean by the name of `springSessionRepositoryFilter` and cast it to a `Filter`. For every request that `DelegatingFilterProxy`
 is invoked, the `springSessionRepositoryFilter` will be invoked.
 // end::config[]
@@ -176,7 +176,7 @@ Go ahead and view the cookies (click for help with https://developer.chrome.com/
 or https://getfirebug.com/wiki/index.php/Cookies_Panel#Cookies_List[Firefox]).
 
 NOTE: The following instructions assume you have a local GemFire installation.  For more information on installation,
-see http://gemfire.docs.pivotal.io/gemfire/getting_started/installation/install_intro.html[Installing Pivotal GemFire].
+see https://gemfire.docs.pivotal.io/gemfire/getting_started/installation/install_intro.html[Installing Pivotal GemFire].
 
 If you like, you can easily remove the session using `gfsh`. For example, on a Linux-based system type the following
 at the command-line:
@@ -205,6 +205,6 @@ NEXT_STEP_NAME : END
 gfsh>remove --region=/ClusteredSpringSessions --key="70002719-3c54-4c20-82c3-e7faa6b718f3"
 ....
 
-NOTE: The _GemFire User Guide_ has more detailed instructions on using http://gemfire.docs.pivotal.io/docs-gemfire/latest/tools_modules/gfsh/chapter_overview.html[gfsh].
+NOTE: The _GemFire User Guide_ has more detailed instructions on using https://gemfire.docs.pivotal.io/docs-gemfire/latest/tools_modules/gfsh/chapter_overview.html[gfsh].
 
 Now visit the application at http://localhost:8080/ and observe that the attribute we added is no longer displayed.

--- a/docs/src/docs/asciidoc/guides/httpsession-gemfire-p2p.adoc
+++ b/docs/src/docs/asciidoc/guides/httpsession-gemfire-p2p.adoc
@@ -96,14 +96,14 @@ Spring Session sample application.
 TIP: Additionally, we have configured this data node (server) as a GemFire Manager as well using GemFire-specific
 JMX System properties that enable JMX client (e.g. _Gfsh_) to connect to this running data node.
 
-NOTE: For more information on configuring _Spring Data GemFire_, refer to the http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[reference guide].
+NOTE: For more information on configuring _Spring Data GemFire_, refer to the https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/[reference guide].
 
 The `@EnableGemFireHttpSession` annotation enables a developer to configure certain aspects of Spring Session
 and GemFire out-of-the-box using the following attributes:
 
 * `maxInactiveIntervalInSeconds` - controls HttpSession idle-timeout expiration (defaults to **30 minutes**).
 * `regionName` - specifies the name of the GemFire Region used to store `HttpSession` state (defaults is "_ClusteredSpringSessions_").
-* `serverRegionShort` - specifies GemFire http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/management_all_region_types/chapter_overview.html[data management policies]
+* `serverRegionShort` - specifies GemFire https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/management_all_region_types/chapter_overview.html[data management policies]
 with a GemFire https://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/RegionShortcut.html[RegionShortcut]
 (default is `PARTITION`).
 
@@ -204,6 +204,6 @@ NEXT_STEP_NAME : END
 gfsh>remove --region=/ClusteredSpringSessions --key="70002719-3c54-4c20-82c3-e7faa6b718f3"
 ....
 
-NOTE: The _GemFire User Guide_ has more detailed instructions on using http://gemfire.docs.pivotal.io/docs-gemfire/latest/tools_modules/gfsh/chapter_overview.html[gfsh].
+NOTE: The _GemFire User Guide_ has more detailed instructions on using https://gemfire.docs.pivotal.io/docs-gemfire/latest/tools_modules/gfsh/chapter_overview.html[gfsh].
 
 Now visit the application at http://localhost:8080/ and observe that the attribute we added is no longer displayed.

--- a/docs/src/docs/asciidoc/guides/httpsession-jdbc-boot.adoc
+++ b/docs/src/docs/asciidoc/guides/httpsession-jdbc-boot.adoc
@@ -95,7 +95,7 @@ spring.datasource.username=myapp
 spring.datasource.password=secret
 ----
 
-For more information, refer to http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-configure-datasource[Configure a DataSource] portion of the Spring Boot documentation.
+For more information, refer to https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-configure-datasource[Configure a DataSource] portion of the Spring Boot documentation.
 
 [[httpsession-jdbc-boot-servlet-configuration]]
 == Servlet Container Initialization

--- a/docs/src/docs/asciidoc/guides/httpsession-jdbc-xml.adoc
+++ b/docs/src/docs/asciidoc/guides/httpsession-jdbc-xml.adoc
@@ -87,7 +87,7 @@ In this instance Spring Session is backed by a relational database.
 We configure the H2 database to create database tables using the SQL script which is included in Spring Session.
 <3> We create a `transactionManager` that manages transactions for previously configured `dataSource`.
 
-For additional information on how to configure data access related concerns, please refer to the http://docs.spring.io/spring/docs/current/spring-framework-reference/html/spring-data-tier.html[Spring Framework Reference Documentation].
+For additional information on how to configure data access related concerns, please refer to the https://docs.spring.io/spring/docs/current/spring-framework-reference/html/spring-data-tier.html[Spring Framework Reference Documentation].
 
 == XML Servlet Container Initialization
 
@@ -105,7 +105,7 @@ include::{samples-dir}httpsession-xml/src/main/webapp/WEB-INF/web.xml[tags=conte
 include::{samples-dir}httpsession-xml/src/main/webapp/WEB-INF/web.xml[tags=listeners]
 ----
 
-The http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#context-create[ContextLoaderListener] reads the contextConfigLocation and picks up our session.xml configuration.
+The https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#context-create[ContextLoaderListener] reads the contextConfigLocation and picks up our session.xml configuration.
 
 Last we need to ensure that our Servlet Container (i.e. Tomcat) uses our `springSessionRepositoryFilter` for every request.
 The following snippet performs this last step for us:
@@ -116,7 +116,7 @@ The following snippet performs this last step for us:
 include::{samples-dir}httpsession-xml/src/main/webapp/WEB-INF/web.xml[tags=springSessionRepositoryFilter]
 ----
 
-The http://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html[DelegatingFilterProxy] will look up a Bean by the name of `springSessionRepositoryFilter` and cast it to a `Filter`.
+The https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html[DelegatingFilterProxy] will look up a Bean by the name of `springSessionRepositoryFilter` and cast it to a `Filter`.
 For every request that `DelegatingFilterProxy` is invoked, the `springSessionRepositoryFilter` will be invoked.
 
 // end::config[]

--- a/docs/src/docs/asciidoc/guides/httpsession-jdbc.adoc
+++ b/docs/src/docs/asciidoc/guides/httpsession-jdbc.adoc
@@ -85,7 +85,7 @@ In this instance Spring Session is backed by a relational database.
 We configure the H2 database to create database tables using the SQL script which is included in Spring Session.
 <3> We create a `transactionManager` that manages transactions for previously configured `dataSource`.
 
-For additional information on how to configure data access related concerns, please refer to the http://docs.spring.io/spring/docs/current/spring-framework-reference/html/spring-data-tier.html[Spring Framework Reference Documentation].
+For additional information on how to configure data access related concerns, please refer to the https://docs.spring.io/spring/docs/current/spring-framework-reference/html/spring-data-tier.html[Spring Framework Reference Documentation].
 
 == Java Servlet Container Initialization
 

--- a/docs/src/docs/asciidoc/guides/httpsession-xml.adoc
+++ b/docs/src/docs/asciidoc/guides/httpsession-xml.adoc
@@ -90,7 +90,7 @@ The filter is what is in charge of replacing the `HttpSession` implementation to
 In this instance Spring Session is backed by Redis.
 <2> We create a `RedisConnectionFactory` that connects Spring Session to the Redis Server.
 We configure the connection to connect to localhost on the default port (6379)
-For more information on configuring Spring Data Redis, refer to the http://docs.spring.io/spring-data/data-redis/docs/current/reference/html/[reference documentation].
+For more information on configuring Spring Data Redis, refer to the https://docs.spring.io/spring-data/data-redis/docs/current/reference/html/[reference documentation].
 
 == XML Servlet Container Initialization
 
@@ -108,7 +108,7 @@ include::{samples-dir}httpsession-xml/src/main/webapp/WEB-INF/web.xml[tags=conte
 include::{samples-dir}httpsession-xml/src/main/webapp/WEB-INF/web.xml[tags=listeners]
 ----
 
-The http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#context-create[ContextLoaderListener] reads the contextConfigLocation and picks up our session.xml configuration.
+The https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#context-create[ContextLoaderListener] reads the contextConfigLocation and picks up our session.xml configuration.
 
 Last we need to ensure that our Servlet Container (i.e. Tomcat) uses our `springSessionRepositoryFilter` for every request.
 The following snippet performs this last step for us:
@@ -119,7 +119,7 @@ The following snippet performs this last step for us:
 include::{samples-dir}httpsession-xml/src/main/webapp/WEB-INF/web.xml[tags=springSessionRepositoryFilter]
 ----
 
-The http://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html[DelegatingFilterProxy] will look up a Bean by the name of `springSessionRepositoryFilter` and cast it to a `Filter`.
+The https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html[DelegatingFilterProxy] will look up a Bean by the name of `springSessionRepositoryFilter` and cast it to a `Filter`.
 For every request that `DelegatingFilterProxy` is invoked, the `springSessionRepositoryFilter` will be invoked.
 
 // end::config[]
@@ -133,7 +133,7 @@ You can run the sample by obtaining the {download-url}[source code] and invoking
 
 [NOTE]
 ====
-For the sample to work, you must http://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
+For the sample to work, you must https://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
 Alternatively, you can update the `LettuceConnectionFactory` to point to a Redis server.
 ====
 
@@ -170,7 +170,7 @@ If you like, you can easily remove the session using redis-cli. For example, on 
 
 	$ redis-cli keys '*' | xargs redis-cli del
 
-TIP: The Redis documentation has instructions for http://redis.io/topics/quickstart[installing redis-cli].
+TIP: The Redis documentation has instructions for https://redis.io/topics/quickstart[installing redis-cli].
 
 Alternatively, you can also delete the explicit key. Enter the following into your terminal ensuring to replace `7e8383a4-082c-4ffe-a4bc-c40fd3363c5e` with the value of your SESSION cookie:
 

--- a/docs/src/docs/asciidoc/guides/httpsession.adoc
+++ b/docs/src/docs/asciidoc/guides/httpsession.adoc
@@ -88,7 +88,7 @@ The filter is what is in charge of replacing the `HttpSession` implementation to
 In this instance Spring Session is backed by Redis.
 <2> We create a `RedisConnectionFactory` that connects Spring Session to the Redis Server.
 We configure the connection to connect to localhost on the default port (6379)
-For more information on configuring Spring Data Redis, refer to the http://docs.spring.io/spring-data/data-redis/docs/current/reference/html/[reference documentation].
+For more information on configuring Spring Data Redis, refer to the https://docs.spring.io/spring-data/data-redis/docs/current/reference/html/[reference documentation].
 
 == Java Servlet Container Initialization
 
@@ -125,7 +125,7 @@ You can run the sample by obtaining the {download-url}[source code] and invoking
 
 [NOTE]
 ====
-For the sample to work, you must http://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
+For the sample to work, you must https://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
 Alternatively, you can update the `LettuceConnectionFactory` to point to a Redis server.
 ====
 
@@ -162,7 +162,7 @@ If you like, you can easily remove the session using redis-cli. For example, on 
 
 	$ redis-cli keys '*' | xargs redis-cli del
 
-TIP: The Redis documentation has instructions for http://redis.io/topics/quickstart[installing redis-cli].
+TIP: The Redis documentation has instructions for https://redis.io/topics/quickstart[installing redis-cli].
 
 Alternatively, you can also delete the explicit key. Enter the following into your terminal ensuring to replace `7e8383a4-082c-4ffe-a4bc-c40fd3363c5e` with the value of your SESSION cookie:
 

--- a/docs/src/docs/asciidoc/guides/mongo.adoc
+++ b/docs/src/docs/asciidoc/guides/mongo.adoc
@@ -100,7 +100,7 @@ spring.data.mongodb.port=27018
 spring.data.mongodb.database=prod
 ----
 
-For more information, refer to http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-connecting-to-mongodb[Connecting to MongoDB] portion of the Spring Boot documentation.
+For more information, refer to https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-connecting-to-mongodb[Connecting to MongoDB] portion of the Spring Boot documentation.
 
 [[boot-servlet-configuration]]
 == Servlet Container Initialization

--- a/docs/src/docs/asciidoc/guides/rest.adoc
+++ b/docs/src/docs/asciidoc/guides/rest.adoc
@@ -88,7 +88,7 @@ The filter is what is in charge of replacing the `HttpSession` implementation to
 In this instance Spring Session is backed by Redis.
 <2> We create a `RedisConnectionFactory` that connects Spring Session to the Redis Server.
 We configure the connection to connect to localhost on the default port (6379)
-For more information on configuring Spring Data Redis, refer to the http://docs.spring.io/spring-data/data-redis/docs/current/reference/html/[reference documentation].
+For more information on configuring Spring Data Redis, refer to the https://docs.spring.io/spring-data/data-redis/docs/current/reference/html/[reference documentation].
 <3> We customize Spring Session's HttpSession integration to use HTTP headers to convey the current session information instead of cookies.
 
 == Servlet Container Initialization
@@ -126,7 +126,7 @@ You can run the sample by obtaining the {download-url}[source code] and invoking
 
 [NOTE]
 ====
-For the sample to work, you must http://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
+For the sample to work, you must https://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
 Alternatively, you can update the `LettuceConnectionFactory` to point to a Redis server.
 ====
 
@@ -208,7 +208,7 @@ Now remove the session using redis-cli. For example, on a Linux based system you
 
 	$ redis-cli keys '*' | xargs redis-cli del
 
-TIP: The Redis documentation has instructions for http://redis.io/topics/quickstart[installing redis-cli].
+TIP: The Redis documentation has instructions for https://redis.io/topics/quickstart[installing redis-cli].
 
 Alternatively, you can also delete the explicit key. Enter the following into your terminal ensuring to replace `7e8383a4-082c-4ffe-a4bc-c40fd3363c5e` with the value of your SESSION cookie:
 

--- a/docs/src/docs/asciidoc/guides/security.adoc
+++ b/docs/src/docs/asciidoc/guides/security.adoc
@@ -87,7 +87,7 @@ The filter is what is in charge of replacing the `HttpSession` implementation to
 In this instance Spring Session is backed by Redis.
 <2> We create a `RedisConnectionFactory` that connects Spring Session to the Redis Server.
 We configure the connection to connect to localhost on the default port (6379)
-For more information on configuring Spring Data Redis, refer to the http://docs.spring.io/spring-data/data-redis/docs/current/reference/html/[reference documentation].
+For more information on configuring Spring Data Redis, refer to the https://docs.spring.io/spring-data/data-redis/docs/current/reference/html/[reference documentation].
 
 == Servlet Container Initialization
 
@@ -130,7 +130,7 @@ You can run the sample by obtaining the {download-url}[source code] and invoking
 
 [NOTE]
 ====
-For the sample to work, you must http://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
+For the sample to work, you must https://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
 Alternatively, you can update the `LettuceConnectionFactory` to point to a Redis server.
 ====
 
@@ -164,7 +164,7 @@ If you like, you can easily remove the session using redis-cli. For example, on 
 
 	$ redis-cli keys '*' | xargs redis-cli del
 
-TIP: The Redis documentation has instructions for http://redis.io/topics/quickstart[installing redis-cli].
+TIP: The Redis documentation has instructions for https://redis.io/topics/quickstart[installing redis-cli].
 
 Alternatively, you can also delete the explicit key. Enter the following into your terminal ensuring to replace `7e8383a4-082c-4ffe-a4bc-c40fd3363c5e` with the value of your SESSION cookie:
 

--- a/docs/src/docs/asciidoc/guides/users.adoc
+++ b/docs/src/docs/asciidoc/guides/users.adoc
@@ -19,7 +19,7 @@ You can run the sample by obtaining the {download-url}[source code] and invoking
 
 [NOTE]
 ====
-For the sample to work, you must http://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
+For the sample to work, you must https://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
 Alternatively, you can update the `LettuceConnectionFactory` to point to a Redis server.
 ====
 
@@ -140,7 +140,7 @@ For example, if the URL is http://localhost:8080/?_s=1 this alias would be used.
 
 The nice thing about specifying the session alias in the URL is that we can have multiple tabs open with different active sessions.
 The bad thing is that we need to include the session alias in every URL of our application.
-Fortunately, Spring Session will automatically include the session alias in any URL that passes through http://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletResponse.html#encodeURL(java.lang.String)[HttpServletResponse#encodeURL(java.lang.String)]
+Fortunately, Spring Session will automatically include the session alias in any URL that passes through https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletResponse.html#encodeURL(java.lang.String)[HttpServletResponse#encodeURL(java.lang.String)]
 
 This means that if you are using standard tag libraries the session alias is automatically included in the URL.
 For example, if we are currently using the session with the alias of *1*, then the following:

--- a/docs/src/docs/asciidoc/guides/websocket.adoc
+++ b/docs/src/docs/asciidoc/guides/websocket.adoc
@@ -84,7 +84,7 @@ include::{samples-dir}websocket/src/main/java/sample/config/WebSecurityConfig.ja
 
 [NOTE]
 ====
-For the sample to work, you must http://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
+For the sample to work, you must https://redis.io/download[install Redis 2.8+] on localhost and run it with the default port (6379).
 Alternatively, you can update the `LettuceConnectionFactory` to point to a Redis server.
 ====
 

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -31,8 +31,8 @@ https://github.com/spring-projects/spring-session/milestone/18?closed=1[1.3.0.M2
 https://github.com/spring-projects/spring-session/milestone/16?closed=1[1.3.0.RC1], and
 https://github.com/spring-projects/spring-session/milestone/19?closed=1[1.3.0.RELEASE].
 
-* First class support for http://docs.spring.io/spring-session/docs/1.3.0.RELEASE/reference/html5/#httpsession-hazelcast[Hazelcast]
-* First class support for http://docs.spring.io/spring-session/docs/1.3.0.RELEASE/reference/html5/#spring-security-concurrent-sessions-how[Spring Security's concurrent session management]
+* First class support for https://docs.spring.io/spring-session/docs/1.3.0.RELEASE/reference/html5/#httpsession-hazelcast[Hazelcast]
+* First class support for https://docs.spring.io/spring-session/docs/1.3.0.RELEASE/reference/html5/#spring-security-concurrent-sessions-how[Spring Security's concurrent session management]
 * Added https://github.com/maseev/spring-session-orientdb[OrientDB Community Extension]
 * https://github.com/spring-projects/spring-session/tree/1.3.0.RELEASE/samples/httpsession-redis-json[GenericJackson2JsonRedisSerializer sample] with Spring Security's new Jackson Support
 * Guides now https://github.com/spring-projects/spring-session/pull/652[use Lettuce]
@@ -192,14 +192,14 @@ The two most common topologies to manage Spring Sessions using GemFire include:
 * <<httpsession-gemfire-clientserver,Client-Server>>
 * <<httpsession-gemfire-p2p,Peer-To-Peer (P2P)>>
 
-Additionally, GemFire supports site-to-site replication using http://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/multi_site_configuration/chapter_overview.html[WAN functionality].
+Additionally, GemFire supports site-to-site replication using https://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/multi_site_configuration/chapter_overview.html[WAN functionality].
 The ability to configure and use GemFire's WAN support is independent of Spring Session, and is beyond the scope
-of this document. More details on GemFire WAN functionality can be found http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#bootstrap:gateway[here].
+of this document. More details on GemFire WAN functionality can be found https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/#bootstrap:gateway[here].
 
 [[httpsession-gemfire-clientserver]]
 ==== GemFire Client-Server
 
-The http://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/cs_configuration/chapter_overview.html[Client-Server]
+The https://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/cs_configuration/chapter_overview.html[Client-Server]
 topology will probably be the more common configuration preference for users when using GemFire as a provider in
 Spring Session since a GemFire server will have significantly different and unique JVM heap requirements when compared
 to the application. Using a client-server topology enables an application to manage (e.g. replicate) application state
@@ -241,14 +241,14 @@ include::guides/httpsession-gemfire-clientserver-xml.adoc[tags=config,leveloffse
 ==== GemFire Peer-To-Peer (P2P)
 
 Perhaps less common would be to configure the Spring Session application as a peer member in the GemFire cluster using
-the http://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/p2p_configuration/chapter_overview.html[Peer-To-Peer (P2P)] topology.
+the https://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/p2p_configuration/chapter_overview.html[Peer-To-Peer (P2P)] topology.
 In this configuration, a Spring Session application would be an actual data node (server) in the GemFire cluster,
 and **not** a cache client as before.
 
 One advantage to this approach is the proximity of the application to the application's state (i.e. it's data). However,
 there are other effective means of accomplishing similar data dependent computations, such as using GemFire's
-http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/function_exec/chapter_overview.html[Function Execution].
-Any of GemFire's other http://gemfire.docs.pivotal.io/docs-gemfire/latest/getting_started/product_intro.html[features]
+https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/function_exec/chapter_overview.html[Function Execution].
+Any of GemFire's other https://gemfire.docs.pivotal.io/docs-gemfire/latest/getting_started/product_intro.html[features]
 can be used when GemFire is serving as a provider in Spring Session.
 
 P2P is very useful for both testing purposes as well as smaller, more focused and self-contained applications,
@@ -532,7 +532,7 @@ Spring Session provides integration with Spring Security.
 [[spring-security-rememberme]]
 === Spring Security Remember-Me Support
 
-Spring Session provides integration with http://docs.spring.io/spring-security/site/docs/4.2.x/reference/htmlsingle/#remember-me[Spring Security's Remember-Me Authentication].
+Spring Session provides integration with https://docs.spring.io/spring-security/site/docs/4.2.x/reference/htmlsingle/#remember-me[Spring Security's Remember-Me Authentication].
 The support will:
 
 * Change the session expiration length
@@ -737,7 +737,7 @@ You can customize the serialization by creating a Bean named `springSessionDefau
 
 `RedisOperationsSessionRepository` is subscribed to receive events from redis using a `RedisMessageListenerContainer`.
 You can customize the way those events are dispatched, by creating a Bean named `springSessionRedisTaskExecutor` and/or a Bean `springSessionRedisSubscriptionExecutor`.
-More details on configuring redis task executors can be found http://docs.spring.io/spring-data-redis/docs/current/reference/html/#redis:pubsub:subscribe:containers[here].
+More details on configuring redis task executors can be found https://docs.spring.io/spring-data-redis/docs/current/reference/html/#redis:pubsub:subscribe:containers[here].
 
 [[api-redisoperationssessionrepository-storage]]
 ==== Storage Details
@@ -816,7 +816,7 @@ The `SessionRepository.getSession(String)` method ensures that no expired sessio
 This means there is no need to check the expiration before using a session.
 ====
 
-Spring Session relies on the delete and expired http://redis.io/topics/notifications[keyspace notifications] from Redis to fire a <<api-redisoperationssessionrepository-sessiondestroyedevent,SessionDeletedEvent>> and <<api-redisoperationssessionrepository-sessiondestroyedevent,SessionExpiredEvent>> respectively.
+Spring Session relies on the delete and expired https://redis.io/topics/notifications[keyspace notifications] from Redis to fire a <<api-redisoperationssessionrepository-sessiondestroyedevent,SessionDeletedEvent>> and <<api-redisoperationssessionrepository-sessiondestroyedevent,SessionExpiredEvent>> respectively.
 It is the `SessionDeletedEvent` or `SessionExpiredEvent` that ensures resources associated with the Session are cleaned up.
 For example, when using Spring Session's WebSocket support the Redis expired or delete event is what triggers any WebSocket connections associated with the session to be closed.
 
@@ -831,7 +831,7 @@ When a session expires key is deleted or expires, the keyspace notification trig
 
 One problem with relying on Redis expiration exclusively is that Redis makes no guarantee of when the expired event will be fired if the key has not been accessed.
 Specifically the background task that Redis uses to clean up expired keys is a low priority task and may not trigger the key expiration.
-For additional details see http://redis.io/topics/notifications[Timing of expired events] section in the Redis documentation.
+For additional details see https://redis.io/topics/notifications[Timing of expired events] section in the Redis documentation.
 
 To circumvent the fact that expired events are not guaranteed to happen we can ensure that each key is accessed when it is expected to expire.
 This means that if the TTL is expired on the key, Redis will remove the key and fire the expired event when we try to access the key.
@@ -866,7 +866,7 @@ This is necessary to ensure resources associated with the `Session` are properly
 
 For example, when integrating with WebSockets the `SessionDestroyedEvent` is in charge of closing any active WebSocket connections.
 
-Firing `SessionDeletedEvent` or `SessionExpiredEvent` is made available through the `SessionMessageListener` which listens to http://redis.io/topics/notifications[Redis Keyspace events].
+Firing `SessionDeletedEvent` or `SessionExpiredEvent` is made available through the `SessionMessageListener` which listens to https://redis.io/topics/notifications[Redis Keyspace events].
 In order for this to work, Redis Keyspace events for Generic commands and Expired events needs to be enabled.
 For example:
 
@@ -905,7 +905,7 @@ If registered as a MessageListener (default), then `RedisOperationsSessionReposi
 [[api-redisoperationssessionrepository-cli]]
 ==== Viewing the Session in Redis
 
-After http://redis.io/topics/quickstart[installing redis-cli], you can inspect the values in Redis http://redis.io/commands#hash[using the redis-cli].
+After https://redis.io/topics/quickstart[installing redis-cli], you can inspect the values in Redis https://redis.io/commands#hash[using the redis-cli].
 For example, enter the following into a terminal:
 
 [source,bash]
@@ -1010,9 +1010,9 @@ Session attribute a value that is not `Comparable` and the Session is saved to G
 
 NOTE: Any Session attribute that is not indexed may store non-`Comparable` values.
 
-To learn more about GemFire's Range-based Indexes, see http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/query_index/creating_map_indexes.html[Creating Indexes on Map Fields].
+To learn more about GemFire's Range-based Indexes, see https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/query_index/creating_map_indexes.html[Creating Indexes on Map Fields].
 
-To learn more about GemFire Indexing in general, see http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/query_index/query_index.html[Working with Indexes].
+To learn more about GemFire Indexing in general, see https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/query_index/query_index.html[Working with Indexes].
 
 
 [[api-mapsessionrepository]]
@@ -1066,7 +1066,7 @@ A typical example of how to create a new instance can be seen below:
 include::{indexdoc-tests}[tags=new-jdbcoperationssessionrepository]
 ----
 
-For additional information on how to create and configure `JdbcTemplate` and `PlatformTransactionManager`, refer to the http://docs.spring.io/spring/docs/current/spring-framework-reference/html/spring-data-tier.html[Spring Framework Reference Documentation].
+For additional information on how to create and configure `JdbcTemplate` and `PlatformTransactionManager`, refer to the https://docs.spring.io/spring/docs/current/spring-framework-reference/html/spring-data-tier.html[Spring Framework Reference Documentation].
 
 [[api-jdbcoperationssessionrepository-config]]
 ==== EnableJdbcHttpSession
@@ -1133,12 +1133,12 @@ A typical example of how to create a new instance can be seen below:
 include::{indexdoc-tests}[tags=new-hazelcastsessionrepository]
 ----
 
-For additional information on how to create and configure Hazelcast instance, refer to the http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#hazelcast-configuration[Hazelcast documentation].
+For additional information on how to create and configure Hazelcast instance, refer to the https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#hazelcast-configuration[Hazelcast documentation].
 
 [[api-enablehazelcasthttpsession]]
 ==== EnableHazelcastHttpSession
 
-If you wish to use http://hazelcast.org/[Hazelcast] as your backing source for the `SessionRepository`, then the `@EnableHazelcastHttpSession` annotation
+If you wish to use https://hazelcast.org/[Hazelcast] as your backing source for the `SessionRepository`, then the `@EnableHazelcastHttpSession` annotation
 can be added to an `@Configuration` class. This extends the functionality provided by the `@EnableSpringHttpSession` annotation but makes the `SessionRepository` for you in Hazelcast.
 You must provide a single `HazelcastInstance` bean for the configuration to work.
 Complete configuration example can be found in the <<samples>>
@@ -1174,7 +1174,7 @@ Please find additional information below.
 [[community-support]]
 === Support
 
-You can get help by asking questions on http://stackoverflow.com/questions/tagged/spring-session[StackOverflow with the tag spring-session].
+You can get help by asking questions on https://stackoverflow.com/questions/tagged/spring-session[StackOverflow with the tag spring-session].
 Similarly we encourage helping others by answering questions on StackOverflow.
 
 [[community-source]]
@@ -1207,7 +1207,7 @@ Spring Session is Open Source software released under the https://www.apache.org
 | https://github.com/maseev/spring-session-orientdb
 
 | Spring Session Infinispan
-| http://infinispan.org/docs/dev/user_guide/user_guide.html#externalizing_session_using_spring_session
+| https://infinispan.org/docs/dev/user_guide/user_guide.html#externalizing_session_using_spring_session
 
 |===
 

--- a/samples/boot/src/main/resources/templates/index.html
+++ b/samples/boot/src/main/resources/templates/index.html
@@ -1,4 +1,4 @@
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layout">
+<html xmlns:th="https://www.thymeleaf.org" xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect" layout:decorator="layout">
 <head>
 	<title>Secured Content</title>
 </head>

--- a/samples/boot/src/main/resources/templates/layout.html
+++ b/samples/boot/src/main/resources/templates/layout.html
@@ -1,7 +1,7 @@
-<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
+<!DOCTYPE html SYSTEM "https://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-			xmlns:th="http://www.thymeleaf.org"
-			xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+			xmlns:th="https://www.thymeleaf.org"
+			xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect">
 	<head>
 		<title layout:title-pattern="$DECORATOR_TITLE - $CONTENT_TITLE">Spring Session Sample</title>
 		<link rel="icon" type="image/x-icon" th:href="@{/resources/img/favicon.ico}" href="../static/img/favicon.ico"/>
@@ -115,7 +115,7 @@
 
 		<div id="footer">
 			<div class="container">
-				<p class="muted credit">Visit the <a href="http://spring.io/spring-security">Spring Security</a> site for more <a href="https://github.com/spring-projects/spring-security/blob/master/samples/">samples</a>.</p>
+				<p class="muted credit">Visit the <a href="https://spring.io/spring-security">Spring Security</a> site for more <a href="https://github.com/spring-projects/spring-security/blob/master/samples/">samples</a>.</p>
 			</div>
 		</div>
 	</body>

--- a/samples/findbyusername/README.adoc
+++ b/samples/findbyusername/README.adoc
@@ -1,4 +1,4 @@
 Demonstrates using Spring Session to lookup a user's session by the username.
 The sample provides a hook to add the current username to the session (required for finding the user) by providing a custom implementation of Spring Security's `AuthenticationSuccessHandler`.
 
-NOTE: This product includes GeoLite2 data created by MaxMind, available from http://www.maxmind.com
+NOTE: This product includes GeoLite2 data created by MaxMind, available from https://www.maxmind.com

--- a/samples/findbyusername/src/main/resources/templates/index.html
+++ b/samples/findbyusername/src/main/resources/templates/index.html
@@ -1,4 +1,4 @@
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layout">
+<html xmlns:th="https://www.thymeleaf.org" xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect" layout:decorator="layout">
 <head>
 	<title>Secured Content</title>
 </head>

--- a/samples/findbyusername/src/main/resources/templates/layout.html
+++ b/samples/findbyusername/src/main/resources/templates/layout.html
@@ -1,7 +1,7 @@
-<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
+<!DOCTYPE html SYSTEM "https://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-			xmlns:th="http://www.thymeleaf.org"
-			xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+			xmlns:th="https://www.thymeleaf.org"
+			xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect">
 	<head>
 		<title layout:title-pattern="$DECORATOR_TITLE - $CONTENT_TITLE">Spring Session Sample</title>
 		<link rel="icon" type="image/x-icon" th:href="@{/resources/img/favicon.ico}" href="../static/img/favicon.ico"/>
@@ -115,7 +115,7 @@
 
 		<div id="footer">
 			<div class="container">
-				<p class="muted credit">This product includes GeoLite2 data created by MaxMind, available from <a href="http://www.maxmind.com">http://www.maxmind.com</a>.</p>
+				<p class="muted credit">This product includes GeoLite2 data created by MaxMind, available from <a href="https://www.maxmind.com">https://www.maxmind.com</a>.</p>
 			</div>
 		</div>
 	</body>

--- a/samples/findbyusername/src/main/resources/templates/login.html
+++ b/samples/findbyusername/src/main/resources/templates/login.html
@@ -1,5 +1,5 @@
-<html xmlns:th="http://www.thymeleaf.org"
-	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+<html xmlns:th="https://www.thymeleaf.org"
+	xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect"
 	layout:decorator="layout">
 <head>
 <title>Log In</title>

--- a/samples/grails3/grails-app/conf/logback.groovy
+++ b/samples/grails3/grails-app/conf/logback.groovy
@@ -1,7 +1,7 @@
 import grails.util.BuildSettings
 import grails.util.Environment
 
-// See http://logback.qos.ch/manual/groovy.html for details on configuration
+// See https://logback.qos.ch/manual/groovy.html for details on configuration
 appender('STDOUT', ConsoleAppender) {
     encoder(PatternLayoutEncoder) {
         pattern = "%level %logger - %msg%n"

--- a/samples/httpsession-gemfire-boot/src/main/resources/templates/index.html
+++ b/samples/httpsession-gemfire-boot/src/main/resources/templates/index.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<!DOCTYPE html SYSTEM "https://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org">
 <head>
 	<title>Session Attributes</title>
 	<link rel="stylesheet" th:href="@{/webjars/bootstrap/css/bootstrap.min.css}" href="/webjars/bootstrap/css/bootstrap.min.css"/>

--- a/samples/httpsession-jdbc-boot/src/main/resources/templates/index.html
+++ b/samples/httpsession-jdbc-boot/src/main/resources/templates/index.html
@@ -1,4 +1,4 @@
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layout">
+<html xmlns:th="https://www.thymeleaf.org" xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect" layout:decorator="layout">
 <head>
 	<title>Secured Content</title>
 </head>

--- a/samples/httpsession-jdbc-boot/src/main/resources/templates/layout.html
+++ b/samples/httpsession-jdbc-boot/src/main/resources/templates/layout.html
@@ -1,7 +1,7 @@
-<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
+<!DOCTYPE html SYSTEM "https://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-			xmlns:th="http://www.thymeleaf.org"
-			xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+			xmlns:th="https://www.thymeleaf.org"
+			xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect">
 	<head>
 		<title layout:title-pattern="$DECORATOR_TITLE - $CONTENT_TITLE">Spring Session Sample</title>
 		<link rel="icon" type="image/x-icon" th:href="@{/resources/img/favicon.ico}" href="../static/img/favicon.ico"/>
@@ -115,7 +115,7 @@
 
 		<div id="footer">
 			<div class="container">
-				<p class="muted credit">Visit the <a href="http://spring.io/spring-security">Spring Security</a> site for more <a href="https://github.com/spring-projects/spring-security/blob/master/samples/">samples</a>.</p>
+				<p class="muted credit">Visit the <a href="https://spring.io/spring-security">Spring Security</a> site for more <a href="https://github.com/spring-projects/spring-security/blob/master/samples/">samples</a>.</p>
 			</div>
 		</div>
 	</body>

--- a/samples/httpsession-redis-json/src/main/resources/templates/home.html
+++ b/samples/httpsession-redis-json/src/main/resources/templates/home.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layout">
+<html xmlns:th="https://www.thymeleaf.org" xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect" layout:decorator="layout">
 <head>
     <meta charset="UTF-8"/>
     <title>Home</title>

--- a/samples/httpsession-redis-json/src/main/resources/templates/layout.html
+++ b/samples/httpsession-redis-json/src/main/resources/templates/layout.html
@@ -1,7 +1,7 @@
-<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
+<!DOCTYPE html SYSTEM "https://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-			xmlns:th="http://www.thymeleaf.org"
-			xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+			xmlns:th="https://www.thymeleaf.org"
+			xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect">
 	<head>
 		<title layout:title-pattern="$DECORATOR_TITLE - $CONTENT_TITLE">Spring Session Sample</title>
 		<link rel="icon" type="image/x-icon" th:href="@{/resources/img/favicon.ico}" href="../static/img/favicon.ico"/>
@@ -69,7 +69,7 @@
 
 		<!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
 		<!--[if lt IE 9]>
-			<script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+			<script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
 		<![endif]-->
 	</head>
 

--- a/samples/httpsession-redis-json/src/main/resources/templates/login.html
+++ b/samples/httpsession-redis-json/src/main/resources/templates/login.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layout">
+<html xmlns:th="https://www.thymeleaf.org" xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect" layout:decorator="layout">
 <head>
     <meta charset="UTF-8"/>
     <title>Login</title>

--- a/samples/mongo/src/main/resources/templates/index.html
+++ b/samples/mongo/src/main/resources/templates/index.html
@@ -1,4 +1,4 @@
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layout">
+<html xmlns:th="https://www.thymeleaf.org" xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect" layout:decorator="layout">
 <head>
 	<title>Secured Content</title>
 </head>

--- a/samples/mongo/src/main/resources/templates/layout.html
+++ b/samples/mongo/src/main/resources/templates/layout.html
@@ -1,7 +1,7 @@
-<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
+<!DOCTYPE html SYSTEM "https://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-			xmlns:th="http://www.thymeleaf.org"
-			xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+			xmlns:th="https://www.thymeleaf.org"
+			xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect">
 	<head>
 		<title layout:title-pattern="$DECORATOR_TITLE - $CONTENT_TITLE">Spring Session Sample</title>
 		<link rel="icon" type="image/x-icon" th:href="@{/resources/img/favicon.ico}" href="../static/img/favicon.ico"/>
@@ -115,7 +115,7 @@
 
 		<div id="footer">
 			<div class="container">
-				<p class="muted credit">Visit the <a href="http://spring.io/spring-security">Spring Security</a> site for more <a href="https://github.com/spring-projects/spring-security/blob/master/samples/">samples</a>.</p>
+				<p class="muted credit">Visit the <a href="https://spring.io/spring-security">Spring Security</a> site for more <a href="https://github.com/spring-projects/spring-security/blob/master/samples/">samples</a>.</p>
 			</div>
 		</div>
 	</body>

--- a/samples/users/src/main/webapp/assets/js/ie10-viewport-bug-workaround.js
+++ b/samples/users/src/main/webapp/assets/js/ie10-viewport-bug-workaround.js
@@ -2,11 +2,11 @@
  * IE10 viewport hack for Surface/desktop Windows 8 bug
  * Copyright 2014 Twitter, Inc.
  * Licensed under the Creative Commons Attribution 3.0 Unported License. For
- * details, see http://creativecommons.org/licenses/by/3.0/.
+ * details, see https://creativecommons.org/licenses/by/3.0/.
  */
 
 // See the Getting Started docs for more information:
-// http://getbootstrap.com/getting-started/#support-ie10-width
+// https://getbootstrap.com/getting-started/#support-ie10-width
 
 (function () {
   'use strict';

--- a/samples/websocket/src/main/resources/templates/index.html
+++ b/samples/websocket/src/main/resources/templates/index.html
@@ -1,4 +1,4 @@
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layout">
+<html xmlns:th="https://www.thymeleaf.org" xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect" layout:decorator="layout">
 <head>
 	<title>View All</title>
 </head>

--- a/samples/websocket/src/main/resources/templates/layout.html
+++ b/samples/websocket/src/main/resources/templates/layout.html
@@ -1,7 +1,7 @@
-<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
+<!DOCTYPE html SYSTEM "https://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-	  xmlns:th="http://www.thymeleaf.org"
-	  xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+	  xmlns:th="https://www.thymeleaf.org"
+	  xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect">
 <head>
 	<title layout:title-pattern="$DECORATOR_TITLE - $CONTENT_TITLE">SecureMail</title>
 	<link rel="icon" type="image/x-icon" th:href="@{/resources/img/favicon.ico}" href="../static/img/favicon.ico"/>
@@ -117,7 +117,7 @@
 
 	<div id="footer">
 	  <div class="container">
-		<p class="muted credit">Visit the <a href="http://spring.io/spring-security">Spring Security</a> site for more <a href="https://github.com/spring-projects/spring-security/blob/master/samples/">samples</a>.</p>
+		<p class="muted credit">Visit the <a href="https://spring.io/spring-security">Spring Security</a> site for more <a href="https://github.com/spring-projects/spring-security/blob/master/samples/">samples</a>.</p>
 	  </div>
 	</div>
 </body>

--- a/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
@@ -71,7 +71,7 @@ import org.springframework.util.Assert;
  *
  * <p>
  * For additional information on how to create a RedisTemplate, refer to the
- * <a href = "http://docs.spring.io/spring-data/data-redis/docs/current/reference/html/" >
+ * <a href = "https://docs.spring.io/spring-data/data-redis/docs/current/reference/html/" >
  * Spring Data Redis Reference</a>.
  * </p>
  *
@@ -94,8 +94,8 @@ import org.springframework.util.Assert;
  *
  * <p>
  * Each session is stored in Redis as a
- * <a href="http://redis.io/topics/data-types#hashes">Hash</a>. Each session is set and
- * updated using the <a href="http://redis.io/commands/hmset">HMSET command</a>. An
+ * <a href="https://redis.io/topics/data-types#hashes">Hash</a>. Each session is set and
+ * updated using the <a href="https://redis.io/commands/hmset">HMSET command</a>. An
  * example of how each session is stored can be seen below.
  * </p>
  *
@@ -151,7 +151,7 @@ import org.springframework.util.Assert;
  *
  * <p>
  * An expiration is associated to each session using the
- * <a href="http://redis.io/commands/expire">EXPIRE command</a> based upon the
+ * <a href="https://redis.io/commands/expire">EXPIRE command</a> based upon the
  * {@link org.springframework.session.data.redis.RedisOperationsSessionRepository.RedisSession#getMaxInactiveIntervalInSeconds()}
  * . For example:
  * </p>
@@ -176,7 +176,7 @@ import org.springframework.util.Assert;
  *
  * <p>
  * Spring Session relies on the expired and delete
- * <a href="http://redis.io/topics/notifications">keyspace notifications</a> from Redis to
+ * <a href="https://redis.io/topics/notifications">keyspace notifications</a> from Redis to
  * fire a SessionDestroyedEvent. It is the SessionDestroyedEvent that ensures resources
  * associated with the Session are cleaned up. For example, when using Spring Session's
  * WebSocket support the Redis expired or delete event is what triggers any WebSocket
@@ -204,7 +204,7 @@ import org.springframework.util.Assert;
  * guarantee of when the expired event will be fired if the key has not been accessed.
  * Specifically the background task that Redis uses to clean up expired keys is a low
  * priority task and may not trigger the key expiration. For additional details see
- * <a href="http://redis.io/topics/notifications">Timing of expired events</a> section in
+ * <a href="https://redis.io/topics/notifications">Timing of expired events</a> section in
  * the Redis documentation.
  * </p>
  *

--- a/spring-session/src/main/java/org/springframework/session/data/redis/config/ConfigureNotifyKeyspaceEventsAction.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/config/ConfigureNotifyKeyspaceEventsAction.java
@@ -79,7 +79,7 @@ public class ConfigureNotifyKeyspaceEventsAction implements ConfigureRedisAction
 		}
 		catch (InvalidDataAccessApiUsageException e) {
 			throw new IllegalStateException(
-					"Unable to configure Redis to keyspace notifications. See http://docs.spring.io/spring-session/docs/current/reference/html5/#api-redisoperationssessionrepository-sessiondestroyedevent",
+					"Unable to configure Redis to keyspace notifications. See https://docs.spring.io/spring-session/docs/current/reference/html5/#api-redisoperationssessionrepository-sessiondestroyedevent",
 					e);
 		}
 	}

--- a/spring-session/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/jdbc/JdbcOperationsSessionRepository.java
@@ -83,7 +83,7 @@ import org.springframework.util.StringUtils;
  *
  * For additional information on how to create and configure {@link JdbcTemplate} and
  * {@link PlatformTransactionManager}, refer to the
- * <a href="http://docs.spring.io/spring/docs/current/spring-framework-reference/html/spring-data-tier.html">
+ * <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/html/spring-data-tier.html">
  * Spring Framework Reference Documentation</a>.
  * <p>
  * By default, this implementation uses <code>SPRING_SESSION</code> and

--- a/spring-session/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/EnableJdbcHttpSession.java
+++ b/spring-session/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/EnableJdbcHttpSession.java
@@ -59,7 +59,7 @@ import org.springframework.session.jdbc.JdbcOperationsSessionRepository;
  *
  * For additional information on how to configure data access related concerns, please
  * refer to the
- * <a href="http://docs.spring.io/spring/docs/current/spring-framework-reference/html/spring-data-tier.html">
+ * <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/html/spring-data-tier.html">
  * Spring Framework Reference Documentation</a>.
  *
  * @author Vedran Pavic

--- a/spring-session/src/main/java/org/springframework/session/web/http/Base64.java
+++ b/spring-session/src/main/java/org/springframework/session/web/http/Base64.java
@@ -18,7 +18,7 @@ package org.springframework.session.web.http;
 /**
  * Base64 encoder which is a reduced version of Robert Harder's public domain
  * implementation (version 2.3.7). See <a
- * href="http://iharder.net/base64">http://iharder.net/base64</a> for more information.
+ * href="http://iharder.sourceforge.net/current/java/base64/">http://iharder.sourceforge.net/current/java/base64/</a> for more information.
  * <p>
  * For internal use only.
  *
@@ -42,7 +42,7 @@ final class Base64 {
 	/**
 	 * Encode using Base64-like encoding that is URL- and Filename-safe as described in
 	 * Section 4 of RFC3548: <a
-	 * href="http://www.faqs.org/rfcs/rfc3548.html">http://www.faqs
+	 * href="http://www.faqs.org/rfcs/rfc3548.html">https://www.faqs
 	 * .org/rfcs/rfc3548.html</a>. It is important to note that data encoded this way is
 	 * <em>not</em> officially valid Base64, or at the very least should not be called
 	 * Base64 without also specifying that is was encoded using the URL- and Filename-safe
@@ -192,7 +192,7 @@ final class Base64 {
 	/**
 	 * I don't get the point of this technique, but someone requested it, and it is
 	 * described here: <a
-	 * href="http://www.faqs.org/qa/rfcc-1940.html">http://www.faqs.org/
+	 * href="http://www.faqs.org/qa/rfcc-1940.html">http://www.faqs.org/faqs/
 	 * qa/rfcc-1940.html</a>.
 	 */
 	private final static byte[] _ORDERED_ALPHABET = { (byte) '-', (byte) '0', (byte) '1',


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://www.faqs.org/qa/rfcc-1940.html (200) with 3 occurrences could not be migrated:  
   ([https](https://www.faqs.org/qa/rfcc-1940.html) result AnnotatedConnectException).
* [ ] http://www.faqs.org/rfcs/rfc3548.html (200) with 3 occurrences could not be migrated:  
   ([https](https://www.faqs.org/rfcs/rfc3548.html) result AnnotatedConnectException).
* [ ] http://www.faqs.org/ (301) with 1 occurrences could not be migrated:  
   ([https](https://www.faqs.org/) result AnnotatedConnectException).
* [ ] http://www.somehost.com/some/path (302) with 4 occurrences could not be migrated:  
   ([https](https://www.somehost.com/some/path) result ConnectTimeoutException).
* [ ] http://www.somehost.com/some/path?%s=5 (302) with 2 occurrences could not be migrated:  
   ([https](https://www.somehost.com/some/path?%s=5) result ConnectTimeoutException).
* [ ] http://www.somehost.com/some/path?a=b (302) with 4 occurrences could not be migrated:  
   ([https](https://www.somehost.com/some/path?a=b) result ConnectTimeoutException).
* [ ] http://www.somehost.com/some/path?a=b&%s=5&c=d (302) with 2 occurrences could not be migrated:  
   ([https](https://www.somehost.com/some/path?a=b&%s=5&c=d) result ConnectTimeoutException).
* [ ] http://iharder.net/base64 (303) with 2 occurrences could not be migrated:  
   ([https](https://iharder.net/base64) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.ultraq.net.nz/thymeleaf/layout (302) with 14 occurrences migrated to:  
  https://github.com/ultraq/thymeleaf-layout-dialect ([https](https://www.ultraq.net.nz/thymeleaf/layout) result ConnectTimeoutException).
* [ ] http://192.168.1.100:8080/ (AnnotatedConnectException) with 1 occurrences migrated to:  
  https://192.168.1.100:8080/ ([https](https://192.168.1.100:8080/) result ConnectTimeoutException).
* [ ] http://www.faqs (UnknownHostException) with 1 occurrences migrated to:  
  https://www.faqs ([https](https://www.faqs) result UnknownHostException).
* [ ] http://html5shim.googlecode.com/svn/trunk/html5.js (404) with 1 occurrences migrated to:  
  https://html5shim.googlecode.com/svn/trunk/html5.js ([https](https://html5shim.googlecode.com/svn/trunk/html5.js) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by/3.0/ ([https](https://creativecommons.org/licenses/by/3.0/) result 200).
* [ ] http://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/RegionShortcut.html with 2 occurrences migrated to:  
  https://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/RegionShortcut.html ([https](https://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/RegionShortcut.html) result 200).
* [ ] http://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/client/ClientRegionShortcut.html with 1 occurrences migrated to:  
  https://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/client/ClientRegionShortcut.html ([https](https://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/client/ClientRegionShortcut.html) result 200).
* [ ] http://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/client/PoolFactory.html with 1 occurrences migrated to:  
  https://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/client/PoolFactory.html ([https](https://data-docs-samples.cfapps.io/docs-gemfire/latest/javadocs/japi/com/gemstone/gemfire/cache/client/PoolFactory.html) result 200).
* [ ] http://docs.hazelcast.org/docs/latest/manual/html-single/index.html with 8 occurrences migrated to:  
  https://docs.hazelcast.org/docs/latest/manual/html-single/index.html ([https](https://docs.hazelcast.org/docs/latest/manual/html-single/index.html) result 200).
* [ ] http://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletResponse.html with 1 occurrences migrated to:  
  https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletResponse.html ([https](https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletResponse.html) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ with 4 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-data-gemfire/docs/current/reference/html/ with 6 occurrences migrated to:  
  https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/ ([https](https://docs.spring.io/spring-data-gemfire/docs/current/reference/html/) result 200).
* [ ] http://docs.spring.io/spring-data-redis/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data-redis/docs/current/reference/html/ ([https](https://docs.spring.io/spring-data-redis/docs/current/reference/html/) result 200).
* [ ] http://docs.spring.io/spring-data/data-redis/docs/current/reference/html/ with 5 occurrences migrated to:  
  https://docs.spring.io/spring-data/data-redis/docs/current/reference/html/ ([https](https://docs.spring.io/spring-data/data-redis/docs/current/reference/html/) result 200).
* [ ] http://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html with 4 occurrences migrated to:  
  https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html ([https](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/filter/DelegatingFilterProxy.html) result 200).
* [ ] http://docs.spring.io/spring-security/site/docs/4.2.x/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-security/site/docs/4.2.x/reference/htmlsingle/ ([https](https://docs.spring.io/spring-security/site/docs/4.2.x/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-session/docs/1.3.0.RELEASE/reference/html5/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-session/docs/1.3.0.RELEASE/reference/html5/ ([https](https://docs.spring.io/spring-session/docs/1.3.0.RELEASE/reference/html5/) result 200).
* [ ] http://docs.spring.io/spring-session/docs/current/reference/html5/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-session/docs/current/reference/html5/ ([https](https://docs.spring.io/spring-session/docs/current/reference/html5/) result 200).
* [ ] http://getbootstrap.com/getting-started/ with 1 occurrences migrated to:  
  https://getbootstrap.com/getting-started/ ([https](https://getbootstrap.com/getting-started/) result 200).
* [ ] http://hazelcast.org/ with 1 occurrences migrated to:  
  https://hazelcast.org/ ([https](https://hazelcast.org/) result 200).
* [ ] http://infinispan.org/docs/dev/user_guide/user_guide.html with 1 occurrences migrated to:  
  https://infinispan.org/docs/dev/user_guide/user_guide.html ([https](https://infinispan.org/docs/dev/user_guide/user_guide.html) result 200).
* [ ] http://logback.qos.ch/manual/groovy.html with 1 occurrences migrated to:  
  https://logback.qos.ch/manual/groovy.html ([https](https://logback.qos.ch/manual/groovy.html) result 200).
* [ ] http://projects.spring.io/spring-session/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-session/ ([https](https://projects.spring.io/spring-session/) result 200).
* [ ] http://redis.io/commands with 1 occurrences migrated to:  
  https://redis.io/commands ([https](https://redis.io/commands) result 200).
* [ ] http://redis.io/commands/expire with 1 occurrences migrated to:  
  https://redis.io/commands/expire ([https](https://redis.io/commands/expire) result 200).
* [ ] http://redis.io/commands/hmset with 1 occurrences migrated to:  
  https://redis.io/commands/hmset ([https](https://redis.io/commands/hmset) result 200).
* [ ] http://redis.io/download with 10 occurrences migrated to:  
  https://redis.io/download ([https](https://redis.io/download) result 200).
* [ ] http://redis.io/topics/data-types with 1 occurrences migrated to:  
  https://redis.io/topics/data-types ([https](https://redis.io/topics/data-types) result 200).
* [ ] http://redis.io/topics/notifications with 5 occurrences migrated to:  
  https://redis.io/topics/notifications ([https](https://redis.io/topics/notifications) result 200).
* [ ] http://redis.io/topics/quickstart with 7 occurrences migrated to:  
  https://redis.io/topics/quickstart ([https](https://redis.io/topics/quickstart) result 200).
* [ ] http://stackoverflow.com with 1 occurrences migrated to:  
  https://stackoverflow.com ([https](https://stackoverflow.com) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-session with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-session ([https](https://stackoverflow.com/questions/tagged/spring-session) result 200).
* [ ] http://stackoverflow.com/tags/spring-session with 1 occurrences migrated to:  
  https://stackoverflow.com/tags/spring-session ([https](https://stackoverflow.com/tags/spring-session) result 200).
* [ ] http://www.thymeleaf.org with 15 occurrences migrated to:  
  https://www.thymeleaf.org ([https](https://www.thymeleaf.org) result 200).
* [ ] http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd with 7 occurrences migrated to:  
  https://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd ([https](https://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-spring4-3.dtd) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/html/spring-data-tier.html with 5 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/html/spring-data-tier.html ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/spring-data-tier.html) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ with 4 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/getting_started/installation/install_intro.html with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/getting_started/installation/install_intro.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/getting_started/installation/install_intro.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/function_exec/chapter_overview.html with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/function_exec/chapter_overview.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/function_exec/chapter_overview.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/management_all_region_types/chapter_overview.html with 5 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/management_all_region_types/chapter_overview.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/management_all_region_types/chapter_overview.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/query_index/creating_map_indexes.html with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/query_index/creating_map_indexes.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/query_index/creating_map_indexes.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/query_index/query_index.html with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/query_index/query_index.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/latest/developing/query_index/query_index.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/latest/getting_started/product_intro.html with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/latest/getting_started/product_intro.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/latest/getting_started/product_intro.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/latest/reference/topics/gemfire_properties.html with 3 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/latest/reference/topics/gemfire_properties.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/latest/reference/topics/gemfire_properties.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/latest/tools_modules/gfsh/chapter_overview.html with 5 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/latest/tools_modules/gfsh/chapter_overview.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/latest/tools_modules/gfsh/chapter_overview.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/cs_configuration/chapter_overview.html with 4 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/cs_configuration/chapter_overview.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/cs_configuration/chapter_overview.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/multi_site_configuration/chapter_overview.html with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/multi_site_configuration/chapter_overview.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/multi_site_configuration/chapter_overview.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/p2p_configuration/chapter_overview.html with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/p2p_configuration/chapter_overview.html ([https](https://gemfire.docs.pivotal.io/docs-gemfire/latest/topologies_and_comm/p2p_configuration/chapter_overview.html) result 302).
* [ ] http://gemfire.docs.pivotal.io/gemfire/getting_started/installation/install_intro.html with 1 occurrences migrated to:  
  https://gemfire.docs.pivotal.io/gemfire/getting_started/installation/install_intro.html ([https](https://gemfire.docs.pivotal.io/gemfire/getting_started/installation/install_intro.html) result 302).
* [ ] http://spring.io/spring-security with 4 occurrences migrated to:  
  https://spring.io/spring-security ([https](https://spring.io/spring-security) result 302).
* [ ] http://www.maxmind.com with 3 occurrences migrated to:  
  https://www.maxmind.com ([https](https://www.maxmind.com) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/jsp/jstl/core with 14 occurrences
* http://localhost:8080/ with 45 occurrences
* http://localhost:8080/?_s=0 with 1 occurrences
* http://localhost:8080/?_s=1 with 2 occurrences
* http://localhost:8080/h2-console/ with 3 occurrences
* http://localhost:8080/logout with 1 occurrences
* http://localhost:8080/test/index with 2 occurrences
* http://localhost:xxxxx/hazelcast/rest/maps/spring:session:sessions/7e8383a4-082c-4ffe-a4bc-c40fd3363c5e with 1 occurrences
* http://www.w3.org/1999/xhtml with 7 occurrences
* http://www.webjars.org/tags with 14 occurrences