### PR TITLE
[2.4.x] Avoid extraneous call to SessionRespository.findById(...) in SessionRepositoryRequestWrapper.commitSession()

### DIFF
--- a/spring-session-core/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
+++ b/spring-session-core/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
@@ -221,11 +221,15 @@ public class SessionRepositoryFilter<S extends Session> extends OncePerRequestFi
 			}
 			else {
 				S session = wrappedSession.getSession();
-				clearRequestedSessionCache();
-				SessionRepositoryFilter.this.sessionRepository.save(session);
-				String sessionId = session.getId();
-				if (!isRequestedSessionIdValid() || !sessionId.equals(getRequestedSessionId())) {
-					SessionRepositoryFilter.this.httpSessionIdResolver.setSessionId(this, this.response, sessionId);
+				try {
+					SessionRepositoryFilter.this.sessionRepository.save(session);
+					String sessionId = session.getId();
+					if (!isRequestedSessionIdValid() || !sessionId.equals(getRequestedSessionId())) {
+						SessionRepositoryFilter.this.httpSessionIdResolver.setSessionId(this, this.response, sessionId);
+					}
+				}
+				finally {
+					clearRequestedSessionCache();
 				}
 			}
 		}

--- a/spring-session-core/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
@@ -1313,8 +1313,8 @@ class SessionRepositoryFilterTests {
 			}
 		});
 
-		// 3 invocations expected: initial resolution, after invalidation, after commit
-		verify(sessionRepository, times(3)).findById(eq(session.getId()));
+		// 3 invocations expected: initial resolution, after invalidation
+		verify(sessionRepository, times(2)).findById(eq(session.getId()));
 		verify(sessionRepository).deleteById(eq(session.getId()));
 		verify(sessionRepository).createSession();
 		verify(sessionRepository).save(any());


### PR DESCRIPTION
Backports https://github.com/spring-projects/spring-session/pull/1732 to 2.4.x
Resolves #1731