### PR TITLE
Always set existing time to live on Hazelcast 4 map entry when Session is updated

### DIFF
--- a/spring-session-hazelcast/hazelcast4/src/main/java/org/springframework/session/hazelcast/Hazelcast4SessionUpdateEntryProcessor.java
+++ b/spring-session-hazelcast/hazelcast4/src/main/java/org/springframework/session/hazelcast/Hazelcast4SessionUpdateEntryProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,13 +63,8 @@ public class Hazelcast4SessionUpdateEntryProcessor implements EntryProcessor<Str
 				}
 			}
 		}
-		if (this.maxInactiveInterval != null) {
-			((ExtendedMapEntry<String, MapSession>) entry).setValue(value, this.maxInactiveInterval.getSeconds(),
-					TimeUnit.SECONDS);
-		}
-		else {
-			entry.setValue(value);
-		}
+		((ExtendedMapEntry<String, MapSession>) entry).setValue(value, value.getMaxInactiveInterval().getSeconds(),
+				TimeUnit.SECONDS);
 		return Boolean.TRUE;
 	}
 

--- a/spring-session-hazelcast/hazelcast4/src/test/java/org/springframework/session/hazelcast/Hazelcast4IndexedSessionRepositoryTests.java
+++ b/spring-session-hazelcast/hazelcast4/src/test/java/org/springframework/session/hazelcast/Hazelcast4IndexedSessionRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -254,7 +253,6 @@ class Hazelcast4IndexedSessionRepositoryTests {
 		session.setMaxInactiveInterval(Duration.ofSeconds(1));
 		verify(this.sessions, times(1)).set(eq(sessionId), eq(session.getDelegate()), isA(Long.class),
 				eq(TimeUnit.SECONDS));
-		verify(this.sessions).setTtl(eq(sessionId), anyLong(), any());
 		verify(this.sessions, times(1)).executeOnKey(eq(sessionId), any(EntryProcessor.class));
 
 		this.repository.save(session);

--- a/spring-session-hazelcast/hazelcast4/src/test/java/org/springframework/session/hazelcast/Hazelcast4SessionUpdateEntryProcessorTest.java
+++ b/spring-session-hazelcast/hazelcast4/src/test/java/org/springframework/session/hazelcast/Hazelcast4SessionUpdateEntryProcessorTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2014-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.hazelcast;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+import com.hazelcast.map.ExtendedMapEntry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.session.MapSession;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class Hazelcast4SessionUpdateEntryProcessorTest {
+
+	private Hazelcast4SessionUpdateEntryProcessor processor;
+
+	@BeforeEach
+	void setUp() {
+		this.processor = new Hazelcast4SessionUpdateEntryProcessor();
+	}
+
+	@Test
+	void shouldReturnFalseIfNoSessionExistsInHazelcastMapEntry() {
+		@SuppressWarnings("unchecked")
+		ExtendedMapEntry<String, MapSession> mapEntry = mock(ExtendedMapEntry.class);
+
+		Object result = this.processor.process(mapEntry);
+
+		assertThat(result).isEqualTo(Boolean.FALSE);
+	}
+
+	@Test
+	void shouldUpdateMaxInactiveIntervalOnSessionAndSetMapEntryValueWithNewTimeToLive() {
+		Duration newMaxInactiveInterval = Duration.ofSeconds(123L);
+		MapSession mapSession = new MapSession();
+		@SuppressWarnings("unchecked")
+		ExtendedMapEntry<String, MapSession> mapEntry = mock(ExtendedMapEntry.class);
+		given(mapEntry.getValue()).willReturn(mapSession);
+
+		this.processor.setMaxInactiveInterval(newMaxInactiveInterval);
+		Object result = this.processor.process(mapEntry);
+
+		assertThat(result).isEqualTo(Boolean.TRUE);
+		assertThat(mapSession.getMaxInactiveInterval()).isEqualTo(newMaxInactiveInterval);
+		verify(mapEntry).setValue(mapSession, newMaxInactiveInterval.getSeconds(), TimeUnit.SECONDS);
+	}
+
+	@Test
+	void shouldSetMapEntryValueWithOldTimeToLiveIfNoChangeToMaxInactiveIntervalIsRegistered() {
+		Duration maxInactiveInterval = Duration.ofSeconds(123L);
+		MapSession mapSession = new MapSession();
+		mapSession.setMaxInactiveInterval(maxInactiveInterval);
+		@SuppressWarnings("unchecked")
+		ExtendedMapEntry<String, MapSession> mapEntry = mock(ExtendedMapEntry.class);
+		given(mapEntry.getValue()).willReturn(mapSession);
+
+		Object result = this.processor.process(mapEntry);
+
+		assertThat(result).isEqualTo(Boolean.TRUE);
+		assertThat(mapSession.getMaxInactiveInterval()).isEqualTo(maxInactiveInterval);
+		verify(mapEntry).setValue(mapSession, maxInactiveInterval.getSeconds(), TimeUnit.SECONDS);
+	}
+
+	@Test
+	void shouldUpdateLastAccessTimeOnSessionAndSetMapEntryValueWithOldTimeToLive() {
+		Instant lastAccessTime = Instant.ofEpochSecond(1234L);
+		MapSession mapSession = new MapSession();
+		@SuppressWarnings("unchecked")
+		ExtendedMapEntry<String, MapSession> mapEntry = mock(ExtendedMapEntry.class);
+		given(mapEntry.getValue()).willReturn(mapSession);
+
+		this.processor.setLastAccessedTime(lastAccessTime);
+		Object result = this.processor.process(mapEntry);
+
+		assertThat(result).isEqualTo(Boolean.TRUE);
+		assertThat(mapSession.getLastAccessedTime()).isEqualTo(lastAccessTime);
+		verify(mapEntry).setValue(mapSession, mapSession.getMaxInactiveInterval().getSeconds(), TimeUnit.SECONDS);
+	}
+
+	@Test
+	void shouldUpdateSessionAttributesFromDeltaAndSetMapEntryValueWithOldTimeToLive() {
+		MapSession mapSession = new MapSession();
+		mapSession.setAttribute("changed", "oldValue");
+		mapSession.setAttribute("removed", "existingValue");
+		@SuppressWarnings("unchecked")
+		ExtendedMapEntry<String, MapSession> mapEntry = mock(ExtendedMapEntry.class);
+		given(mapEntry.getValue()).willReturn(mapSession);
+
+		HashMap<String, Object> delta = new HashMap<>();
+		delta.put("added", "addedValue");
+		delta.put("changed", "newValue");
+		delta.put("removed", null);
+		this.processor.setDelta(delta);
+
+		Object result = this.processor.process(mapEntry);
+
+		assertThat(result).isEqualTo(Boolean.TRUE);
+		assertThat((String) mapSession.getAttribute("added")).isEqualTo("addedValue");
+		assertThat((String) mapSession.getAttribute("changed")).isEqualTo("newValue");
+		assertThat((String) mapSession.getAttribute("removed")).isNull();
+		verify(mapEntry).setValue(mapSession, mapSession.getMaxInactiveInterval().getSeconds(), TimeUnit.SECONDS);
+	}
+
+}


### PR DESCRIPTION
Due to the changes in Hazelcast 4, an EntryProcessor always has to define the intended time-to-live (ttl) when setting the value on an ExtendedMapEntry, otherwise any existing ttl on such an entry would be reset to the default time configured on the map itself or to Integer.MAX.

The `Hazelcast4SessionUpdateEntryProcessor` was adjusted to use either the updated or the existing `maxInactiveInterval` of the session being processed, so that the resulting Hazelcast IMap entry always has the right ttl for this session instance. In the previous implementation the ttl was only set if the `maxInactiveInterval` was actually updated on the session.

This commit fixes #1899
