### PR TITLE
Principal Name Index is not stored in Hazelcast Session when flush mode is immediate

### DIFF
--- a/spring-session-hazelcast/hazelcast4/src/main/java/org/springframework/session/hazelcast/Hazelcast4IndexedSessionRepository.java
+++ b/spring-session-hazelcast/hazelcast4/src/main/java/org/springframework/session/hazelcast/Hazelcast4IndexedSessionRepository.java
@@ -450,6 +450,7 @@ public class Hazelcast4IndexedSessionRepository
 						.resolveIndexesFor(this);
 				String principal = (attributeValue != null) ? indexes.get(PRINCIPAL_NAME_INDEX_NAME) : null;
 				this.delegate.setAttribute(PRINCIPAL_NAME_INDEX_NAME, principal);
+				this.delta.put(PRINCIPAL_NAME_INDEX_NAME, principal);
 			}
 			flushImmediateIfNecessary();
 		}

--- a/spring-session-hazelcast/hazelcast4/src/main/java/org/springframework/session/hazelcast/Hazelcast4IndexedSessionRepository.java
+++ b/spring-session-hazelcast/hazelcast4/src/main/java/org/springframework/session/hazelcast/Hazelcast4IndexedSessionRepository.java
@@ -450,7 +450,7 @@ public class Hazelcast4IndexedSessionRepository
 						.resolveIndexesFor(this);
 				String principal = (attributeValue != null) ? indexes.get(PRINCIPAL_NAME_INDEX_NAME) : null;
 				this.delegate.setAttribute(PRINCIPAL_NAME_INDEX_NAME, principal);
-				this.delta.put(PRINCIPAL_NAME_INDEX_NAME, principal);
+//				this.delta.put(PRINCIPAL_NAME_INDEX_NAME, principal);
 			}
 			flushImmediateIfNecessary();
 		}

--- a/spring-session-hazelcast/hazelcast4/src/main/java/org/springframework/session/hazelcast/Hazelcast4IndexedSessionRepository.java
+++ b/spring-session-hazelcast/hazelcast4/src/main/java/org/springframework/session/hazelcast/Hazelcast4IndexedSessionRepository.java
@@ -450,7 +450,7 @@ public class Hazelcast4IndexedSessionRepository
 						.resolveIndexesFor(this);
 				String principal = (attributeValue != null) ? indexes.get(PRINCIPAL_NAME_INDEX_NAME) : null;
 				this.delegate.setAttribute(PRINCIPAL_NAME_INDEX_NAME, principal);
-//				this.delta.put(PRINCIPAL_NAME_INDEX_NAME, principal);
+				this.delta.put(PRINCIPAL_NAME_INDEX_NAME, principal);
 			}
 			flushImmediateIfNecessary();
 		}

--- a/spring-session-hazelcast/hazelcast4/src/test/java/org/springframework/session/hazelcast/Hazelcast4IndexedSessionRepositoryWithInstanceTests.java
+++ b/spring-session-hazelcast/hazelcast4/src/test/java/org/springframework/session/hazelcast/Hazelcast4IndexedSessionRepositoryWithInstanceTests.java
@@ -1,0 +1,72 @@
+package org.springframework.session.hazelcast;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import org.assertj.core.api.Condition;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.session.FlushMode;
+import org.springframework.session.MapSession;
+import org.springframework.session.SaveMode;
+import org.springframework.session.hazelcast.Hazelcast4IndexedSessionRepository.HazelcastSession;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Hazelcast4IndexedSessionRepositoryWithInstanceTests {
+
+	private static final String SPRING_SECURITY_CONTEXT = "SPRING_SECURITY_CONTEXT";
+
+	private static final String SESSION_MAP_NAME = "spring:session:sessions";
+
+	private HazelcastInstance hzInstance;
+
+	private Hazelcast4IndexedSessionRepository repository;
+
+	@Before
+	public void initialize() {
+		this.hzInstance = Hazelcast.newHazelcastInstance(new Config());
+
+		this.repository = new Hazelcast4IndexedSessionRepository(this.hzInstance);
+		this.repository.setFlushMode(FlushMode.IMMEDIATE);
+		this.repository.setSaveMode(SaveMode.ALWAYS);
+		this.repository.setSessionMapName(SESSION_MAP_NAME);
+		this.repository.init();
+	}
+
+	@Test
+	public void hazelcastInstance() {
+		assertThat(hzInstance).withFailMessage("HazelcastInstance must not be null").isNotNull();
+	}
+
+	@Test
+	public void findByIndexNameAndIndexValuePrincipalIndexNameFound() {
+		String principal = "username";
+		Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "notused",
+				AuthorityUtils.createAuthorityList("ROLE_USER"));
+		SecurityContextImpl securityCtx = new SecurityContextImpl(authentication);
+
+		HazelcastSession newSession = repository.createSession();
+		newSession.setAttribute(SPRING_SECURITY_CONTEXT, securityCtx);
+
+		IMap<String, MapSession> sessionsMap = this.hzInstance.getMap(SESSION_MAP_NAME);
+
+		assertThat(sessionsMap).withFailMessage("SessionsMap is empty")
+				.size().isGreaterThan(0);
+
+		assertThat(sessionsMap).withFailMessage("SessionEntry does not contain the expected attributes")
+				.hasValueSatisfying(new Condition<>(session ->
+						session.getAttributeNames().containsAll(Arrays.asList(
+								"org.springframework.session.FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME",
+								"SPRING_SECURITY_CONTEXT"
+						)), "SessionHasExpectedAttributes"));
+	}
+
+}

