### PR TITLE
Update OncePerRequestFilter to match with spring-web

### DIFF
--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -14,6 +14,7 @@ dependencyManagement {
 			entry 'hazelcast-client'
 		}
 
+		dependency 'org.aspectj:aspectjweaver:1.9.6'
 		dependency 'com.h2database:h2:1.4.200'
 		dependency 'com.ibm.db2:jcc:11.5.0.0'
 		dependency 'com.microsoft.sqlserver:mssql-jdbc:7.4.1.jre8'

--- a/spring-session-core/spring-session-core.gradle
+++ b/spring-session-core/spring-session-core.gradle
@@ -25,5 +25,6 @@ dependencies {
 	testCompile "org.springframework.security:spring-security-core"
 	testCompile "org.junit.jupiter:junit-jupiter-api"
 	testCompile "org.junit.jupiter:junit-jupiter-params"
+	testCompile "org.aspectj:aspectjweaver"
 	testRuntime "org.junit.jupiter:junit-jupiter-engine"
 }

--- a/spring-session-core/src/main/java/org/springframework/session/web/http/OncePerRequestFilter.java
+++ b/spring-session-core/src/main/java/org/springframework/session/web/http/OncePerRequestFilter.java
@@ -64,7 +64,7 @@ abstract class OncePerRequestFilter implements Filter {
 		}
 		HttpServletRequest httpRequest = (HttpServletRequest) request;
 		HttpServletResponse httpResponse = (HttpServletResponse) response;
-		String alreadyFilteredAttributeName = this.alreadyFilteredAttributeName;
+		String alreadyFilteredAttributeName = getAlreadyFilteredAttributeName();
 		boolean hasAlreadyFilteredAttribute = request.getAttribute(alreadyFilteredAttributeName) != null;
 
 		if (hasAlreadyFilteredAttribute) {

--- a/spring-session-core/src/test/java/org/springframework/session/web/http/OncePerRequestFilterAopTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/web/http/OncePerRequestFilterAopTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.web.http;
+
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.session.SessionRepository;
+import org.springframework.session.web.http.OncePerRequestFilterAopTests.Config;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@SpringJUnitConfig(classes = Config.class)
+class OncePerRequestFilterAopTests {
+
+	@Test
+	void doFilterOnce(@Autowired final OncePerRequestFilter filter) {
+		assertThatCode(() -> filter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(),
+				new MockFilterChain())).as("`doFilter` does not throw NPE with the bean is being proxied by Spring AOP")
+						.doesNotThrowAnyException();
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Configuration
+	@EnableAspectJAutoProxy(proxyTargetClass = true)
+	@Aspect
+	public static class Config {
+
+		@Bean
+		public SessionRepository sessionRepository() {
+			return Mockito.mock(SessionRepository.class);
+		}
+
+		@Bean
+		public SessionRepositoryFilter filter() {
+			return new SessionRepositoryFilter(sessionRepository());
+		}
+
+		@AfterReturning("execution(* SessionRepositoryFilter.doFilterInternal(..))")
+		public void doInternalFilterPoincut() {
+			// no op
+		}
+
+	}
+
+}

--- a/spring-session-core/src/test/java/org/springframework/session/web/http/OncePerRequestFilterAopTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/web/http/OncePerRequestFilterAopTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ class OncePerRequestFilterAopTests {
 		}
 
 		@AfterReturning("execution(* SessionRepositoryFilter.doFilterInternal(..))")
-		public void doInternalFilterPoincut() {
+		public void doInternalFilterPointcut() {
 			// no op
 		}
 


### PR DESCRIPTION
Call "getAlreadyFilteredAttributeName()" instead of direct usage if private "this.alreadyFilteredAttributeName"

Fix the error of the property value is null when proxied by CGLIB (bean from extending SessionRepositoryFilter)

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
