### PR TITLE
Fix example in JavaDocs of EnableSpringHttpSession

### DIFF
--- a/spring-session-core/src/main/java/org/springframework/session/config/annotation/web/http/EnableSpringHttpSession.java
+++ b/spring-session-core/src/main/java/org/springframework/session/config/annotation/web/http/EnableSpringHttpSession.java
@@ -40,7 +40,7 @@ import org.springframework.session.events.SessionDestroyedEvent;
  *
  *     {@literal @Bean}
  *     public MapSessionRepository sessionRepository() {
- *         return new MapSessionRepository();
+ *         return new MapSessionRepository(new ConcurrentHashMap<>());
  *     }
  *
  * }

--- a/spring-session-core/src/main/java/org/springframework/session/config/annotation/web/http/SpringHttpSessionConfiguration.java
+++ b/spring-session-core/src/main/java/org/springframework/session/config/annotation/web/http/SpringHttpSessionConfiguration.java
@@ -58,7 +58,7 @@ import org.springframework.util.ObjectUtils;
  *
  *     {@literal @Bean}
  *     public MapSessionRepository sessionRepository() {
- *         return new MapSessionRepository();
+ *         return new MapSessionRepository(new ConcurrentHashMap<>());
  *     }
  *
  * }

--- a/spring-session-core/src/main/java/org/springframework/session/config/annotation/web/server/EnableSpringWebSession.java
+++ b/spring-session-core/src/main/java/org/springframework/session/config/annotation/web/server/EnableSpringWebSession.java
@@ -36,7 +36,7 @@ import org.springframework.context.annotation.Import;
  *
  *     {@literal @Bean}
  *     public ReactiveSessionRepository sessionRepository() {
- *         return new ReactiveMapSessionRepository();
+ *         return new ReactiveMapSessionRepository(new ConcurrentHashMap<>());
  *     }
  *
  * }


### PR DESCRIPTION
The examples in JavaDocs of @EnableSpringHttpSession, SpringHttpSessionConfiguration and @EnableSpringWebSession were creating MapSessionRepository / ReactiveMapSessionRepository using a constructor, which no longer exists in the classes. This should allow the examples to be used out of the box.