--- a/spring-session-hazelcast/hazelcast4/src/test/java/org/springframework/session/hazelcast/Hazelcast4IndexedSessionRepositoryWithInstanceTests.java
+++ b/spring-session-hazelcast/hazelcast4/src/test/java/org/springframework/session/hazelcast/Hazelcast4IndexedSessionRepositoryWithInstanceTests.java
@@ -1,12 +1,31 @@
+/*
+ * Copyright 2014-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.session.hazelcast;
+
+import java.util.Arrays;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 import org.assertj.core.api.Condition;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.AuthorityUtils;
@@ -15,8 +34,6 @@ import org.springframework.session.FlushMode;
 import org.springframework.session.MapSession;
 import org.springframework.session.SaveMode;
 import org.springframework.session.hazelcast.Hazelcast4IndexedSessionRepository.HazelcastSession;
-
-import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,8 +47,8 @@ public class Hazelcast4IndexedSessionRepositoryWithInstanceTests {
 
 	private Hazelcast4IndexedSessionRepository repository;
 
-	@Before
-	public void initialize() {
+	@BeforeEach
+	void initialize() {
 		this.hzInstance = Hazelcast.newHazelcastInstance(new Config());
 
 		this.repository = new Hazelcast4IndexedSessionRepository(this.hzInstance);
@@ -42,18 +59,13 @@ public class Hazelcast4IndexedSessionRepositoryWithInstanceTests {
 	}
 
 	@Test
-	public void hazelcastInstance() {
-		assertThat(hzInstance).withFailMessage("HazelcastInstance must not be null").isNotNull();
-	}
-
-	@Test
-	public void findByIndexNameAndIndexValuePrincipalIndexNameFound() {
+	void findByIndexNameAndIndexValuePrincipalIndexNameFound() {
 		String principal = "username";
 		Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "notused",
 				AuthorityUtils.createAuthorityList("ROLE_USER"));
 		SecurityContextImpl securityCtx = new SecurityContextImpl(authentication);
 
-		HazelcastSession newSession = repository.createSession();
+		HazelcastSession newSession = this.repository.createSession();
 		newSession.setAttribute(SPRING_SECURITY_CONTEXT, securityCtx);
 
 		IMap<String, MapSession> sessionsMap = this.hzInstance.getMap(SESSION_MAP_NAME);
@@ -61,7 +73,7 @@ public class Hazelcast4IndexedSessionRepositoryWithInstanceTests {
 		assertThat(sessionsMap).withFailMessage("SessionsMap is empty").size().isGreaterThan(0);
 
 		assertThat(sessionsMap).withFailMessage("SessionEntry does not contain the expected attributes")
-				.hasValueSatisfying(new Condition<>(session -> session.getAttributeNames().containsAll(Arrays.asList(
+				.hasValueSatisfying(new Condition<>((session) -> session.getAttributeNames().containsAll(Arrays.asList(
 						"org.springframework.session.FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME",
 						"SPRING_SECURITY_CONTEXT")), "SessionHasExpectedAttributes"));
 	}

--- a/spring-session-hazelcast/hazelcast4/src/test/java/org/springframework/session/hazelcast/Hazelcast4IndexedSessionRepositoryWithInstanceTests.java
+++ b/spring-session-hazelcast/hazelcast4/src/test/java/org/springframework/session/hazelcast/Hazelcast4IndexedSessionRepositoryWithInstanceTests.java
@@ -58,15 +58,12 @@ public class Hazelcast4IndexedSessionRepositoryWithInstanceTests {
 
 		IMap<String, MapSession> sessionsMap = this.hzInstance.getMap(SESSION_MAP_NAME);
 
-		assertThat(sessionsMap).withFailMessage("SessionsMap is empty")
-				.size().isGreaterThan(0);
+		assertThat(sessionsMap).withFailMessage("SessionsMap is empty").size().isGreaterThan(0);
 
 		assertThat(sessionsMap).withFailMessage("SessionEntry does not contain the expected attributes")
-				.hasValueSatisfying(new Condition<>(session ->
-						session.getAttributeNames().containsAll(Arrays.asList(
-								"org.springframework.session.FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME",
-								"SPRING_SECURITY_CONTEXT"
-						)), "SessionHasExpectedAttributes"));
+				.hasValueSatisfying(new Condition<>(session -> session.getAttributeNames().containsAll(Arrays.asList(
+						"org.springframework.session.FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME",
+						"SPRING_SECURITY_CONTEXT")), "SessionHasExpectedAttributes"));
 	}
 
 }


### PR DESCRIPTION
We found out that the Principal Name attribute is not being stored in the Hazelcast Session Repository. This attribute should be written to the session's map, so that we could efficiently search sessions by principal name. 

This is the value used by the index _Hazelcast4IndexedSessionRepository.PRINCIPAL_NAME_ATTRIBUTE_, which is suggested to be set on the session's map.

As far as we can see the attribute is properly set, but the save method doesn't save it into the Hazelcast map, because the delta that would instruct the entry processor to do so is missing.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
