### PR TITLE
Memory leak in Index for principal `null`

### DIFF
--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
@@ -858,11 +858,13 @@ public class RedisIndexedSessionRepository
 				catch (NonTransientDataAccessException ex) {
 					handleErrNoSuchKeyError(ex);
 				}
-				String originalPrincipalRedisKey = getPrincipalKey(this.originalPrincipalName);
-				RedisIndexedSessionRepository.this.sessionRedisOperations.boundSetOps(originalPrincipalRedisKey)
-						.remove(this.originalSessionId);
-				RedisIndexedSessionRepository.this.sessionRedisOperations.boundSetOps(originalPrincipalRedisKey)
-						.add(sessionId);
+				if (this.originalPrincipalName != null) {
+					String originalPrincipalRedisKey = getPrincipalKey(this.originalPrincipalName);
+					RedisIndexedSessionRepository.this.sessionRedisOperations.boundSetOps(originalPrincipalRedisKey)
+							.remove(this.originalSessionId);
+					RedisIndexedSessionRepository.this.sessionRedisOperations.boundSetOps(originalPrincipalRedisKey)
+							.add(sessionId);
+				}
 			}
 			this.originalSessionId = sessionId;
 		}


### PR DESCRIPTION
I believe this should be a solution for the reported issue.

The explanation is the following. There are only two places where we add `sessionId` into an index: [first](https://github.com/spring-projects/spring-session/blob/main/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java#L826), [second](https://github.com/spring-projects/spring-session/blob/main/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java#L864).

And the first one is under the validation: [if (principal != null)](https://github.com/spring-projects/spring-session/blob/main/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java#L824).
So, we do not create an index if a principal is `null`.

When a session changes its ID, we try to change it in the index as well.
But we do not check here that the principal is null. So, we do not check if the index exists.

In the end, instead of replacing sessionId in Index, we create a new one. And this leads to a memory leak.

Close #1987