### PR TITLE
Harmonize Redis key namespace configurations

### DIFF
--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisSessionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,13 +42,13 @@ import org.springframework.util.Assert;
  */
 public class RedisSessionRepository implements SessionRepository<RedisSessionRepository.RedisSession> {
 
-	private static final String DEFAULT_KEY_NAMESPACE = "spring:session:";
+	private static final String DEFAULT_KEY_NAMESPACE = "spring:session";
 
 	private final RedisOperations<String, Object> sessionRedisOperations;
 
 	private Duration defaultMaxInactiveInterval = Duration.ofSeconds(MapSession.DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS);
 
-	private String keyNamespace = DEFAULT_KEY_NAMESPACE;
+	private String keyNamespace = DEFAULT_KEY_NAMESPACE + ":";
 
 	private FlushMode flushMode = FlushMode.ON_SAVE;
 
@@ -76,10 +76,21 @@ public class RedisSessionRepository implements SessionRepository<RedisSessionRep
 	/**
 	 * Set the key namespace.
 	 * @param keyNamespace the key namespace
+	 * @deprecated since 2.4.0 in favor of {@link #setRedisKeyNamespace(String)}
 	 */
+	@Deprecated
 	public void setKeyNamespace(String keyNamespace) {
 		Assert.hasText(keyNamespace, "keyNamespace must not be empty");
 		this.keyNamespace = keyNamespace;
+	}
+
+	/**
+	 * Set the Redis key namespace.
+	 * @param namespace the Redis key namespace
+	 */
+	public void setRedisKeyNamespace(String namespace) {
+		Assert.hasText(namespace, "namespace must not be empty");
+		this.keyNamespace = namespace.trim() + ":";
 	}
 
 	/**

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisSessionRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,15 +103,33 @@ class RedisSessionRepositoryTests {
 	}
 
 	@Test
+	void setRedisKeyNamespace_ValidNamespace_ShouldSetNamespace() {
+		this.sessionRepository.setRedisKeyNamespace("test");
+		assertThat(ReflectionTestUtils.getField(this.sessionRepository, "keyNamespace")).isEqualTo("test:");
+	}
+
+	@Test
 	void setKeyNamespace_NullNamespace_ShouldThrowException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.sessionRepository.setKeyNamespace(null))
 				.withMessage("keyNamespace must not be empty");
 	}
 
 	@Test
+	void setRedisKeyNamespace_NullNamespace_ShouldThrowException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.sessionRepository.setRedisKeyNamespace(null))
+				.withMessage("namespace must not be empty");
+	}
+
+	@Test
 	void setKeyNamespace_EmptyNamespace_ShouldThrowException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.sessionRepository.setKeyNamespace(" "))
 				.withMessage("keyNamespace must not be empty");
+	}
+
+	@Test
+	void setRedisKeyNamespace_EmptyNamespace_ShouldThrowException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.sessionRepository.setRedisKeyNamespace(" "))
+				.withMessage("namespace must not be empty");
 	}
 
 	@Test
@@ -185,7 +203,7 @@ class RedisSessionRepositoryTests {
 
 	@Test
 	void save_NewSessionAndCustomKeyNamespace_ShouldSaveSession() {
-		this.sessionRepository.setKeyNamespace("custom:");
+		this.sessionRepository.setRedisKeyNamespace("custom");
 		RedisSession session = this.sessionRepository.createSession();
 		this.sessionRepository.save(session);
 		String key = "custom:sessions:" + session.getId();


### PR DESCRIPTION
At present, the `RedisSessionRepository#setKeyNamespace` expects users to provide the trailing colon (`:`) character that is used as separator between namespace segments. This is unlike `RedisIndexedSessionRepository` and `ReactiveRedisSessionRepository` that apply the separator implicitly in their respective `#setRedisKeyNamespace` methods.

This PR harmonizes the Redis key namespaces configurations across all Redis-backed session repository implementations.

I've noticed this while applying the approach from #1710 in one project.
Ideally, this should be merged before #1710 which should then updated to pick up the new `#setRedisKeyNamespace` method and use it in the sample.

