### PR TITLE
Optimize the createDefaultCookieSerializer method of SpringHttpSessionConfiguration

### DIFF
--- a/spring-session-core/src/main/java/org/springframework/session/config/annotation/web/http/SpringHttpSessionConfiguration.java
+++ b/spring-session-core/src/main/java/org/springframework/session/config/annotation/web/http/SpringHttpSessionConfiguration.java
@@ -178,6 +178,8 @@ public class SpringHttpSessionConfiguration implements ApplicationContextAware {
 				if (sessionCookieConfig.getMaxAge() != -1) {
 					cookieSerializer.setCookieMaxAge(sessionCookieConfig.getMaxAge());
 				}
+				cookieSerializer.setUseHttpOnlyCookie(sessionCookieConfig.isHttpOnly());
+				cookieSerializer.setUseSecureCookie(sessionCookieConfig.isSecure());
 			}
 		}
 		if (this.usesSpringSessionRememberMeServices) {

--- a/spring-session-core/src/test/java/org/springframework/session/config/annotation/web/http/SpringHttpSessionConfigurationTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/config/annotation/web/http/SpringHttpSessionConfigurationTests.java
@@ -93,6 +93,8 @@ class SpringHttpSessionConfigurationTests {
 		assertThat(ReflectionTestUtils.getField(cookieSerializer, "cookiePath")).isEqualTo("test-path");
 		assertThat(ReflectionTestUtils.getField(cookieSerializer, "cookieMaxAge")).isEqualTo(600);
 		assertThat(ReflectionTestUtils.getField(cookieSerializer, "domainName")).isEqualTo("test-domain");
+		assertThat(ReflectionTestUtils.getField(cookieSerializer, "useHttpOnlyCookie")).isEqualTo(true);
+		assertThat(ReflectionTestUtils.getField(cookieSerializer, "useSecureCookie")).isEqualTo(true);
 	}
 
 	@Test
@@ -143,6 +145,8 @@ class SpringHttpSessionConfigurationTests {
 			servletContext.getSessionCookieConfig().setDomain("test-domain");
 			servletContext.getSessionCookieConfig().setPath("test-path");
 			servletContext.getSessionCookieConfig().setMaxAge(600);
+			servletContext.getSessionCookieConfig().setHttpOnly(true);
+			servletContext.getSessionCookieConfig().setSecure(true);
 			return servletContext;
 		}
 


### PR DESCRIPTION
If assemble `DefaultCookieSerializer` from `SessionCookieConfig`, we also need to consider the **Secure** and **HttpOnly** attributes of the cookie. Otherwise **Secure** will always be `null` and **HttpOnly** will always be the default value `true`.