### PR TITLE
Feature/id with strategy

### DIFF
--- a/spring-session-core/src/main/java/org/springframework/session/MapSession.java
+++ b/spring-session-core/src/main/java/org/springframework/session/MapSession.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 /**
  * <p>
@@ -44,6 +43,7 @@ import java.util.UUID;
  *
  * @author Rob Winch
  * @author Vedran Pavic
+ * @author Jakub Maciej
  * @since 1.0
  */
 public final class MapSession implements Session, Serializable {
@@ -67,13 +67,6 @@ public final class MapSession implements Session, Serializable {
 	 * Defaults to 30 minutes.
 	 */
 	private Duration maxInactiveInterval = Duration.ofSeconds(DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS);
-
-	/**
-	 * Creates a new instance with a secure randomly generated identifier.
-	 */
-	public MapSession() {
-		this(generateId());
-	}
 
 	/**
 	 * Creates a new instance with the specified id. This is preferred to the default
@@ -124,20 +117,18 @@ public final class MapSession implements Session, Serializable {
 		return this.id;
 	}
 
+	@Override
+	public void changeSessionId(final String id) {
+		setId(id);
+	}
+
 	/**
 	 * Get the original session id.
 	 * @return the original session id
-	 * @see #changeSessionId()
+	 * @see #changeSessionId(String changedId)
 	 */
 	public String getOriginalId() {
 		return this.originalId;
-	}
-
-	@Override
-	public String changeSessionId() {
-		String changedId = generateId();
-		setId(changedId);
-		return changedId;
 	}
 
 	@Override
@@ -220,10 +211,6 @@ public final class MapSession implements Session, Serializable {
 	@Override
 	public int hashCode() {
 		return this.id.hashCode();
-	}
-
-	private static String generateId() {
-		return UUID.randomUUID().toString();
 	}
 
 	private static final long serialVersionUID = 7160779239673823561L;

--- a/spring-session-core/src/main/java/org/springframework/session/MapSessionRepository.java
+++ b/spring-session-core/src/main/java/org/springframework/session/MapSessionRepository.java
@@ -47,7 +47,7 @@ public class MapSessionRepository implements SessionRepository<MapSession> {
 
 	private final Map<String, Session> sessions;
 
-	private SessionIdStrategy idGenerationStrategy = SessionIdStrategy.getDefaultGenerationStrategy();
+	private SessionIdStrategy sessionIdStrategy = SessionIdStrategy.getDefaultSessionIdStrategy();
 
 	/**
 	 * Creates a new instance backed by the provided {@link java.util.Map}. This allows
@@ -99,22 +99,22 @@ public class MapSessionRepository implements SessionRepository<MapSession> {
 
 	@Override
 	public String changeSessionId(final MapSession session) {
-		String newId = this.idGenerationStrategy.createSessionId();
+		String newId = this.sessionIdStrategy.createSessionId();
 		session.changeSessionId(newId);
 		return newId;
 	}
 
 	@Override
 	public MapSession createSession() {
-		MapSession result = new MapSession(this.idGenerationStrategy.createSessionId());
+		MapSession result = new MapSession(this.sessionIdStrategy.createSessionId());
 		if (this.defaultMaxInactiveInterval != null) {
 			result.setMaxInactiveInterval(Duration.ofSeconds(this.defaultMaxInactiveInterval));
 		}
 		return result;
 	}
 
-	public void setIdGenerationStrategy(final SessionIdStrategy idGenerationStrategy) {
-		this.idGenerationStrategy = idGenerationStrategy;
+	public void setsessionIdStrategy(final SessionIdStrategy sessionIdStrategy) {
+		this.sessionIdStrategy = sessionIdStrategy;
 	}
 
 }

--- a/spring-session-core/src/main/java/org/springframework/session/MapSessionRepository.java
+++ b/spring-session-core/src/main/java/org/springframework/session/MapSessionRepository.java
@@ -34,6 +34,7 @@ import org.springframework.session.events.SessionExpiredEvent;
  * </p>
  *
  * @author Rob Winch
+ * @author Jakub Maciej
  * @since 1.0
  */
 public class MapSessionRepository implements SessionRepository<MapSession> {
@@ -45,6 +46,8 @@ public class MapSessionRepository implements SessionRepository<MapSession> {
 	private Integer defaultMaxInactiveInterval;
 
 	private final Map<String, Session> sessions;
+
+	private SessionIdStrategy idGenerationStrategy = SessionIdStrategy.getDefaultGenerationStrategy();
 
 	/**
 	 * Creates a new instance backed by the provided {@link java.util.Map}. This allows
@@ -95,12 +98,23 @@ public class MapSessionRepository implements SessionRepository<MapSession> {
 	}
 
 	@Override
+	public String changeSessionId(final MapSession session) {
+		String newId = this.idGenerationStrategy.createSessionId();
+		session.changeSessionId(newId);
+		return newId;
+	}
+
+	@Override
 	public MapSession createSession() {
-		MapSession result = new MapSession();
+		MapSession result = new MapSession(this.idGenerationStrategy.createSessionId());
 		if (this.defaultMaxInactiveInterval != null) {
 			result.setMaxInactiveInterval(Duration.ofSeconds(this.defaultMaxInactiveInterval));
 		}
 		return result;
+	}
+
+	public void setIdGenerationStrategy(final SessionIdStrategy idGenerationStrategy) {
+		this.idGenerationStrategy = idGenerationStrategy;
 	}
 
 }

--- a/spring-session-core/src/main/java/org/springframework/session/ReactiveMapSessionRepository.java
+++ b/spring-session-core/src/main/java/org/springframework/session/ReactiveMapSessionRepository.java
@@ -36,9 +36,12 @@ import org.springframework.session.events.SessionExpiredEvent;
  * </p>
  *
  * @author Rob Winch
+ * @author Jakub Maciej
  * @since 2.0
  */
 public class ReactiveMapSessionRepository implements ReactiveSessionRepository<MapSession> {
+
+	private SessionIdStrategy idGenerationStrategy = SessionIdStrategy.getDefaultGenerationStrategy();
 
 	/**
 	 * If non-null, this value is used to override
@@ -98,12 +101,16 @@ public class ReactiveMapSessionRepository implements ReactiveSessionRepository<M
 	@Override
 	public Mono<MapSession> createSession() {
 		return Mono.defer(() -> {
-			MapSession result = new MapSession();
+			MapSession result = new MapSession(this.idGenerationStrategy.createSessionId());
 			if (this.defaultMaxInactiveInterval != null) {
 				result.setMaxInactiveInterval(Duration.ofSeconds(this.defaultMaxInactiveInterval));
 			}
 			return Mono.just(result);
 		});
+	}
+
+	public void setIdGenerationStrategy(final SessionIdStrategy idGenerationStrategy) {
+		this.idGenerationStrategy = idGenerationStrategy;
 	}
 
 }

--- a/spring-session-core/src/main/java/org/springframework/session/ReactiveMapSessionRepository.java
+++ b/spring-session-core/src/main/java/org/springframework/session/ReactiveMapSessionRepository.java
@@ -41,7 +41,7 @@ import org.springframework.session.events.SessionExpiredEvent;
  */
 public class ReactiveMapSessionRepository implements ReactiveSessionRepository<MapSession> {
 
-	private SessionIdStrategy idGenerationStrategy = SessionIdStrategy.getDefaultGenerationStrategy();
+	private SessionIdStrategy sessionIdStrategy = SessionIdStrategy.getDefaultSessionIdStrategy();
 
 	/**
 	 * If non-null, this value is used to override
@@ -101,7 +101,7 @@ public class ReactiveMapSessionRepository implements ReactiveSessionRepository<M
 	@Override
 	public Mono<MapSession> createSession() {
 		return Mono.defer(() -> {
-			MapSession result = new MapSession(this.idGenerationStrategy.createSessionId());
+			MapSession result = new MapSession(this.sessionIdStrategy.createSessionId());
 			if (this.defaultMaxInactiveInterval != null) {
 				result.setMaxInactiveInterval(Duration.ofSeconds(this.defaultMaxInactiveInterval));
 			}
@@ -109,8 +109,8 @@ public class ReactiveMapSessionRepository implements ReactiveSessionRepository<M
 		});
 	}
 
-	public void setIdGenerationStrategy(final SessionIdStrategy idGenerationStrategy) {
-		this.idGenerationStrategy = idGenerationStrategy;
+	public void setsessionIdStrategy(final SessionIdStrategy sessionIdStrategy) {
+		this.sessionIdStrategy = sessionIdStrategy;
 	}
 
 }

--- a/spring-session-core/src/main/java/org/springframework/session/Session.java
+++ b/spring-session-core/src/main/java/org/springframework/session/Session.java
@@ -26,6 +26,7 @@ import java.util.Set;
  *
  * @author Rob Winch
  * @author Vedran Pavic
+ * @author Jakub Maciej
  * @since 1.0
  */
 public interface Session {
@@ -39,9 +40,9 @@ public interface Session {
 	/**
 	 * Changes the session id. After invoking the {@link #getId()} will return a new
 	 * identifier.
-	 * @return the new session id which {@link #getId()} will now return
+	 * @param id desired new sessionId
 	 */
-	String changeSessionId();
+	void changeSessionId(String id);
 
 	/**
 	 * Gets the Object associated with the specified name or null if no Object is

--- a/spring-session-core/src/main/java/org/springframework/session/SessionIdStrategy.java
+++ b/spring-session-core/src/main/java/org/springframework/session/SessionIdStrategy.java
@@ -34,7 +34,7 @@ public interface SessionIdStrategy {
 	 * Gets default strategy used to generate session id {@link SessionIdStrategy}.
 	 * @return gets default strategy used to generate session id {@link SessionIdStrategy}
 	 */
-	static SessionIdStrategy getDefaultGenerationStrategy() {
+	static SessionIdStrategy getDefaultSessionIdStrategy() {
 		return new UUIDSessionIdStrategy();
 	}
 

--- a/spring-session-core/src/main/java/org/springframework/session/SessionIdStrategy.java
+++ b/spring-session-core/src/main/java/org/springframework/session/SessionIdStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session;
+
+/**
+ * Provides a common interface for id generation strategy. Allows customization of session
+ * id creation process.
+ *
+ * @author Jakub Maciej
+ */
+public interface SessionIdStrategy {
+
+	/**
+	 * Gets a unique string that identifies the {@link Session}.
+	 * @return a unique string that identifies the {@link Session}
+	 */
+	String createSessionId();
+
+	/**
+	 * Gets default strategy used to generate session id {@link SessionIdStrategy}.
+	 * @return gets default strategy used to generate session id {@link SessionIdStrategy}
+	 */
+	static SessionIdStrategy getDefaultGenerationStrategy() {
+		return new UUIDSessionIdStrategy();
+	}
+
+}

--- a/spring-session-core/src/main/java/org/springframework/session/SessionRepository.java
+++ b/spring-session-core/src/main/java/org/springframework/session/SessionRepository.java
@@ -21,6 +21,7 @@ package org.springframework.session;
  *
  * @param <S> the {@link Session} type
  * @author Rob Winch
+ * @author Jakub Maciej
  * @since 1.0
  */
 public interface SessionRepository<S extends Session> {
@@ -67,5 +68,12 @@ public interface SessionRepository<S extends Session> {
 	 * @param id the {@link org.springframework.session.Session#getId()} to delete
 	 */
 	void deleteById(String id);
+
+	/**
+	 * Changes the session id.
+	 * @param session which id should be changed
+	 * @return new session id
+	 */
+	String changeSessionId(S session);
 
 }

--- a/spring-session-core/src/main/java/org/springframework/session/UUIDSessionIdStrategy.java
+++ b/spring-session-core/src/main/java/org/springframework/session/UUIDSessionIdStrategy.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session;
+
+import java.util.UUID;
+
+/**
+ * UUID based session generation strategy. This is default strategy for session id
+ * generation.
+ *
+ * @author Jakub Maciej
+ */
+public class UUIDSessionIdStrategy implements SessionIdStrategy {
+
+	@Override
+	public String createSessionId() {
+		return UUID.randomUUID().toString();
+	}
+
+}

--- a/spring-session-core/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
+++ b/spring-session-core/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
@@ -75,6 +75,7 @@ import org.springframework.session.SessionRepository;
  * @author Rob Winch
  * @author Vedran Pavic
  * @author Josh Cummings
+ * @author Jakub Maciej
  */
 @Order(SessionRepositoryFilter.DEFAULT_ORDER)
 public class SessionRepositoryFilter<S extends Session> extends OncePerRequestFilter {
@@ -254,7 +255,7 @@ public class SessionRepositoryFilter<S extends Session> extends OncePerRequestFi
 						"Cannot change session ID. There is no session associated with this request.");
 			}
 
-			return getCurrentSession().getSession().changeSessionId();
+			return SessionRepositoryFilter.this.sessionRepository.changeSessionId(getCurrentSession().getSession());
 		}
 
 		@Override

--- a/spring-session-core/src/main/java/org/springframework/session/web/server/session/SpringSessionWebSessionStore.java
+++ b/spring-session-core/src/main/java/org/springframework/session/web/server/session/SpringSessionWebSessionStore.java
@@ -55,7 +55,7 @@ public class SpringSessionWebSessionStore<S extends Session> implements WebSessi
 
 	private final ReactiveSessionRepository<S> sessions;
 
-	private SessionIdStrategy idGenerationStrategy = SessionIdStrategy.getDefaultGenerationStrategy();
+	private SessionIdStrategy sessionIdStrategy = SessionIdStrategy.getDefaultSessionIdStrategy();
 
 	private Clock clock = Clock.system(ZoneOffset.UTC);
 
@@ -112,8 +112,8 @@ public class SpringSessionWebSessionStore<S extends Session> implements WebSessi
 		return new SpringSessionWebSession(session, State.STARTED);
 	}
 
-	public void setIdGenerationStrategy(final SessionIdStrategy idGenerationStrategy) {
-		this.idGenerationStrategy = idGenerationStrategy;
+	public void setsessionIdStrategy(final SessionIdStrategy sessionIdStrategy) {
+		this.sessionIdStrategy = sessionIdStrategy;
 	}
 
 	/**
@@ -142,7 +142,7 @@ public class SpringSessionWebSessionStore<S extends Session> implements WebSessi
 		@Override
 		public Mono<Void> changeSessionId() {
 			return Mono.defer(() -> {
-				this.session.changeSessionId(SpringSessionWebSessionStore.this.idGenerationStrategy.createSessionId());
+				this.session.changeSessionId(SpringSessionWebSessionStore.this.sessionIdStrategy.createSessionId());
 				return save();
 			});
 		}

--- a/spring-session-core/src/test/java/org/springframework/session/DelegatingIndexResolverTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/DelegatingIndexResolverTests.java
@@ -40,7 +40,7 @@ class DelegatingIndexResolverTests {
 
 	@Test
 	void resolve() {
-		MapSession session = new MapSession();
+		MapSession session = new MapSession("1");
 		session.setAttribute("one", "first");
 		session.setAttribute("two", "second");
 		Map<String, String> indexes = this.indexResolver.resolveIndexesFor(session);

--- a/spring-session-core/src/test/java/org/springframework/session/MapSessionRepositoryTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/MapSessionRepositoryTests.java
@@ -38,7 +38,7 @@ class MapSessionRepositoryTests {
 	@BeforeEach
 	void setup() {
 		this.repository = new MapSessionRepository(new ConcurrentHashMap<>());
-		this.session = new MapSession();
+		this.session = new MapSession("1");
 	}
 
 	@Test
@@ -55,12 +55,12 @@ class MapSessionRepositoryTests {
 		Session session = this.repository.createSession();
 
 		assertThat(session).isInstanceOf(MapSession.class);
-		assertThat(session.getMaxInactiveInterval()).isEqualTo(new MapSession().getMaxInactiveInterval());
+		assertThat(session.getMaxInactiveInterval()).isEqualTo(new MapSession("1").getMaxInactiveInterval());
 	}
 
 	@Test
 	void createSessionCustomDefaultExpiration() {
-		final Duration expectedMaxInterval = new MapSession().getMaxInactiveInterval().plusSeconds(10);
+		final Duration expectedMaxInterval = new MapSession("1").getMaxInactiveInterval().plusSeconds(10);
 		this.repository.setDefaultMaxInactiveInterval((int) expectedMaxInterval.getSeconds());
 
 		Session session = this.repository.createSession();
@@ -73,7 +73,7 @@ class MapSessionRepositoryTests {
 		MapSession createSession = this.repository.createSession();
 
 		String originalId = createSession.getId();
-		createSession.changeSessionId();
+		createSession.changeSessionId("1");
 
 		this.repository.save(createSession);
 
@@ -88,7 +88,7 @@ class MapSessionRepositoryTests {
 		this.repository.save(createSession);
 
 		String originalId = createSession.getId();
-		createSession.changeSessionId();
+		createSession.changeSessionId("1");
 
 		this.repository.save(createSession);
 

--- a/spring-session-core/src/test/java/org/springframework/session/MapSessionTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/MapSessionTests.java
@@ -32,7 +32,7 @@ class MapSessionTests {
 
 	@BeforeEach
 	void setup() {
-		this.session = new MapSession();
+		this.session = new MapSession("1");
 		this.session.setLastAccessedTime(Instant.ofEpochMilli(1413258262962L));
 	}
 
@@ -151,7 +151,7 @@ class MapSessionTests {
 		}
 
 		@Override
-		public String changeSessionId() {
+		public void changeSessionId(String id) {
 			throw new UnsupportedOperationException();
 		}
 

--- a/spring-session-core/src/test/java/org/springframework/session/PrincipalNameIndexResolverTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/PrincipalNameIndexResolverTests.java
@@ -47,7 +47,7 @@ class PrincipalNameIndexResolverTests {
 
 	@Test
 	void resolveFromPrincipalName() {
-		MapSession session = new MapSession();
+		MapSession session = new MapSession("1");
 		session.setAttribute(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME, PRINCIPAL_NAME);
 		assertThat(this.indexResolver.resolveIndexValueFor(session)).isEqualTo(PRINCIPAL_NAME);
 	}
@@ -58,7 +58,7 @@ class PrincipalNameIndexResolverTests {
 				AuthorityUtils.createAuthorityList("ROLE_USER"));
 		SecurityContext context = new SecurityContextImpl();
 		context.setAuthentication(authentication);
-		MapSession session = new MapSession();
+		MapSession session = new MapSession("1");
 		session.setAttribute(SPRING_SECURITY_CONTEXT, context);
 		assertThat(this.indexResolver.resolveIndexValueFor(session)).isEqualTo(PRINCIPAL_NAME);
 	}

--- a/spring-session-core/src/test/java/org/springframework/session/ReactiveMapSessionRepositoryTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/ReactiveMapSessionRepositoryTests.java
@@ -98,12 +98,12 @@ class ReactiveMapSessionRepositoryTests {
 		Session session = this.repository.createSession().block();
 
 		assertThat(session).isInstanceOf(MapSession.class);
-		assertThat(session.getMaxInactiveInterval()).isEqualTo(new MapSession().getMaxInactiveInterval());
+		assertThat(session.getMaxInactiveInterval()).isEqualTo(new MapSession("1").getMaxInactiveInterval());
 	}
 
 	@Test
 	void createSessionWhenCustomMaxInactiveIntervalThenCustomMaxInactiveInterval() {
-		final Duration expectedMaxInterval = new MapSession().getMaxInactiveInterval().plusSeconds(10);
+		final Duration expectedMaxInterval = new MapSession("1").getMaxInactiveInterval().plusSeconds(10);
 		this.repository.setDefaultMaxInactiveInterval((int) expectedMaxInterval.getSeconds());
 
 		Session session = this.repository.createSession().block();
@@ -116,7 +116,7 @@ class ReactiveMapSessionRepositoryTests {
 		MapSession createSession = this.repository.createSession().block();
 
 		String originalId = createSession.getId();
-		createSession.changeSessionId();
+		createSession.changeSessionId("1");
 
 		this.repository.save(createSession).block();
 
@@ -131,7 +131,7 @@ class ReactiveMapSessionRepositoryTests {
 		this.repository.save(createSession).block();
 
 		String originalId = createSession.getId();
-		createSession.changeSessionId();
+		createSession.changeSessionId("1");
 
 		this.repository.save(createSession).block();
 

--- a/spring-session-core/src/test/java/org/springframework/session/config/annotation/web/http/EnableSpringHttpSessionCustomCookieSerializerTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/config/annotation/web/http/EnableSpringHttpSessionCustomCookieSerializerTests.java
@@ -102,7 +102,7 @@ class EnableSpringHttpSessionCustomCookieSerializerTests {
 
 	@Test
 	void usesWrite() throws Exception {
-		given(this.sessionRepository.createSession()).willReturn(new MapSession());
+		given(this.sessionRepository.createSession()).willReturn(new MapSession("1"));
 
 		this.sessionRepositoryFilter.doFilter(this.request, this.response, new MockFilterChain() {
 

--- a/spring-session-core/src/test/java/org/springframework/session/web/http/CookieHttpSessionIdResolverTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/web/http/CookieHttpSessionIdResolverTests.java
@@ -49,7 +49,7 @@ class CookieHttpSessionIdResolverTests {
 	@BeforeEach
 	void setup() {
 		this.cookieName = "SESSION";
-		this.session = new MapSession();
+		this.session = new MapSession("1");
 		this.request = new MockHttpServletRequest();
 		this.response = new MockHttpServletResponse();
 		this.strategy = new CookieHttpSessionIdResolver();
@@ -91,7 +91,7 @@ class CookieHttpSessionIdResolverTests {
 
 	@Test
 	void onNewSessionTwiceNewId() {
-		Session newSession = new MapSession();
+		Session newSession = new MapSession("2");
 
 		this.strategy.setSessionId(this.request, this.response, this.session.getId());
 		this.strategy.setSessionId(this.request, this.response, newSession.getId());

--- a/spring-session-core/src/test/java/org/springframework/session/web/http/SessionEventHttpSessionListenerAdapterTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/web/http/SessionEventHttpSessionListenerAdapterTests.java
@@ -73,7 +73,7 @@ class SessionEventHttpSessionListenerAdapterTests {
 		this.listener = new SessionEventHttpSessionListenerAdapter(Arrays.asList(this.listener1, this.listener2));
 		this.listener.setServletContext(new MockServletContext());
 
-		Session session = new MapSession();
+		Session session = new MapSession("1");
 		this.destroyed = new SessionDestroyedEvent(this, session);
 		this.created = new SessionCreatedEvent(this, session);
 	}

--- a/spring-session-core/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
@@ -133,7 +133,7 @@ class SessionRepositoryFilterTests {
 
 	@Test
 	void doFilterCreateSetsLastAccessedTime() throws Exception {
-		MapSession session = new MapSession();
+		MapSession session = new MapSession("1");
 		session.setLastAccessedTime(Instant.EPOCH);
 		this.sessionRepository = spy(this.sessionRepository);
 		given(this.sessionRepository.createSession()).willReturn(session);

--- a/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/ReactiveRedisSessionRepositoryITests.java
+++ b/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/ReactiveRedisSessionRepositoryITests.java
@@ -114,7 +114,8 @@ class ReactiveRedisSessionRepositoryITests extends AbstractRedisITests {
 		assertThat(findById.<String>getAttribute(attrName)).isEqualTo(attrValue);
 
 		String originalFindById = findById.getId();
-		String changeSessionId = findById.changeSessionId();
+		String changeSessionId = "1";
+		findById.changeSessionId(changeSessionId);
 
 		this.repository.save(findById).block();
 
@@ -132,8 +133,10 @@ class ReactiveRedisSessionRepositoryITests extends AbstractRedisITests {
 		this.repository.save(toSave).block();
 
 		String originalId = toSave.getId();
-		String changeId1 = toSave.changeSessionId();
-		String changeId2 = toSave.changeSessionId();
+		String changeId1 = "1";
+		toSave.changeSessionId(changeId1);
+		String changeId2 = "2";
+		toSave.changeSessionId(changeId2);
 
 		this.repository.save(toSave).block();
 
@@ -156,7 +159,8 @@ class ReactiveRedisSessionRepositoryITests extends AbstractRedisITests {
 		findById.setAttribute(attrName, attrValue);
 
 		String originalFindById = findById.getId();
-		String changeSessionId = findById.changeSessionId();
+		String changeSessionId = "1";
+		findById.changeSessionId(changeSessionId);
 
 		this.repository.save(findById).block();
 
@@ -171,7 +175,7 @@ class ReactiveRedisSessionRepositoryITests extends AbstractRedisITests {
 	void changeSessionIdWhenHasNotSaved() {
 		RedisSession toSave = this.repository.createSession().block();
 		String originalId = toSave.getId();
-		toSave.changeSessionId();
+		toSave.changeSessionId("1");
 
 		this.repository.save(toSave).block();
 
@@ -184,7 +188,7 @@ class ReactiveRedisSessionRepositoryITests extends AbstractRedisITests {
 	void changeSessionIdSaveTwice() {
 		RedisSession toSave = this.repository.createSession().block();
 		String originalId = toSave.getId();
-		toSave.changeSessionId();
+		toSave.changeSessionId("1");
 
 		this.repository.save(toSave).block();
 		this.repository.save(toSave).block();
@@ -202,7 +206,7 @@ class ReactiveRedisSessionRepositoryITests extends AbstractRedisITests {
 		this.repository.save(toSave).block();
 
 		RedisSession session = this.repository.findById(sessionId).block();
-		session.changeSessionId();
+		session.changeSessionId("1");
 		session.setLastAccessedTime(Instant.now());
 		this.repository.save(session).block();
 

--- a/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryITests.java
+++ b/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryITests.java
@@ -487,7 +487,8 @@ class RedisIndexedSessionRepositoryITests extends AbstractRedisITests {
 		assertThat(findById.<String>getAttribute(attrName)).isEqualTo(attrValue);
 
 		String originalFindById = findById.getId();
-		String changeSessionId = findById.changeSessionId();
+		String changeSessionId = "1";
+		findById.changeSessionId(changeSessionId);
 
 		this.repository.save(findById);
 
@@ -505,8 +506,10 @@ class RedisIndexedSessionRepositoryITests extends AbstractRedisITests {
 		this.repository.save(toSave);
 
 		String originalId = toSave.getId();
-		String changeId1 = toSave.changeSessionId();
-		String changeId2 = toSave.changeSessionId();
+		String changeId1 = "1";
+		toSave.changeSessionId(changeId1);
+		String changeId2 = "2";
+		toSave.changeSessionId(changeId2);
 
 		this.repository.save(toSave);
 
@@ -529,7 +532,8 @@ class RedisIndexedSessionRepositoryITests extends AbstractRedisITests {
 		findById.setAttribute(attrName, attrValue);
 
 		String originalFindById = findById.getId();
-		String changeSessionId = findById.changeSessionId();
+		String changeSessionId = "1";
+		findById.changeSessionId(changeSessionId);
 
 		this.repository.save(findById);
 
@@ -547,7 +551,7 @@ class RedisIndexedSessionRepositoryITests extends AbstractRedisITests {
 
 		RedisSession toSave = this.repository.createSession();
 		String originalId = toSave.getId();
-		toSave.changeSessionId();
+		toSave.changeSessionId("1");
 
 		this.repository.save(toSave);
 
@@ -560,7 +564,7 @@ class RedisIndexedSessionRepositoryITests extends AbstractRedisITests {
 	void changeSessionIdSaveTwice() {
 		RedisSession toSave = this.repository.createSession();
 		String originalId = toSave.getId();
-		toSave.changeSessionId();
+		toSave.changeSessionId("1");
 
 		this.repository.save(toSave);
 		this.repository.save(toSave);
@@ -578,7 +582,7 @@ class RedisIndexedSessionRepositoryITests extends AbstractRedisITests {
 
 		this.repository.deleteById(sessionId);
 
-		toSave.changeSessionId();
+		toSave.changeSessionId("1");
 		this.repository.save(toSave);
 
 		assertThat(this.repository.findById(toSave.getId())).isNull();
@@ -594,9 +598,9 @@ class RedisIndexedSessionRepositoryITests extends AbstractRedisITests {
 		RedisSession copy1 = this.repository.findById(originalId);
 		RedisSession copy2 = this.repository.findById(originalId);
 
-		copy1.changeSessionId();
+		copy1.changeSessionId("1");
 		this.repository.save(copy1);
-		copy2.changeSessionId();
+		copy2.changeSessionId("2");
 		this.repository.save(copy2);
 
 		assertThat(this.repository.findById(originalId)).isNull();

--- a/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/RedisSessionRepositoryITests.java
+++ b/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/RedisSessionRepositoryITests.java
@@ -98,7 +98,8 @@ class RedisSessionRepositoryITests extends AbstractRedisITests {
 		RedisSession session = createAndSaveSession(Instant.now());
 		String originalSessionId = session.getId();
 		updateSession(session, Instant.now(), "attribute1", "value2");
-		String newSessionId = session.changeSessionId();
+		String newSessionId = "1";
+		session.changeSessionId(newSessionId);
 		this.sessionRepository.save(session);
 		RedisSession loaded = this.sessionRepository.findById(newSessionId);
 		assertThat(loaded).isNotNull();
@@ -111,7 +112,8 @@ class RedisSessionRepositoryITests extends AbstractRedisITests {
 	void save_OnlyChangeSessionId_ShouldChangeSessionId() {
 		RedisSession session = createAndSaveSession(Instant.now());
 		String originalSessionId = session.getId();
-		String newSessionId = session.changeSessionId();
+		String newSessionId = "1";
+		session.changeSessionId(newSessionId);
 		this.sessionRepository.save(session);
 		assertThat(this.sessionRepository.findById(newSessionId)).isNotNull();
 		assertThat(this.sessionRepository.findById(originalSessionId)).isNull();
@@ -122,9 +124,11 @@ class RedisSessionRepositoryITests extends AbstractRedisITests {
 		RedisSession session = createAndSaveSession(Instant.now());
 		String originalSessionId = session.getId();
 		updateSession(session, Instant.now(), "attribute1", "value2");
-		String newSessionId1 = session.changeSessionId();
+		String newSessionId1 = "1";
+		session.changeSessionId(newSessionId1);
 		updateSession(session, Instant.now(), "attribute1", "value3");
-		String newSessionId2 = session.changeSessionId();
+		String newSessionId2 = "2";
+		session.changeSessionId(newSessionId2);
 		this.sessionRepository.save(session);
 		assertThat(this.sessionRepository.findById(newSessionId1)).isNull();
 		assertThat(this.sessionRepository.findById(newSessionId2)).isNotNull();
@@ -136,7 +140,8 @@ class RedisSessionRepositoryITests extends AbstractRedisITests {
 		RedisSession session = this.sessionRepository.createSession();
 		String originalSessionId = session.getId();
 		updateSession(session, Instant.now(), "attribute1", "value1");
-		String newSessionId = session.changeSessionId();
+		String newSessionId = "1";
+		session.changeSessionId(newSessionId);
 		this.sessionRepository.save(session);
 		assertThat(this.sessionRepository.findById(newSessionId)).isNotNull();
 		assertThat(this.sessionRepository.findById(originalSessionId)).isNull();
@@ -148,7 +153,8 @@ class RedisSessionRepositoryITests extends AbstractRedisITests {
 		String originalSessionId;
 		originalSessionId = session.getId();
 		updateSession(session, Instant.now(), "attribute1", "value1");
-		String newSessionId = session.changeSessionId();
+		String newSessionId = "1";
+		session.changeSessionId(newSessionId);
 		this.sessionRepository.save(session);
 		this.sessionRepository.save(session);
 		assertThat(this.sessionRepository.findById(newSessionId)).isNotNull();
@@ -161,7 +167,8 @@ class RedisSessionRepositoryITests extends AbstractRedisITests {
 		String originalSessionId = session.getId();
 		this.sessionRepository.deleteById(originalSessionId);
 		updateSession(session, Instant.now(), "attribute1", "value1");
-		String newSessionId = session.changeSessionId();
+		String newSessionId = "1";
+		session.changeSessionId(newSessionId);
 		assertThatIllegalStateException().isThrownBy(() -> this.sessionRepository.save(session))
 				.withMessage("Session was invalidated");
 		assertThat(this.sessionRepository.findById(newSessionId)).isNull();
@@ -175,10 +182,12 @@ class RedisSessionRepositoryITests extends AbstractRedisITests {
 		RedisSession copy2 = this.sessionRepository.findById(originalSessionId);
 		Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
 		updateSession(copy1, now.plusSeconds(1L), "attribute2", "value2");
-		String newSessionId1 = copy1.changeSessionId();
+		String newSessionId1 = "1";
+		copy1.changeSessionId(newSessionId1);
 		this.sessionRepository.save(copy1);
 		updateSession(copy2, now.plusSeconds(2L), "attribute3", "value3");
-		String newSessionId2 = copy2.changeSessionId();
+		String newSessionId2 = "2";
+		copy2.changeSessionId(newSessionId2);
 		assertThatIllegalStateException().isThrownBy(() -> this.sessionRepository.save(copy2))
 				.withMessage("Session was invalidated");
 		assertThat(this.sessionRepository.findById(newSessionId1)).isNotNull();

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisSessionRepository.java
@@ -51,7 +51,7 @@ public class ReactiveRedisSessionRepository
 
 	private final ReactiveRedisOperations<String, Object> sessionRedisOperations;
 
-	private SessionIdStrategy idGenerationStrategy = SessionIdStrategy.getDefaultGenerationStrategy();
+	private SessionIdStrategy idGenerationStrategy = SessionIdStrategy.getDefaultSessionIdStrategy();
 
 	/**
 	 * The namespace for every key used by Spring Session in Redis.

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
@@ -265,7 +265,7 @@ public class RedisIndexedSessionRepository
 	 */
 	public static final String DEFAULT_NAMESPACE = "spring:session";
 
-	private SessionIdStrategy idGenerationStrategy = SessionIdStrategy.getDefaultGenerationStrategy();
+	private SessionIdStrategy idGenerationStrategy = SessionIdStrategy.getDefaultSessionIdStrategy();
 
 	private int database = DEFAULT_DATABASE;
 

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisSessionRepository.java
@@ -48,7 +48,7 @@ public class RedisSessionRepository implements SessionRepository<RedisSessionRep
 
 	private final RedisOperations<String, Object> sessionRedisOperations;
 
-	private SessionIdStrategy idGenerationStrategy = SessionIdStrategy.getDefaultGenerationStrategy();
+	private SessionIdStrategy idGenerationStrategy = SessionIdStrategy.getDefaultSessionIdStrategy();
 
 	private Duration defaultMaxInactiveInterval = Duration.ofSeconds(MapSession.DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS);
 

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/ReactiveRedisSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/ReactiveRedisSessionRepositoryTests.java
@@ -69,7 +69,7 @@ class ReactiveRedisSessionRepositoryTests {
 	void setUp() {
 		this.repository = new ReactiveRedisSessionRepository(this.redisOperations);
 
-		this.cached = new MapSession();
+		this.cached = new MapSession("1");
 		this.cached.setId("session-id");
 		this.cached.setCreationTime(Instant.ofEpochMilli(1404360000000L));
 		this.cached.setLastAccessedTime(Instant.ofEpochMilli(1404360000000L));
@@ -131,7 +131,7 @@ class ReactiveRedisSessionRepositoryTests {
 		given(this.hashOperations.putAll(anyString(), any())).willReturn(Mono.just(true));
 		given(this.redisOperations.expire(anyString(), any())).willReturn(Mono.just(true));
 
-		RedisSession newSession = this.repository.new RedisSession(new MapSession(), true);
+		RedisSession newSession = this.repository.new RedisSession(new MapSession("1"), true);
 		StepVerifier.create(this.repository.save(newSession)).verifyComplete();
 
 		verify(this.redisOperations).opsForHash();
@@ -217,7 +217,7 @@ class ReactiveRedisSessionRepositoryTests {
 		given(this.redisOperations.expire(anyString(), any())).willReturn(Mono.just(true));
 
 		String attrName = "attrName";
-		RedisSession session = this.repository.new RedisSession(new MapSession(), false);
+		RedisSession session = this.repository.new RedisSession(new MapSession("1"), false);
 		session.removeAttribute(attrName);
 		StepVerifier.create(this.repository.save(session)).verifyComplete();
 
@@ -344,7 +344,7 @@ class ReactiveRedisSessionRepositoryTests {
 		given(this.hashOperations.putAll(anyString(), any())).willReturn(Mono.just(true));
 		given(this.redisOperations.expire(anyString(), any())).willReturn(Mono.just(true));
 		this.repository.setSaveMode(SaveMode.ON_SET_ATTRIBUTE);
-		MapSession delegate = new MapSession();
+		MapSession delegate = new MapSession("1");
 		delegate.setAttribute("attribute1", "value1");
 		delegate.setAttribute("attribute2", "value2");
 		delegate.setAttribute("attribute3", "value3");
@@ -368,7 +368,7 @@ class ReactiveRedisSessionRepositoryTests {
 		given(this.hashOperations.putAll(anyString(), any())).willReturn(Mono.just(true));
 		given(this.redisOperations.expire(anyString(), any())).willReturn(Mono.just(true));
 		this.repository.setSaveMode(SaveMode.ON_GET_ATTRIBUTE);
-		MapSession delegate = new MapSession();
+		MapSession delegate = new MapSession("1");
 		delegate.setAttribute("attribute1", "value1");
 		delegate.setAttribute("attribute2", "value2");
 		delegate.setAttribute("attribute3", "value3");
@@ -392,7 +392,7 @@ class ReactiveRedisSessionRepositoryTests {
 		given(this.hashOperations.putAll(anyString(), any())).willReturn(Mono.just(true));
 		given(this.redisOperations.expire(anyString(), any())).willReturn(Mono.just(true));
 		this.repository.setSaveMode(SaveMode.ALWAYS);
-		MapSession delegate = new MapSession();
+		MapSession delegate = new MapSession("1");
 		delegate.setAttribute("attribute1", "value1");
 		delegate.setAttribute("attribute2", "value2");
 		delegate.setAttribute("attribute3", "value3");

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryTests.java
@@ -101,7 +101,7 @@ class RedisIndexedSessionRepositoryTests {
 		this.redisRepository = new RedisIndexedSessionRepository(this.redisOperations);
 		this.redisRepository.setDefaultSerializer(this.defaultSerializer);
 
-		this.cached = new MapSession();
+		this.cached = new MapSession("1");
 		this.cached.setId("session-id");
 		this.cached.setCreationTime(Instant.ofEpochMilli(1404360000000L));
 		this.cached.setLastAccessedTime(Instant.ofEpochMilli(1404360000000L));
@@ -121,7 +121,8 @@ class RedisIndexedSessionRepositoryTests {
 
 		RedisSession createSession = this.redisRepository.createSession();
 		String originalId = createSession.getId();
-		String changeSessionId = createSession.changeSessionId();
+		String changeSessionId = "1";
+		createSession.changeSessionId(changeSessionId);
 		this.redisRepository.save(createSession);
 
 		verify(this.redisOperations, never()).rename(anyString(), anyString());
@@ -139,7 +140,8 @@ class RedisIndexedSessionRepositoryTests {
 		RedisSession session = this.redisRepository.new RedisSession(this.cached, false);
 		session.setLastAccessedTime(session.getLastAccessedTime());
 		String originalId = session.getId();
-		String changeSessionId = session.changeSessionId();
+		String changeSessionId = "1";
+		session.changeSessionId(changeSessionId);
 		this.redisRepository.save(session);
 
 		verify(this.redisOperations, times(2)).rename(anyString(), anyString());
@@ -151,7 +153,7 @@ class RedisIndexedSessionRepositoryTests {
 	@Test
 	void createSessionDefaultMaxInactiveInterval() {
 		Session session = this.redisRepository.createSession();
-		assertThat(session.getMaxInactiveInterval()).isEqualTo(new MapSession().getMaxInactiveInterval());
+		assertThat(session.getMaxInactiveInterval()).isEqualTo(new MapSession("1").getMaxInactiveInterval());
 	}
 
 	@Test
@@ -257,7 +259,7 @@ class RedisIndexedSessionRepositoryTests {
 	@Test
 	void saveSetAttribute() {
 		String attrName = "attrName";
-		RedisSession session = this.redisRepository.new RedisSession(new MapSession(), false);
+		RedisSession session = this.redisRepository.new RedisSession(new MapSession("1"), false);
 		session.setAttribute(attrName, "attrValue");
 		given(this.redisOperations.boundHashOps(anyString())).willReturn(this.boundHashOperations);
 		given(this.redisOperations.boundSetOps(anyString())).willReturn(this.boundSetOperations);
@@ -272,7 +274,7 @@ class RedisIndexedSessionRepositoryTests {
 	@Test
 	void saveRemoveAttribute() {
 		String attrName = "attrName";
-		RedisSession session = this.redisRepository.new RedisSession(new MapSession(), false);
+		RedisSession session = this.redisRepository.new RedisSession(new MapSession("1"), false);
 		session.removeAttribute(attrName);
 		given(this.redisOperations.boundHashOps(anyString())).willReturn(this.boundHashOperations);
 		given(this.redisOperations.boundSetOps(anyString())).willReturn(this.boundSetOperations);
@@ -285,7 +287,7 @@ class RedisIndexedSessionRepositoryTests {
 
 	@Test
 	void saveExpired() {
-		RedisSession session = this.redisRepository.new RedisSession(new MapSession(), false);
+		RedisSession session = this.redisRepository.new RedisSession(new MapSession("1"), false);
 		session.setMaxInactiveInterval(Duration.ZERO);
 		given(this.redisOperations.boundHashOps(anyString())).willReturn(this.boundHashOperations);
 		given(this.redisOperations.boundSetOps(anyString())).willReturn(this.boundSetOperations);
@@ -312,7 +314,7 @@ class RedisIndexedSessionRepositoryTests {
 	@SuppressWarnings("unchecked")
 	void delete() {
 		String attrName = "attrName";
-		MapSession expected = new MapSession();
+		MapSession expected = new MapSession("1");
 		expected.setLastAccessedTime(Instant.now().minusSeconds(60));
 		expected.setAttribute(attrName, "attrValue");
 		given(this.redisOperations.boundHashOps(anyString())).willReturn(this.boundHashOperations);
@@ -357,7 +359,7 @@ class RedisIndexedSessionRepositoryTests {
 	void getSessionFound() {
 		String attribute1 = "attribute1";
 		String attribute2 = "attribute2";
-		MapSession expected = new MapSession();
+		MapSession expected = new MapSession("1");
 		expected.setLastAccessedTime(Instant.now().minusSeconds(60));
 		expected.setAttribute(attribute1, "test");
 		expected.setAttribute(attribute2, null);
@@ -739,7 +741,7 @@ class RedisIndexedSessionRepositoryTests {
 	void changeRedisNamespace() {
 		String namespace = "foo:bar";
 		this.redisRepository.setRedisKeyNamespace(namespace);
-		RedisSession session = this.redisRepository.new RedisSession(new MapSession(), false);
+		RedisSession session = this.redisRepository.new RedisSession(new MapSession("1"), false);
 		session.setMaxInactiveInterval(Duration.ZERO);
 		given(this.redisOperations.boundHashOps(anyString())).willReturn(this.boundHashOperations);
 		given(this.redisOperations.boundSetOps(anyString())).willReturn(this.boundSetOperations);
@@ -835,7 +837,7 @@ class RedisIndexedSessionRepositoryTests {
 		given(this.redisOperations.boundSetOps(anyString())).willReturn(this.boundSetOperations);
 		given(this.redisOperations.boundValueOps(anyString())).willReturn(this.boundValueOperations);
 		this.redisRepository.setSaveMode(SaveMode.ON_SET_ATTRIBUTE);
-		MapSession delegate = new MapSession();
+		MapSession delegate = new MapSession("1");
 		delegate.setAttribute("attribute1", "value1");
 		delegate.setAttribute("attribute2", "value2");
 		delegate.setAttribute("attribute3", "value3");
@@ -852,7 +854,7 @@ class RedisIndexedSessionRepositoryTests {
 		given(this.redisOperations.boundSetOps(anyString())).willReturn(this.boundSetOperations);
 		given(this.redisOperations.boundValueOps(anyString())).willReturn(this.boundValueOperations);
 		this.redisRepository.setSaveMode(SaveMode.ON_GET_ATTRIBUTE);
-		MapSession delegate = new MapSession();
+		MapSession delegate = new MapSession("1");
 		delegate.setAttribute("attribute1", "value1");
 		delegate.setAttribute("attribute2", "value2");
 		delegate.setAttribute("attribute3", "value3");
@@ -869,7 +871,7 @@ class RedisIndexedSessionRepositoryTests {
 		given(this.redisOperations.boundSetOps(anyString())).willReturn(this.boundSetOperations);
 		given(this.redisOperations.boundValueOps(anyString())).willReturn(this.boundValueOperations);
 		this.redisRepository.setSaveMode(SaveMode.ALWAYS);
-		MapSession delegate = new MapSession();
+		MapSession delegate = new MapSession("1");
 		delegate.setAttribute("attribute1", "value1");
 		delegate.setAttribute("attribute2", "value2");
 		delegate.setAttribute("attribute3", "value3");

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisSessionExpirationPolicyTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisSessionExpirationPolicyTests.java
@@ -69,7 +69,7 @@ class RedisSessionExpirationPolicyTests {
 		RedisIndexedSessionRepository repository = new RedisIndexedSessionRepository(this.sessionRedisOperations);
 		this.policy = new RedisSessionExpirationPolicy(this.sessionRedisOperations, repository::getExpirationsKey,
 				repository::getSessionKey);
-		this.session = new MapSession();
+		this.session = new MapSession("1");
 		this.session.setLastAccessedTime(Instant.ofEpochMilli(1429116694675L));
 		this.session.setId("12345");
 

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisSessionRepositoryTests.java
@@ -200,7 +200,7 @@ class RedisSessionRepositoryTests {
 	@Test
 	void save_NewSessionAndChangedSessionId_ShouldSaveSession() {
 		RedisSession session = this.sessionRepository.createSession();
-		session.changeSessionId();
+		session.changeSessionId("1");
 		this.sessionRepository.save(session);
 		String key = getSessionKey(session.getId());
 		verify(this.sessionRedisOperations).opsForHash();

--- a/spring-session-docs/src/test/java/docs/http/AbstractHttpSessionListenerTests.java
+++ b/spring-session-docs/src/test/java/docs/http/AbstractHttpSessionListenerTests.java
@@ -54,7 +54,7 @@ public abstract class AbstractHttpSessionListenerTests {
 
 	@Test
 	void springSessionDestroyedTranslatedToSpringSecurityDestroyed() {
-		Session session = new MapSession();
+		Session session = new MapSession("1");
 
 		this.publisher.publishEvent(new org.springframework.session.events.SessionDestroyedEvent(this, session));
 

--- a/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/AbstractHazelcastIndexedSessionRepositoryITests.java
+++ b/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/AbstractHazelcastIndexedSessionRepositoryITests.java
@@ -84,7 +84,8 @@ abstract class AbstractHazelcastIndexedSessionRepositoryITests {
 		assertThat(findById.<String>getAttribute(attrName)).isEqualTo(attrValue);
 
 		String originalFindById = findById.getId();
-		String changeSessionId = findById.changeSessionId();
+		String changeSessionId = "1";
+		findById.changeSessionId(changeSessionId);
 
 		this.repository.save(findById);
 
@@ -104,8 +105,10 @@ abstract class AbstractHazelcastIndexedSessionRepositoryITests {
 		this.repository.save(toSave);
 
 		String originalId = toSave.getId();
-		String changeId1 = toSave.changeSessionId();
-		String changeId2 = toSave.changeSessionId();
+		String changeId1 = "1";
+		toSave.changeSessionId(changeId1);
+		String changeId2 = "2";
+		toSave.changeSessionId(changeId2);
 
 		this.repository.save(toSave);
 
@@ -130,7 +133,8 @@ abstract class AbstractHazelcastIndexedSessionRepositoryITests {
 		findById.setAttribute(attrName, attrValue);
 
 		String originalFindById = findById.getId();
-		String changeSessionId = findById.changeSessionId();
+		String changeSessionId = "1";
+		findById.changeSessionId(changeSessionId);
 
 		this.repository.save(findById);
 
@@ -147,7 +151,7 @@ abstract class AbstractHazelcastIndexedSessionRepositoryITests {
 	void changeSessionIdWhenHasNotSaved() {
 		HazelcastSession toSave = this.repository.createSession();
 		String originalId = toSave.getId();
-		toSave.changeSessionId();
+		toSave.changeSessionId("1");
 
 		this.repository.save(toSave);
 

--- a/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/SessionEventHazelcastIndexedSessionRepositoryTests.java
+++ b/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/SessionEventHazelcastIndexedSessionRepositoryTests.java
@@ -52,6 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Tommy Ludwig
  * @author Vedran Pavic
+ * @author Jakub Maciej
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
@@ -172,7 +173,7 @@ class SessionEventHazelcastIndexedSessionRepositoryTests<S extends Session> {
 				.isInstanceOf(SessionCreatedEvent.class);
 		this.registry.clear();
 
-		sessionToSave.changeSessionId();
+		sessionToSave.changeSessionId("1");
 		this.repository.save(sessionToSave);
 
 		assertThat(this.registry.receivedEvent(sessionToSave.getId())).isFalse();

--- a/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/HazelcastIndexedSessionRepository.java
+++ b/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/HazelcastIndexedSessionRepository.java
@@ -135,7 +135,7 @@ public class HazelcastIndexedSessionRepository
 
 	private final HazelcastInstance hazelcastInstance;
 
-	private SessionIdStrategy idGenerationStrategy = SessionIdStrategy.getDefaultGenerationStrategy();
+	private SessionIdStrategy sessionIdStrategy = SessionIdStrategy.getDefaultSessionIdStrategy();
 
 	private ApplicationEventPublisher eventPublisher = (event) -> {
 	};
@@ -238,7 +238,7 @@ public class HazelcastIndexedSessionRepository
 
 	@Override
 	public HazelcastSession createSession() {
-		MapSession cached = new MapSession(this.idGenerationStrategy.createSessionId());
+		MapSession cached = new MapSession(this.sessionIdStrategy.createSessionId());
 		if (this.defaultMaxInactiveInterval != null) {
 			cached.setMaxInactiveInterval(Duration.ofSeconds(this.defaultMaxInactiveInterval));
 		}
@@ -302,7 +302,7 @@ public class HazelcastIndexedSessionRepository
 
 	@Override
 	public String changeSessionId(final HazelcastSession session) {
-		String newId = this.idGenerationStrategy.createSessionId();
+		String newId = this.sessionIdStrategy.createSessionId();
 		session.changeSessionId(newId);
 		return newId;
 	}
@@ -350,8 +350,8 @@ public class HazelcastIndexedSessionRepository
 		}
 	}
 
-	public void setIdGenerationStrategy(final SessionIdStrategy idGenerationStrategy) {
-		this.idGenerationStrategy = idGenerationStrategy;
+	public void setSessionIdStrategy(final SessionIdStrategy sessionIdStrategy) {
+		this.sessionIdStrategy = sessionIdStrategy;
 	}
 
 	/**

--- a/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/HazelcastIndexedSessionRepository.java
+++ b/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/HazelcastIndexedSessionRepository.java
@@ -412,6 +412,7 @@ public class HazelcastIndexedSessionRepository
 		public void changeSessionId(final String id) {
 			this.delegate.changeSessionId(id);
 			this.sessionIdChanged = true;
+			flushImmediateIfNecessary();
 		}
 
 		@Override

--- a/spring-session-hazelcast/src/test/java/org/springframework/session/hazelcast/HazelcastIndexedSessionRepositoryTests.java
+++ b/spring-session-hazelcast/src/test/java/org/springframework/session/hazelcast/HazelcastIndexedSessionRepositoryTests.java
@@ -98,7 +98,7 @@ class HazelcastIndexedSessionRepositoryTests {
 
 		HazelcastSession session = this.repository.createSession();
 
-		assertThat(session.getMaxInactiveInterval()).isEqualTo(new MapSession().getMaxInactiveInterval());
+		assertThat(session.getMaxInactiveInterval()).isEqualTo(new MapSession("1").getMaxInactiveInterval());
 		verifyZeroInteractions(this.sessions);
 	}
 
@@ -306,7 +306,7 @@ class HazelcastIndexedSessionRepositoryTests {
 	void getSessionExpired() {
 		verify(this.sessions, times(1)).addEntryListener(any(MapListener.class), anyBoolean());
 
-		MapSession expired = new MapSession();
+		MapSession expired = new MapSession("1");
 		expired.setLastAccessedTime(Instant.now().minusSeconds(MapSession.DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS + 1));
 		given(this.sessions.get(eq(expired.getId()))).willReturn(expired);
 
@@ -322,7 +322,7 @@ class HazelcastIndexedSessionRepositoryTests {
 	void getSessionFound() {
 		verify(this.sessions, times(1)).addEntryListener(any(MapListener.class), anyBoolean());
 
-		MapSession saved = new MapSession();
+		MapSession saved = new MapSession("1");
 		saved.setAttribute("savedName", "savedValue");
 		given(this.sessions.get(eq(saved.getId()))).willReturn(saved);
 
@@ -381,10 +381,10 @@ class HazelcastIndexedSessionRepositoryTests {
 		Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "notused",
 				AuthorityUtils.createAuthorityList("ROLE_USER"));
 		List<MapSession> saved = new ArrayList<>(2);
-		MapSession saved1 = new MapSession();
+		MapSession saved1 = new MapSession("1");
 		saved1.setAttribute(SPRING_SECURITY_CONTEXT, authentication);
 		saved.add(saved1);
-		MapSession saved2 = new MapSession();
+		MapSession saved2 = new MapSession("2");
 		saved2.setAttribute(SPRING_SECURITY_CONTEXT, authentication);
 		saved.add(saved2);
 		given(this.sessions.values(isA(EqualPredicate.class))).willReturn(saved);
@@ -415,7 +415,7 @@ class HazelcastIndexedSessionRepositoryTests {
 	void saveWithSaveModeOnSetAttribute() {
 		verify(this.sessions).addEntryListener(any(MapListener.class), anyBoolean());
 		this.repository.setSaveMode(SaveMode.ON_SET_ATTRIBUTE);
-		MapSession delegate = new MapSession();
+		MapSession delegate = new MapSession("1");
 		delegate.setAttribute("attribute1", "value1");
 		delegate.setAttribute("attribute2", "value2");
 		delegate.setAttribute("attribute3", "value3");
@@ -434,7 +434,7 @@ class HazelcastIndexedSessionRepositoryTests {
 	void saveWithSaveModeOnGetAttribute() {
 		verify(this.sessions).addEntryListener(any(MapListener.class), anyBoolean());
 		this.repository.setSaveMode(SaveMode.ON_GET_ATTRIBUTE);
-		MapSession delegate = new MapSession();
+		MapSession delegate = new MapSession("1");
 		delegate.setAttribute("attribute1", "value1");
 		delegate.setAttribute("attribute2", "value2");
 		delegate.setAttribute("attribute3", "value3");
@@ -453,7 +453,7 @@ class HazelcastIndexedSessionRepositoryTests {
 	void saveWithSaveModeAlways() {
 		verify(this.sessions).addEntryListener(any(MapListener.class), anyBoolean());
 		this.repository.setSaveMode(SaveMode.ALWAYS);
-		MapSession delegate = new MapSession();
+		MapSession delegate = new MapSession("1");
 		delegate.setAttribute("attribute1", "value1");
 		delegate.setAttribute("attribute2", "value2");
 		delegate.setAttribute("attribute3", "value3");

--- a/spring-session-jdbc/src/integration-test/java/org/springframework/session/jdbc/AbstractJdbcIndexedSessionRepositoryITests.java
+++ b/spring-session-jdbc/src/integration-test/java/org/springframework/session/jdbc/AbstractJdbcIndexedSessionRepositoryITests.java
@@ -578,7 +578,8 @@ abstract class AbstractJdbcIndexedSessionRepositoryITests {
 		assertThat(findById.<String>getAttribute(attrName)).isEqualTo(attrValue);
 
 		String originalFindById = findById.getId();
-		String changeSessionId = findById.changeSessionId();
+		String changeSessionId = "1";
+		findById.changeSessionId(changeSessionId);
 
 		this.repository.save(findById);
 
@@ -598,8 +599,10 @@ abstract class AbstractJdbcIndexedSessionRepositoryITests {
 		this.repository.save(toSave);
 
 		String originalId = toSave.getId();
-		String changeId1 = toSave.changeSessionId();
-		String changeId2 = toSave.changeSessionId();
+		String changeId1 = "1";
+		toSave.changeSessionId(changeId1);
+		String changeId2 = "2";
+		toSave.changeSessionId(changeId2);
 
 		this.repository.save(toSave);
 
@@ -622,7 +625,8 @@ abstract class AbstractJdbcIndexedSessionRepositoryITests {
 		findById.setAttribute(attrName, attrValue);
 
 		String originalFindById = findById.getId();
-		String changeSessionId = findById.changeSessionId();
+		String changeSessionId = "1";
+		findById.changeSessionId(changeSessionId);
 
 		this.repository.save(findById);
 
@@ -639,7 +643,7 @@ abstract class AbstractJdbcIndexedSessionRepositoryITests {
 	void changeSessionIdWhenHasNotSaved() {
 		JdbcSession toSave = this.repository.createSession();
 		String originalId = toSave.getId();
-		toSave.changeSessionId();
+		toSave.changeSessionId("1");
 
 		this.repository.save(toSave);
 
@@ -647,7 +651,8 @@ abstract class AbstractJdbcIndexedSessionRepositoryITests {
 		assertThat(this.repository.findById(originalId)).isNull();
 	}
 
-	@Test // gh-1070
+	@Test
+	// gh-1070
 	void saveUpdatedAddAndModifyAttribute() {
 		JdbcSession session = this.repository.createSession();
 		this.repository.save(session);
@@ -660,7 +665,8 @@ abstract class AbstractJdbcIndexedSessionRepositoryITests {
 		assertThat(session.<String>getAttribute("testName")).isEqualTo("testValue2");
 	}
 
-	@Test // gh-1070
+	@Test
+	// gh-1070
 	void saveUpdatedAddAndRemoveAttribute() {
 		JdbcSession session = this.repository.createSession();
 		this.repository.save(session);
@@ -673,7 +679,8 @@ abstract class AbstractJdbcIndexedSessionRepositoryITests {
 		assertThat(session.<String>getAttribute("testName")).isNull();
 	}
 
-	@Test // gh-1070
+	@Test
+	// gh-1070
 	void saveUpdatedModifyAndRemoveAttribute() {
 		JdbcSession session = this.repository.createSession();
 		session.setAttribute("testName", "testValue1");
@@ -687,7 +694,8 @@ abstract class AbstractJdbcIndexedSessionRepositoryITests {
 		assertThat(session.<String>getAttribute("testName")).isNull();
 	}
 
-	@Test // gh-1070
+	@Test
+	// gh-1070
 	void saveUpdatedRemoveAndAddAttribute() {
 		JdbcSession session = this.repository.createSession();
 		session.setAttribute("testName", "testValue1");
@@ -701,7 +709,8 @@ abstract class AbstractJdbcIndexedSessionRepositoryITests {
 		assertThat(session.<String>getAttribute("testName")).isEqualTo("testValue2");
 	}
 
-	@Test // gh-1031
+	@Test
+	// gh-1031
 	void saveDeleted() {
 		JdbcSession session = this.repository.createSession();
 		this.repository.save(session);
@@ -713,7 +722,8 @@ abstract class AbstractJdbcIndexedSessionRepositoryITests {
 		assertThat(this.repository.findById(session.getId())).isNull();
 	}
 
-	@Test // gh-1031
+	@Test
+	// gh-1031
 	void saveDeletedAddAttribute() {
 		JdbcSession session = this.repository.createSession();
 		this.repository.save(session);
@@ -726,7 +736,8 @@ abstract class AbstractJdbcIndexedSessionRepositoryITests {
 		assertThat(this.repository.findById(session.getId())).isNull();
 	}
 
-	@Test // gh-1133
+	@Test
+	// gh-1133
 	void sessionFromStoreResolvesAttributesLazily() {
 		JdbcSession session = this.repository.createSession();
 		session.setAttribute("attribute1", "value1");
@@ -745,7 +756,8 @@ abstract class AbstractJdbcIndexedSessionRepositoryITests {
 		assertThat(ReflectionTestUtils.getField(attribute2, "value")).isEqualTo("value2");
 	}
 
-	@Test // gh-1203
+	@Test
+	// gh-1203
 	void saveWithLargeAttribute() {
 		String attributeName = "largeAttribute";
 		int arraySize = 4000;

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcIndexedSessionRepository.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcIndexedSessionRepository.java
@@ -200,7 +200,7 @@ public class JdbcIndexedSessionRepository
 
 	private final ResultSetExtractor<List<JdbcSession>> extractor = new SessionResultSetExtractor();
 
-	private SessionIdStrategy idGenerationStrategy = SessionIdStrategy.getDefaultGenerationStrategy();
+	private SessionIdStrategy idGenerationStrategy = SessionIdStrategy.getDefaultSessionIdStrategy();
 
 	/**
 	 * The name of database table used by Spring Session to store sessions.

--- a/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcIndexedSessionRepositoryTests.java
+++ b/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcIndexedSessionRepositoryTests.java
@@ -242,7 +242,7 @@ class JdbcIndexedSessionRepositoryTests {
 		JdbcSession session = this.repository.createSession();
 
 		assertThat(session.isNew()).isTrue();
-		assertThat(session.getMaxInactiveInterval()).isEqualTo(new MapSession().getMaxInactiveInterval());
+		assertThat(session.getMaxInactiveInterval()).isEqualTo(new MapSession("1").getMaxInactiveInterval());
 		verifyNoMoreInteractions(this.jdbcOperations);
 	}
 
@@ -311,7 +311,7 @@ class JdbcIndexedSessionRepositoryTests {
 
 	@Test
 	void saveUpdatedAddSingleAttribute() {
-		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
+		JdbcSession session = this.repository.new JdbcSession(new MapSession("1"), "primaryKey", false);
 		session.setAttribute("testName", "testValue");
 
 		this.repository.save(session);
@@ -324,7 +324,7 @@ class JdbcIndexedSessionRepositoryTests {
 
 	@Test
 	void saveUpdatedAddMultipleAttributes() {
-		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
+		JdbcSession session = this.repository.new JdbcSession(new MapSession("1"), "primaryKey", false);
 		session.setAttribute("testName1", "testValue1");
 		session.setAttribute("testName2", "testValue2");
 
@@ -338,7 +338,7 @@ class JdbcIndexedSessionRepositoryTests {
 
 	@Test
 	void saveUpdatedModifySingleAttribute() {
-		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
+		JdbcSession session = this.repository.new JdbcSession(new MapSession("1"), "primaryKey", false);
 		session.setAttribute("testName", "testValue");
 		session.clearChangeFlags();
 		session.setAttribute("testName", "testValue");
@@ -353,7 +353,7 @@ class JdbcIndexedSessionRepositoryTests {
 
 	@Test
 	void saveUpdatedModifyMultipleAttributes() {
-		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
+		JdbcSession session = this.repository.new JdbcSession(new MapSession("1"), "primaryKey", false);
 		session.setAttribute("testName1", "testValue1");
 		session.setAttribute("testName2", "testValue2");
 		session.clearChangeFlags();
@@ -370,7 +370,7 @@ class JdbcIndexedSessionRepositoryTests {
 
 	@Test
 	void saveUpdatedRemoveSingleAttribute() {
-		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
+		JdbcSession session = this.repository.new JdbcSession(new MapSession("1"), "primaryKey", false);
 		session.setAttribute("testName", "testValue");
 		session.clearChangeFlags();
 		session.removeAttribute("testName");
@@ -385,7 +385,7 @@ class JdbcIndexedSessionRepositoryTests {
 
 	@Test
 	void saveUpdatedRemoveNonExistingAttribute() {
-		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
+		JdbcSession session = this.repository.new JdbcSession(new MapSession("1"), "primaryKey", false);
 		session.removeAttribute("testName");
 
 		this.repository.save(session);
@@ -396,7 +396,7 @@ class JdbcIndexedSessionRepositoryTests {
 
 	@Test
 	void saveUpdatedRemoveMultipleAttributes() {
-		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
+		JdbcSession session = this.repository.new JdbcSession(new MapSession("1"), "primaryKey", false);
 		session.setAttribute("testName1", "testValue1");
 		session.setAttribute("testName2", "testValue2");
 		session.clearChangeFlags();
@@ -413,7 +413,7 @@ class JdbcIndexedSessionRepositoryTests {
 
 	@Test // gh-1070
 	void saveUpdatedAddAndModifyAttribute() {
-		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
+		JdbcSession session = this.repository.new JdbcSession(new MapSession("1"), "primaryKey", false);
 		session.setAttribute("testName", "testValue1");
 		session.setAttribute("testName", "testValue2");
 
@@ -427,7 +427,7 @@ class JdbcIndexedSessionRepositoryTests {
 
 	@Test // gh-1070
 	void saveUpdatedAddAndRemoveAttribute() {
-		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
+		JdbcSession session = this.repository.new JdbcSession(new MapSession("1"), "primaryKey", false);
 		session.setAttribute("testName", "testValue");
 		session.removeAttribute("testName");
 
@@ -439,7 +439,7 @@ class JdbcIndexedSessionRepositoryTests {
 
 	@Test // gh-1070
 	void saveUpdatedModifyAndRemoveAttribute() {
-		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
+		JdbcSession session = this.repository.new JdbcSession(new MapSession("1"), "primaryKey", false);
 		session.setAttribute("testName", "testValue1");
 		session.clearChangeFlags();
 		session.setAttribute("testName", "testValue2");
@@ -455,7 +455,7 @@ class JdbcIndexedSessionRepositoryTests {
 
 	@Test // gh-1070
 	void saveUpdatedRemoveAndAddAttribute() {
-		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
+		JdbcSession session = this.repository.new JdbcSession(new MapSession("1"), "primaryKey", false);
 		session.setAttribute("testName", "testValue1");
 		session.clearChangeFlags();
 		session.removeAttribute("testName");
@@ -471,7 +471,7 @@ class JdbcIndexedSessionRepositoryTests {
 
 	@Test
 	void saveUpdatedLastAccessedTime() {
-		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
+		JdbcSession session = this.repository.new JdbcSession(new MapSession("1"), "primaryKey", false);
 		session.setLastAccessedTime(Instant.now());
 
 		this.repository.save(session);
@@ -484,7 +484,7 @@ class JdbcIndexedSessionRepositoryTests {
 
 	@Test
 	void saveUnchanged() {
-		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
+		JdbcSession session = this.repository.new JdbcSession(new MapSession("1"), "primaryKey", false);
 
 		this.repository.save(session);
 
@@ -525,7 +525,7 @@ class JdbcIndexedSessionRepositoryTests {
 	@Test
 	@SuppressWarnings("unchecked")
 	void getSessionFound() {
-		Session saved = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
+		Session saved = this.repository.new JdbcSession(new MapSession("1"), "primaryKey", false);
 		saved.setAttribute("savedName", "savedValue");
 		given(this.jdbcOperations.query(isA(String.class), isA(PreparedStatementSetter.class),
 				isA(ResultSetExtractor.class))).willReturn(Collections.singletonList(saved));
@@ -620,7 +620,7 @@ class JdbcIndexedSessionRepositoryTests {
 	@Test
 	void saveWithSaveModeOnSetAttribute() {
 		this.repository.setSaveMode(SaveMode.ON_SET_ATTRIBUTE);
-		MapSession delegate = new MapSession();
+		MapSession delegate = new MapSession("1");
 		delegate.setAttribute("attribute1", (Supplier<String>) () -> "value1");
 		delegate.setAttribute("attribute2", (Supplier<String>) () -> "value2");
 		delegate.setAttribute("attribute3", (Supplier<String>) () -> "value3");
@@ -636,7 +636,7 @@ class JdbcIndexedSessionRepositoryTests {
 	@Test
 	void saveWithSaveModeOnGetAttribute() {
 		this.repository.setSaveMode(SaveMode.ON_GET_ATTRIBUTE);
-		MapSession delegate = new MapSession();
+		MapSession delegate = new MapSession("1");
 		delegate.setAttribute("attribute1", (Supplier<String>) () -> "value1");
 		delegate.setAttribute("attribute2", (Supplier<String>) () -> "value2");
 		delegate.setAttribute("attribute3", (Supplier<String>) () -> "value3");
@@ -654,7 +654,7 @@ class JdbcIndexedSessionRepositoryTests {
 	@Test
 	void saveWithSaveModeAlways() {
 		this.repository.setSaveMode(SaveMode.ALWAYS);
-		MapSession delegate = new MapSession();
+		MapSession delegate = new MapSession("1");
 		delegate.setAttribute("attribute1", (Supplier<String>) () -> "value1");
 		delegate.setAttribute("attribute2", (Supplier<String>) () -> "value2");
 		delegate.setAttribute("attribute3", (Supplier<String>) () -> "value3");
@@ -672,7 +672,7 @@ class JdbcIndexedSessionRepositoryTests {
 	@Test
 	void flushModeImmediateSetAttribute() {
 		this.repository.setFlushMode(FlushMode.IMMEDIATE);
-		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
+		JdbcSession session = this.repository.new JdbcSession(new MapSession("1"), "primaryKey", false);
 		String attrName = "someAttribute";
 		session.setAttribute(attrName, "someValue");
 		verify(this.jdbcOperations).update(startsWith("INSERT INTO SPRING_SESSION_ATTRIBUTES("),
@@ -683,7 +683,7 @@ class JdbcIndexedSessionRepositoryTests {
 	@Test
 	void flushModeImmediateRemoveAttribute() {
 		this.repository.setFlushMode(FlushMode.IMMEDIATE);
-		MapSession cached = new MapSession();
+		MapSession cached = new MapSession("1");
 		cached.setAttribute("attribute1", "value1");
 		JdbcSession session = this.repository.new JdbcSession(cached, "primaryKey", false);
 		session.removeAttribute("attribute1");
@@ -695,7 +695,7 @@ class JdbcIndexedSessionRepositoryTests {
 	@Test
 	void flushModeSetMaxInactiveIntervalInSeconds() {
 		this.repository.setFlushMode(FlushMode.IMMEDIATE);
-		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
+		JdbcSession session = this.repository.new JdbcSession(new MapSession("1"), "primaryKey", false);
 		session.setMaxInactiveInterval(Duration.ofSeconds(1));
 		verify(this.jdbcOperations).update(startsWith("UPDATE SPRING_SESSION SET"), isA(PreparedStatementSetter.class));
 		verifyNoMoreInteractions(this.jdbcOperations);
@@ -704,7 +704,7 @@ class JdbcIndexedSessionRepositoryTests {
 	@Test
 	void flushModeSetLastAccessedTime() {
 		this.repository.setFlushMode(FlushMode.IMMEDIATE);
-		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
+		JdbcSession session = this.repository.new JdbcSession(new MapSession("1"), "primaryKey", false);
 		session.setLastAccessedTime(Instant.now());
 		verify(this.jdbcOperations).update(startsWith("UPDATE SPRING_SESSION SET"), isA(PreparedStatementSetter.class));
 		verifyNoMoreInteractions(this.jdbcOperations);


### PR DESCRIPTION

After creating PR : #1545 I became aware of **long** ongoing disscusion about 
session generation strategy mainly : #204 which has merge conflicts and author is not present for quite a while, and a general issue #11 going back to 3 Jul 2014.

I tought i would try to takle the problem myself with the strategy approach (differently than in #1545). This PR is my attempt at assimilating strategy based way of controlling id generation process.

While I still prefer #1545 way of doing things 'this' PR is closer the expected behaviour of #11. 
But not without a few pros and cons. 

 #1545 is less invasive - it provides means of controlling session id without changing too much. #1545 doesn't break any existing functionality - especially it doesn't remove any existing methodes - it only adds new.

 At the same time `this` PR while gives us more elegant way of handling session id. It requires us to change a few things , mainly :

- Session creation is not session class reponsibility - it is session-repository reponsibility and as a result - `MapSession` should get valid id from _session-repository instead_ of creating it by itself. While this is easly guaranteed by removal of no-args constructor in `MapSession` it requires us to modify `changeId` methode signature in MapSession. The new id for session should be provided to session externally.

- Existing session repository implementations should provide a way of changing session generation strategy and as a result all session repository should implement additional method "changeSessionId".

Additionally since spring-session is a library - we don't want to introduce any new unwanted behaviour to projects rellying on it. Thats why i additionaly introduce UUIDSessionIdStrategy which is a default go-to behaviour for all session repositories if no strategy is provided.

- As a additional feature it would be nice to expand configuration with a means to customize session id strategy . For example add additional config field to EnableHazelcastHttpSession. 

For now i dont want this PR to grow to large or out of scope so I willy probably try to add the aformentioned feature as a separate PR if `this` gets accepted.