### PR TITLE
Fix bug in JDBC `SaveMode.ON_GET_ATTRIBUTE`

### DIFF
--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcIndexedSessionRepository.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcIndexedSessionRepository.java
@@ -728,7 +728,8 @@ public class JdbcIndexedSessionRepository
 			T attributeValue = supplier.get();
 			if (attributeValue != null
 					&& JdbcIndexedSessionRepository.this.saveMode.equals(SaveMode.ON_GET_ATTRIBUTE)) {
-				this.delta.put(attributeName, DeltaValue.UPDATED);
+				this.delta.merge(attributeName, DeltaValue.UPDATED, (oldDeltaValue,
+						deltaValue) -> (oldDeltaValue == DeltaValue.ADDED) ? oldDeltaValue : deltaValue);
 			}
 			return attributeValue;
 		}

--- a/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcIndexedSessionRepositoryTests.java
+++ b/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcIndexedSessionRepositoryTests.java
@@ -656,6 +656,20 @@ class JdbcIndexedSessionRepositoryTests {
 	}
 
 	@Test
+	void saveWithSaveModeOnGetAttributeAndNewAttributeSetAndGet() {
+		this.repository.setSaveMode(SaveMode.ON_GET_ATTRIBUTE);
+		MapSession delegate = new MapSession();
+		delegate.setAttribute("attribute1", (Supplier<String>) () -> "value1");
+		JdbcSession session = this.repository.new JdbcSession(delegate, UUID.randomUUID().toString(), false);
+		session.setAttribute("attribute2", "value2");
+		session.getAttribute("attribute2");
+		this.repository.save(session);
+		verify(this.jdbcOperations, times(1)).update(startsWith("INSERT INTO SPRING_SESSION_ATTRIBUTES ("),
+				isA(PreparedStatementSetter.class));
+		verifyNoMoreInteractions(this.jdbcOperations);
+	}
+
+	@Test
 	void saveWithSaveModeAlways() {
 		this.repository.setSaveMode(SaveMode.ALWAYS);
 		MapSession delegate = new MapSession();


### PR DESCRIPTION
This fixes a bug in the `JDBC` implementation of `SaveMode.ON_GET_ATTRIBUTE`.

I included a testcase that triggers the bug.

The steps to reproduce the bug are:

  - Use `SaveMode.ON_GET_ATTRIBUTE`
  - Have an existing session
  - Do a `setAttribute` of a new attribute
  - Immediately after, before `save`, do a `getAttribute` of the same attribute
    - `ON_GET_ATTRIBUTE` causes this attribute to be set to  `DeltaValue.UPDATED`
    - **FIX**: Set to `UPDATED` iff not already set to `ADDED`
 - Later `save` tries to just `UPDATE` the new value which fails silently