### PR TITLE
1.3.x

### DIFF
--- a/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/RedisOperationsSessionRepository.java
@@ -429,7 +429,11 @@ public class RedisOperationsSessionRepository implements
 	 * @return the Redis session
 	 */
 	private RedisSession getSession(String id, boolean allowExpired) {
-		Map<Object, Object> entries = getSessionBoundHashOperations(id).entries();
+		BoundHashOperations<Object, Object, Object> sessionBoundHashOperations = getSessionBoundHashOperations(id);
+		if (sessionBoundHashOperations == null) {
+			return null;
+		}
+		Map<Object, Object> entries = sessionBoundHashOperations.entries();
 		if (entries.isEmpty()) {
 			return null;
 		}

--- a/spring-session/src/main/java/org/springframework/session/data/redis/RedisSessionExpirationPolicy.java
+++ b/spring-session/src/main/java/org/springframework/session/data/redis/RedisSessionExpirationPolicy.java
@@ -129,11 +129,15 @@ final class RedisSessionExpirationPolicy {
 
 		String expirationKey = getExpirationKey(prevMin);
 		Set<Object> sessionsToExpire = this.redis.boundSetOps(expirationKey).members();
-		this.redis.delete(expirationKey);
 		for (Object session : sessionsToExpire) {
 			String sessionKey = getSessionKey((String) session);
+
+			String sessionId = sessionKey.substring(sessionKey.lastIndexOf(":") + 1);
+			this.redisSession.delete(sessionId);
+
 			touch(sessionKey);
 		}
+		this.redis.delete(expirationKey);
 	}
 
 	/**


### PR DESCRIPTION
When remove the expired key, call the SessionRepository to remove the session ID from the index too
Fix issue: https://github.com/spring-projects/spring-session/issues/1395