### PR TITLE
Fix a bad typo

### DIFF
--- a/spring-session-docs/src/docs/asciidoc/index.adoc
+++ b/spring-session-docs/src/docs/asciidoc/index.adoc
@@ -289,7 +289,7 @@ Any method that returns an `HttpSession` is overridden.
 All other methods are implemented by `HttpServletRequestWrapper` and delegate to the original `HttpServletRequest` implementation.
 
 We replace the `HttpServletRequest` implementation by using a servlet `Filter` called `SessionRepositoryFilter`.
-The pseudocode belows:
+The following pseudocode shows how it works:
 
 ====
 [source, java]


### PR DESCRIPTION
Caught an egregious typing error from my own earlier work.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
