### PR TITLE
Fix indentation for cron job

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - master
-    schedule:
-      - cron: '0 10 * * *' # Once per day at 10am UTC
+  schedule:
+    - cron: '0 10 * * *' # Once per day at 10am UTC
 
 jobs:
   build:


### PR DESCRIPTION
While looking for the expected nightly cron job builds, I didn't find them. After doing some research, I realized the indentation for part of the YAML file was off. This PR fixes that indentation so that the CI build is run as part of a nightly cron job.

Note: I opened this from the root repository so that we can see if it works (it should trigger a cron job 10am UTC / 3am PST). By opening it from the root, we ensure the job will have access to secrets and the build can run correctly. 