### PR TITLE
Use cached requestedSession info if available

### DIFF
--- a/spring-session-core/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
+++ b/spring-session-core/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
@@ -221,10 +221,11 @@ public class SessionRepositoryFilter<S extends Session> extends OncePerRequestFi
 			}
 			else {
 				S session = wrappedSession.getSession();
+				String sessionId = session.getId();
+				boolean isRequestedSession = isRequestedSessionIdValid() && sessionId.equals(getRequestedSessionId());
 				clearRequestedSessionCache();
 				SessionRepositoryFilter.this.sessionRepository.save(session);
-				String sessionId = session.getId();
-				if (!isRequestedSessionIdValid() || !sessionId.equals(getRequestedSessionId())) {
+				if (!isRequestedSession) {
 					SessionRepositoryFilter.this.httpSessionIdResolver.setSessionId(this, this.response, sessionId);
 				}
 			}


### PR DESCRIPTION
Prevent fetching the session multiple times when checking whether the
sessionId has to be sent to the client, by comparing values before
clearing the requestedSessionCache.

Resolves: #1424