### PR TITLE
Prevent builds from running on forks

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    if: github.repository == 'spring-projects/spring-session'
     strategy:
       matrix:
         jdk: [8, 11]
@@ -32,6 +33,7 @@ jobs:
     name: Deploy Artifacts
     needs: [build]
     runs-on: ubuntu-latest
+    if: github.repository == 'spring-projects/spring-session'
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -61,6 +63,7 @@ jobs:
     name: Deploy Docs
     needs: [build]
     runs-on: ubuntu-latest
+    if: github.repository == 'spring-projects/spring-session'
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK

--- a/.github/workflows/pr-build-workflow.yml
+++ b/.github/workflows/pr-build-workflow.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    if: github.repository == 'spring-projects/spring-session'
     strategy:
       matrix:
         jdk: [8, 11]


### PR DESCRIPTION
Github Actions doesn't currently have an elegant way to prevent builds on forks. Following the suggestion outlined [here](https://github.community/t/stop-github-actions-running-on-a-fork/17965/2), I added checks for each job to ensure it only runs on `spring-projects/spring-session`. 

I opened a PR on my forked version as well as updated my forked master, and confirmed that no builds steps ran.

See https://github.com/elliedori/spring-session/actions/runs/236392775 and https://github.com/elliedori/spring-session/actions/runs/236394687 for more.

This PR resolves https://github.com/spring-projects/spring-session/issues/1678