### PR TITLE
Use wnameless/oracle-xe-11g-r2 for Oracle testing

### DIFF
--- a/spring-session-jdbc/src/integration-test/resources/testcontainers.properties
+++ b/spring-session-jdbc/src/integration-test/resources/testcontainers.properties
@@ -1,1 +1,2 @@
 ryuk.container.timeout=120
+oracle.container.image=wnameless/oracle-xe-11g-r2


### PR DESCRIPTION
According to https://github.com/wnameless/docker-oracle-xe-11g the DMCA issues have been resolved.

This change allows Oracle integration tests to be run.