### PR TITLE
Add optional Hazelcast session serializer

### DIFF
--- a/spring-session-docs/src/docs/asciidoc/guides/java-hazelcast.adoc
+++ b/spring-session-docs/src/docs/asciidoc/guides/java-hazelcast.adoc
@@ -97,10 +97,17 @@ The filter is in charge of replacing the `HttpSession` implementation to be back
 In this instance, Spring Session is backed by Hazelcast.
 <2> In order to support retrieval of sessions by principal name index, an appropriate `ValueExtractor` needs to be registered.
 Spring Session provides `PrincipalNameExtractor` for this purpose.
-<3> We create a `HazelcastInstance` that connects Spring Session to Hazelcast.
+<3> In order to serialize `MapSession` objects efficiently, `HazelcastSessionSerializer` needs to be registered. If this
+is not set, Hazelcast will serialize sessions using native Java serialization.
+<4> We create a `HazelcastInstance` that connects Spring Session to Hazelcast.
 By default, the application starts and connects to an embedded instance of Hazelcast.
 For more information on configuring Hazelcast, see the https://docs.hazelcast.org/docs/{hazelcast-version}/manual/html-single/index.html#hazelcast-configuration[reference documentation].
 ====
+
+NOTE: If `HazelcastSessionSerializer` is preferred, it needs to be configured for all Hazelcast cluster members before they start.
+In a Hazelcast cluster, all members should use the same serialization method for sessions. Also, if Hazelcast Client/Server topology
+is used, then both members and clients must use the same serialization method. The serializer can be registered via `ClientConfig`
+with the same `SerializerConfiguration` of members.
 
 == Servlet Container Initialization
 

--- a/spring-session-docs/src/test/java/docs/http/HazelcastHttpSessionConfig.java
+++ b/spring-session-docs/src/test/java/docs/http/HazelcastHttpSessionConfig.java
@@ -19,12 +19,15 @@ package docs.http;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapAttributeConfig;
 import com.hazelcast.config.MapIndexConfig;
+import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.session.MapSession;
 import org.springframework.session.hazelcast.HazelcastIndexedSessionRepository;
+import org.springframework.session.hazelcast.HazelcastSessionSerializer;
 import org.springframework.session.hazelcast.PrincipalNameExtractor;
 import org.springframework.session.hazelcast.config.annotation.web.http.EnableHazelcastHttpSession;
 
@@ -42,7 +45,10 @@ public class HazelcastHttpSessionConfig {
 		config.getMapConfig(HazelcastIndexedSessionRepository.DEFAULT_SESSION_MAP_NAME) // <2>
 				.addMapAttributeConfig(attributeConfig).addMapIndexConfig(
 						new MapIndexConfig(HazelcastIndexedSessionRepository.PRINCIPAL_NAME_ATTRIBUTE, false));
-		return Hazelcast.newHazelcastInstance(config); // <3>
+		SerializerConfig serializerConfig = new SerializerConfig();
+		serializerConfig.setImplementation(new HazelcastSessionSerializer()).setTypeClass(MapSession.class);
+		config.getSerializationConfig().addSerializerConfig(serializerConfig); // <3>
+		return Hazelcast.newHazelcastInstance(config); // <4>
 	}
 
 }

