### PR TITLE
Fix example in JavaDocs of RedisIndexedSessionRepository and in Storage Details section of the documentation

### DIFF
--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
@@ -88,7 +88,7 @@ import org.springframework.util.Assert;
  * details.
  *
  * <pre>
- * HMSET spring:session:sessions:33fdd1b6-b496-4b33-9f7d-df96679d32fe creationTime 1404360000000 maxInactiveInterval 1800 lastAccessedTime 1404360000000 sessionAttr:attrName someAttrValue sessionAttr2:attrName someAttrValue2
+ * HMSET spring:session:sessions:33fdd1b6-b496-4b33-9f7d-df96679d32fe creationTime 1404360000000 maxInactiveInterval 1800 lastAccessedTime 1404360000000 sessionAttr:attrName someAttrValue sessionAttr:attrName2 someAttrValue2
  * EXPIRE spring:session:sessions:33fdd1b6-b496-4b33-9f7d-df96679d32fe 2100
  * APPEND spring:session:sessions:expires:33fdd1b6-b496-4b33-9f7d-df96679d32fe ""
  * EXPIRE spring:session:sessions:expires:33fdd1b6-b496-4b33-9f7d-df96679d32fe 1800
@@ -131,7 +131,7 @@ import org.springframework.util.Assert;
  * The {@link RedisIndexedSessionRepository.RedisSession} keeps track of the properties
  * that have changed and only updates those. This means if an attribute is written once
  * and read many times we only need to write that attribute once. For example, assume the
- * session attribute "sessionAttr2" from earlier was updated. The following would be
+ * session attribute "attrName2" from earlier was updated. The following would be
  * executed upon saving:
  * </p>
  *

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
@@ -131,8 +131,8 @@ import org.springframework.util.Assert;
  * The {@link RedisIndexedSessionRepository.RedisSession} keeps track of the properties
  * that have changed and only updates those. This means if an attribute is written once
  * and read many times we only need to write that attribute once. For example, assume the
- * session attribute "attrName2" from earlier was updated. The following would be
- * executed upon saving:
+ * session attribute "attrName2" from earlier was updated. The following would be executed
+ * upon saving:
  * </p>
  *
  * <pre>

--- a/spring-session-docs/src/docs/asciidoc/index.adoc
+++ b/spring-session-docs/src/docs/asciidoc/index.adoc
@@ -791,7 +791,7 @@ HMSET spring:session:sessions:33fdd1b6-b496-4b33-9f7d-df96679d32fe creationTime 
 	maxInactiveInterval 1800 \
 	lastAccessedTime 1404360000000 \
 	sessionAttr:attrName someAttrValue \
-	sessionAttr2:attrName someAttrValue2
+	sessionAttr:attrName2 someAttrValue2
 EXPIRE spring:session:sessions:33fdd1b6-b496-4b33-9f7d-df96679d32fe 2100
 APPEND spring:session:sessions:expires:33fdd1b6-b496-4b33-9f7d-df96679d32fe ""
 EXPIRE spring:session:sessions:expires:33fdd1b6-b496-4b33-9f7d-df96679d32fe 1800
@@ -814,7 +814,7 @@ HMSET spring:session:sessions:33fdd1b6-b496-4b33-9f7d-df96679d32fe creationTime 
 	maxInactiveInterval 1800 \
 	lastAccessedTime 1404360000000 \
 	sessionAttr:attrName someAttrValue \
-	sessionAttr2:attrName someAttrValue2
+	sessionAttr:attrName2 someAttrValue2
 ----
 ====
 
@@ -833,7 +833,7 @@ The second session attribute is named `attrName2`, with a value of `someAttrValu
 
 The `Session` instances managed by `RedisIndexedSessionRepository` keeps track of the properties that have changed and updates only those.
 This means that, if an attribute is written once and read many times, we need to write that attribute only once.
-For example, assume the `sessionAttr2` session attribute from the lsiting in the preceding section was updated.
+For example, assume the `attrName2` session attribute from the lsiting in the preceding section was updated.
 The following command would be run upon saving:
 
 ====


### PR DESCRIPTION
This PR fixed `sesstionAttr2:attrName` to `sessionAttr:attrName2` in both JavaDoc of RedisIndexedSessionRepository and  Storage Details section of the documentation.