### PR TITLE
Parse expression only once in PrincipalNameIndexResolver

### DIFF
--- a/spring-session-core/src/main/java/org/springframework/session/PrincipalNameIndexResolver.java
+++ b/spring-session-core/src/main/java/org/springframework/session/PrincipalNameIndexResolver.java
@@ -34,6 +34,8 @@ public class PrincipalNameIndexResolver<S extends Session> extends SingleIndexRe
 
 	private static final SpelExpressionParser parser = new SpelExpressionParser();
 
+	private static final Expression expression = parser.parseExpression("authentication?.name");
+
 	public PrincipalNameIndexResolver() {
 		super(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME);
 	}
@@ -45,7 +47,6 @@ public class PrincipalNameIndexResolver<S extends Session> extends SingleIndexRe
 		}
 		Object authentication = session.getAttribute(SPRING_SECURITY_CONTEXT);
 		if (authentication != null) {
-			Expression expression = parser.parseExpression("authentication?.name");
 			return expression.getValue(authentication, String.class);
 		}
 		return null;

--- a/spring-session-core/src/main/java/org/springframework/session/PrincipalNameIndexResolver.java
+++ b/spring-session-core/src/main/java/org/springframework/session/PrincipalNameIndexResolver.java
@@ -32,9 +32,7 @@ public class PrincipalNameIndexResolver<S extends Session> extends SingleIndexRe
 
 	private static final String SPRING_SECURITY_CONTEXT = "SPRING_SECURITY_CONTEXT";
 
-	private static final SpelExpressionParser parser = new SpelExpressionParser();
-
-	private static final Expression expression = parser.parseExpression("authentication?.name");
+	private static final Expression expression = new SpelExpressionParser().parseExpression("authentication?.name");
 
 	public PrincipalNameIndexResolver() {
 		super(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME);


### PR DESCRIPTION
Hi,

I noticed in some profiling runs of my application that a small share of cycles goes into parsing the expression in PrincipalNameIndexResolver, which seems redundant. This PR puts the expression into a field and reuses it.

Let me know what you think.
Cheers,
Christoph