--- a/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/HazelcastITestUtils.java
+++ b/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/HazelcastITestUtils.java
@@ -20,8 +20,10 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.MapAttributeConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import org.springframework.session.MapSession;
 
 /**
  * Utility class for Hazelcast integration tests.
@@ -48,6 +50,9 @@ final class HazelcastITestUtils {
 		config.getMapConfig(HazelcastIndexedSessionRepository.DEFAULT_SESSION_MAP_NAME)
 				.addMapAttributeConfig(attributeConfig).addMapIndexConfig(
 						new MapIndexConfig(HazelcastIndexedSessionRepository.PRINCIPAL_NAME_ATTRIBUTE, false));
+		SerializerConfig serializerConfig = new SerializerConfig();
+		serializerConfig.setImplementation(new HazelcastSessionSerializer()).setTypeClass(MapSession.class);
+		config.getSerializationConfig().addSerializerConfig(serializerConfig);
 		return Hazelcast.newHazelcastInstance(config);
 	}
 

--- a/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/HazelcastITestUtils.java
+++ b/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/HazelcastITestUtils.java
@@ -23,6 +23,7 @@ import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+
 import org.springframework.session.MapSession;
 
 /**

--- a/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/HazelcastSessionSerializer.java
+++ b/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/HazelcastSessionSerializer.java
@@ -1,0 +1,87 @@
+package org.springframework.session.hazelcast;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.StreamSerializer;
+import org.springframework.session.MapSession;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+
+public class HazelcastSessionSerializer implements StreamSerializer<MapSession> {
+
+	private static final int SERIALIZER_TYPE_ID = 12345;
+
+	@Override
+	public void write(ObjectDataOutput out, MapSession session) throws IOException {
+		out.writeUTF(session.getOriginalId());
+		out.writeUTF(session.getId());
+		writeInstant(out, session.getCreationTime());
+		writeInstant(out, session.getLastAccessedTime());
+		writeDuration(out, session.getMaxInactiveInterval());
+		for (String attrName : session.getAttributeNames()) {
+			Object attrValue = session.getAttribute(attrName);
+			if (attrValue != null) {
+				out.writeUTF(attrName);
+				out.writeObject(attrValue);
+			}
+		}
+	}
+
+	private void writeInstant(ObjectDataOutput out, Instant instant) throws IOException {
+		out.writeLong(instant.getEpochSecond());
+		out.writeInt(instant.getNano());
+	}
+
+	private void writeDuration(ObjectDataOutput out, Duration duration) throws IOException {
+		out.writeLong(duration.getSeconds());
+		out.writeInt(duration.getNano());
+	}
+
+	@Override
+	public MapSession read(ObjectDataInput in) throws IOException {
+		String originalId = in.readUTF();
+		MapSession cached = new MapSession(originalId);
+		cached.setId(in.readUTF());
+		cached.setCreationTime(readInstant(in));
+		cached.setLastAccessedTime(readInstant(in));
+		cached.setMaxInactiveInterval(readDuration(in));
+		try {
+			while (true) {
+				// During write, it's not possible to write
+				// number of non-null attributes without an extra
+				// iteration. Hence the attributes are read until
+				// EOF here.
+				String attrName = in.readUTF();
+				Object attrValue = in.readObject();
+				cached.setAttribute(attrName, attrValue);
+			}
+		} catch (EOFException ignored) {
+		}
+		return cached;
+	}
+
+	private Instant readInstant(ObjectDataInput in) throws IOException {
+		long seconds = in.readLong();
+		int nanos = in.readInt();
+		return Instant.ofEpochSecond(seconds, nanos);
+	}
+
+	private Duration readDuration(ObjectDataInput in) throws IOException {
+		long seconds = in.readLong();
+		int nanos = in.readInt();
+		return Duration.ofSeconds(seconds, nanos);
+	}
+
+	@Override
+	public int getTypeId() {
+		return SERIALIZER_TYPE_ID;
+	}
+
+	@Override
+	public void destroy() {
+	}
+
+}

--- a/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/HazelcastSessionSerializer.java
+++ b/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/HazelcastSessionSerializer.java
@@ -14,10 +14,12 @@ import java.time.Instant;
  * A {@link com.hazelcast.nio.serialization.Serializer} implementation that
  * handles the (de)serialization of {@link MapSession} stored on {@link com.hazelcast.core.IMap}.
  *
+ * <p>
  * The use of this serializer is optional and provides faster serialization of
  * sessions. If not configured to be used, Hazelcast will serialize sessions
  * via {@link java.io.Serializable} by default.
  *
+ * <p>
  * If multiple instances of a Spring application is run, then all of them need to use
  * the same serialization method. If this serializer is registered on one instance
  * and not another one, then it will end up with HazelcastSerializationException.
@@ -62,7 +64,7 @@ import java.time.Instant;
  */
 public class HazelcastSessionSerializer implements StreamSerializer<MapSession> {
 
-	private static final int SERIALIZER_TYPE_ID = 12345;
+	private static final int SERIALIZER_TYPE_ID = 1453;
 
 	@Override
 	public void write(ObjectDataOutput out, MapSession session) throws IOException {

--- a/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/HazelcastSessionSerializer.java
+++ b/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/HazelcastSessionSerializer.java
@@ -10,6 +10,56 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 
+/**
+ * A {@link com.hazelcast.nio.serialization.Serializer} implementation that
+ * handles the (de)serialization of {@link MapSession} stored on {@link com.hazelcast.core.IMap}.
+ *
+ * The use of this serializer is optional and provides faster serialization of
+ * sessions. If not configured to be used, Hazelcast will serialize sessions
+ * via {@link java.io.Serializable} by default.
+ *
+ * If multiple instances of a Spring application is run, then all of them need to use
+ * the same serialization method. If this serializer is registered on one instance
+ * and not another one, then it will end up with HazelcastSerializationException.
+ * The same applies when clients are configured to use this serializer but not the
+ * members, and vice versa. Also note that, if a new instance is created with this
+ * serialization but the existing Hazelcast cluster contains the values not serialized
+ * by this but instead the default one, this will result in incompatibility again.
+ *
+ * <p>
+ * An example of how to register the serializer on embedded instance can be seen below:
+ *
+ * <pre class="code">
+ * Config config = new Config();
+ *
+ * // ... other configurations for Hazelcast ...
+ *
+ * SerializerConfig serializerConfig = new SerializerConfig();
+ * serializerConfig.setImplementation(new HazelcastSessionSerializer()).setTypeClass(MapSession.class);
+ * config.getSerializationConfig().addSerializerConfig(serializerConfig);
+ *
+ * HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(config);
+ * </pre>
+ *
+ * Below is the example of how to register the serializer on client instance. Note that,
+ * to use the serializer in client/server mode, the serializer - and hence {@link MapSession},
+ * must exist on the server's classpath and must be registered via {@link com.hazelcast.config.SerializerConfig}
+ * with the configuration above for each server.
+ *
+ * <pre class="code">
+ * ClientConfig clientConfig = new ClientConfig();
+ *
+ * // ... other configurations for Hazelcast Client ...
+ *
+ * SerializerConfig serializerConfig = new SerializerConfig();
+ * serializerConfig.setImplementation(new HazelcastSessionSerializer()).setTypeClass(MapSession.class);
+ * clientConfig.getSerializationConfig().addSerializerConfig(serializerConfig);
+ *
+ * HazelcastInstance hazelcastClient = HazelcastClient.newHazelcastClient(clientConfig);
+ * </pre>
+ *
+ * @author Enes Ozcan
+ */
 public class HazelcastSessionSerializer implements StreamSerializer<MapSession> {
 
 	private static final int SERIALIZER_TYPE_ID = 12345;

--- a/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/HazelcastSessionSerializer.java
+++ b/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/HazelcastSessionSerializer.java
@@ -79,6 +79,7 @@ import org.springframework.session.MapSession;
  * </pre>
  *
  * @author Enes Ozcan
+ * @since 2.4.0
  */
 public class HazelcastSessionSerializer implements StreamSerializer<MapSession> {
 

--- a/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/HazelcastSessionSerializer.java
+++ b/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/HazelcastSessionSerializer.java
@@ -1,32 +1,49 @@
-package org.springframework.session.hazelcast;
+/*
+ * Copyright 2014-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.StreamSerializer;
-import org.springframework.session.MapSession;
+package org.springframework.session.hazelcast;
 
 import java.io.EOFException;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.StreamSerializer;
+
+import org.springframework.session.MapSession;
+
 /**
- * A {@link com.hazelcast.nio.serialization.Serializer} implementation that
- * handles the (de)serialization of {@link MapSession} stored on {@link com.hazelcast.core.IMap}.
+ * A {@link com.hazelcast.nio.serialization.Serializer} implementation that handles the
+ * (de)serialization of {@link MapSession} stored on {@link com.hazelcast.core.IMap}.
  *
  * <p>
- * The use of this serializer is optional and provides faster serialization of
- * sessions. If not configured to be used, Hazelcast will serialize sessions
- * via {@link java.io.Serializable} by default.
+ * The use of this serializer is optional and provides faster serialization of sessions.
+ * If not configured to be used, Hazelcast will serialize sessions via
+ * {@link java.io.Serializable} by default.
  *
  * <p>
- * If multiple instances of a Spring application is run, then all of them need to use
- * the same serialization method. If this serializer is registered on one instance
- * and not another one, then it will end up with HazelcastSerializationException.
- * The same applies when clients are configured to use this serializer but not the
- * members, and vice versa. Also note that, if a new instance is created with this
- * serialization but the existing Hazelcast cluster contains the values not serialized
- * by this but instead the default one, this will result in incompatibility again.
+ * If multiple instances of a Spring application is run, then all of them need to use the
+ * same serialization method. If this serializer is registered on one instance and not
+ * another one, then it will end up with HazelcastSerializationException. The same applies
+ * when clients are configured to use this serializer but not the members, and vice versa.
+ * Also note that, if a new instance is created with this serialization but the existing
+ * Hazelcast cluster contains the values not serialized by this but instead the default
+ * one, this will result in incompatibility again.
  *
  * <p>
  * An example of how to register the serializer on embedded instance can be seen below:
@@ -44,9 +61,10 @@ import java.time.Instant;
  * </pre>
  *
  * Below is the example of how to register the serializer on client instance. Note that,
- * to use the serializer in client/server mode, the serializer - and hence {@link MapSession},
- * must exist on the server's classpath and must be registered via {@link com.hazelcast.config.SerializerConfig}
- * with the configuration above for each server.
+ * to use the serializer in client/server mode, the serializer - and hence
+ * {@link MapSession}, must exist on the server's classpath and must be registered via
+ * {@link com.hazelcast.config.SerializerConfig} with the configuration above for each
+ * server.
  *
  * <pre class="code">
  * ClientConfig clientConfig = new ClientConfig();
@@ -110,7 +128,8 @@ public class HazelcastSessionSerializer implements StreamSerializer<MapSession> 
 				Object attrValue = in.readObject();
 				cached.setAttribute(attrName, attrValue);
 			}
-		} catch (EOFException ignored) {
+		}
+		catch (EOFException ignored) {
 		}
 		return cached;
 	}

--- a/spring-session-hazelcast/src/test/java/org/springframework/session/hazelcast/HazelcastSessionSerializerTest.java
+++ b/spring-session-hazelcast/src/test/java/org/springframework/session/hazelcast/HazelcastSessionSerializerTest.java
@@ -1,0 +1,81 @@
+package org.springframework.session.hazelcast;
+
+import com.hazelcast.config.SerializationConfig;
+import com.hazelcast.config.SerializerConfig;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.serialization.SerializationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.session.MapSession;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HazelcastSessionSerializerTests {
+
+	private SerializationService serializationService;
+
+	@BeforeEach
+	void setUp() {
+		SerializationConfig serializationConfig = new SerializationConfig();
+		SerializerConfig serializerConfig = new SerializerConfig()
+				.setImplementation(new HazelcastSessionSerializer())
+				.setTypeClass(MapSession.class);
+		serializationConfig.addSerializerConfig(serializerConfig);
+		serializationService = new DefaultSerializationServiceBuilder().setConfig(serializationConfig).build();
+	}
+
+	@Test
+	void serializeSessionWithStreamSerializer() {
+		MapSession originalSession = new MapSession();
+		originalSession.setAttribute("attr1", "value1");
+		originalSession.setAttribute("attr2", "value2");
+		originalSession.setAttribute("attr3", new SerializableTestAttribute(3));
+		originalSession.setMaxInactiveInterval(Duration.ofDays(5));
+		originalSession.setLastAccessedTime(Instant.now());
+		originalSession.setId("custom-id");
+
+		Data serialized = serializationService.toData(originalSession);
+		MapSession cached = serializationService.toObject(serialized);
+
+		assertThat(originalSession.getCreationTime()).isEqualTo(cached.getCreationTime());
+		assertThat(originalSession.getMaxInactiveInterval()).isEqualTo(cached.getMaxInactiveInterval());
+		assertThat(originalSession.getId()).isEqualTo(cached.getId());
+		assertThat(originalSession.getOriginalId()).isEqualTo(cached.getOriginalId());
+		assertThat(originalSession.getAttributeNames().size()).isEqualTo(cached.getAttributeNames().size());
+		assertThat(originalSession.<String>getAttribute("attr1"))
+				.isEqualTo(cached.getAttribute("attr1"));
+		assertThat(originalSession.<String>getAttribute("attr2"))
+				.isEqualTo(cached.getAttribute("attr2"));
+		assertThat(originalSession.<SerializableTestAttribute>getAttribute("attr3"))
+				.isEqualTo(cached.getAttribute("attr3"));
+	}
+
+
+	static class SerializableTestAttribute implements Serializable {
+
+		private int id;
+
+		public SerializableTestAttribute(int id) {
+			this.id = id;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (!(o instanceof SerializableTestAttribute)) return false;
+			SerializableTestAttribute that = (SerializableTestAttribute) o;
+			return id == that.id;
+		}
+
+		@Override
+		public int hashCode() {
+			return id;
+		}
+	}
+
+}

--- a/spring-session-hazelcast/src/test/java/org/springframework/session/hazelcast/HazelcastSessionSerializerTests.java
+++ b/spring-session-hazelcast/src/test/java/org/springframework/session/hazelcast/HazelcastSessionSerializerTests.java
@@ -1,4 +1,24 @@
+/*
+ * Copyright 2014-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.session.hazelcast;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.Instant;
 
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SerializerConfig;
@@ -7,11 +27,8 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.session.MapSession;
 
-import java.io.Serializable;
-import java.time.Duration;
-import java.time.Instant;
+import org.springframework.session.MapSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,11 +39,10 @@ class HazelcastSessionSerializerTests {
 	@BeforeEach
 	void setUp() {
 		SerializationConfig serializationConfig = new SerializationConfig();
-		SerializerConfig serializerConfig = new SerializerConfig()
-				.setImplementation(new HazelcastSessionSerializer())
+		SerializerConfig serializerConfig = new SerializerConfig().setImplementation(new HazelcastSessionSerializer())
 				.setTypeClass(MapSession.class);
 		serializationConfig.addSerializerConfig(serializerConfig);
-		serializationService = new DefaultSerializationServiceBuilder().setConfig(serializationConfig).build();
+		this.serializationService = new DefaultSerializationServiceBuilder().setConfig(serializationConfig).build();
 	}
 
 	@Test
@@ -39,43 +55,45 @@ class HazelcastSessionSerializerTests {
 		originalSession.setLastAccessedTime(Instant.now());
 		originalSession.setId("custom-id");
 
-		Data serialized = serializationService.toData(originalSession);
-		MapSession cached = serializationService.toObject(serialized);
+		Data serialized = this.serializationService.toData(originalSession);
+		MapSession cached = this.serializationService.toObject(serialized);
 
 		assertThat(originalSession.getCreationTime()).isEqualTo(cached.getCreationTime());
 		assertThat(originalSession.getMaxInactiveInterval()).isEqualTo(cached.getMaxInactiveInterval());
 		assertThat(originalSession.getId()).isEqualTo(cached.getId());
 		assertThat(originalSession.getOriginalId()).isEqualTo(cached.getOriginalId());
 		assertThat(originalSession.getAttributeNames().size()).isEqualTo(cached.getAttributeNames().size());
-		assertThat(originalSession.<String>getAttribute("attr1"))
-				.isEqualTo(cached.getAttribute("attr1"));
-		assertThat(originalSession.<String>getAttribute("attr2"))
-				.isEqualTo(cached.getAttribute("attr2"));
+		assertThat(originalSession.<String>getAttribute("attr1")).isEqualTo(cached.getAttribute("attr1"));
+		assertThat(originalSession.<String>getAttribute("attr2")).isEqualTo(cached.getAttribute("attr2"));
 		assertThat(originalSession.<SerializableTestAttribute>getAttribute("attr3"))
 				.isEqualTo(cached.getAttribute("attr3"));
 	}
-
 
 	static class SerializableTestAttribute implements Serializable {
 
 		private int id;
 
-		public SerializableTestAttribute(int id) {
+		SerializableTestAttribute(int id) {
 			this.id = id;
 		}
 
 		@Override
 		public boolean equals(Object o) {
-			if (this == o) return true;
-			if (!(o instanceof SerializableTestAttribute)) return false;
+			if (this == o) {
+				return true;
+			}
+			if (!(o instanceof SerializableTestAttribute)) {
+				return false;
+			}
 			SerializableTestAttribute that = (SerializableTestAttribute) o;
-			return id == that.id;
+			return this.id == that.id;
 		}
 
 		@Override
 		public int hashCode() {
-			return id;
+			return this.id;
 		}
+
 	}
 
 }


### PR DESCRIPTION
Related: #1131 

Provides custom serializer optimized for Hazelcast rather than native Java serialization.

#### Backward Compatibility

This is an optional serializer. If Hazelcast instances are not explicitly configured to use, the serialization mechanism will remain unchanged. However, it's not possible to use this serializer for an existing session store serialized without this.

#### Requirements to Use

In embedded mode, it can be configured directly just before a member starts. In client mode, the serializer - and hence the MapSession, need to be present on member's classpath and configured. Both Hazelcast client and member must use the same serialization mechanism for consistency.

#### About Hazelcast's Portable Serialization

Portable (not used in this PR) is another way to serialize the objects in Hazelcast way. It also fits well with the indexed repository. Because in the current scenario when a query is made to fetch sessions by the principal, the objects on the distributed map are deserialized to extract the value, then serialized and transferred to the caller side, and then deserialized again. Portable serialization, on the other hand, allows map values to be queried without deserializing the whole value but only the necessary one - in this case, `PRINCIPAL_NAME_ATTRIBUTE`.

However, Portable requires a serialization interface to be implemented for the objects to be stored on the map. In that case - as MapSession is final, a wrapper for sessions could be good to go. But this would require some changes in HazelcastIndexedSessionRepository and more importantly, would break the backward compatibility for the sessions serialized in the old fashion. So I think it's better for now to keep this serialization logic optional - maybe until 2.4.0.

#### More on Portable

Also, with the next versions of Hazelcast, it will be possible to run entry processors (in spring-session-hazelcast, sessions are updated via entry processors on the member side, without the need for fetching and then putting the value on the caller side) without including a dependency on members. When this is the case, it will prevent users to be required to adding their classes when using client/server topology. The current version uses user code deployment for this, which is actually not the best way of. (related: #1584)