### PR TITLE
Use simple Redis repository by default

### DIFF
--- a/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryITests.java
+++ b/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryITests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -691,7 +691,7 @@ class RedisIndexedSessionRepositoryITests extends AbstractRedisITests {
 	}
 
 	@Configuration
-	@EnableRedisHttpSession(redisNamespace = "RedisIndexedSessionRepositoryITests")
+	@EnableRedisHttpSession(redisNamespace = "RedisIndexedSessionRepositoryITests", enableIndexingAndEvents = true)
 	static class Config extends BaseConfig {
 
 		@Bean

--- a/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/RedisSessionRepositoryITests.java
+++ b/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/RedisSessionRepositoryITests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,13 +26,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.session.MapSession;
-import org.springframework.session.config.annotation.web.http.EnableSpringHttpSession;
 import org.springframework.session.data.redis.RedisSessionRepository.RedisSession;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -223,16 +220,8 @@ class RedisSessionRepositoryITests extends AbstractRedisITests {
 	}
 
 	@Configuration
-	@EnableSpringHttpSession
+	@EnableRedisHttpSession
 	static class Config extends BaseConfig {
-
-		@Bean
-		RedisSessionRepository sessionRepository(RedisConnectionFactory redisConnectionFactory) {
-			RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-			redisTemplate.setConnectionFactory(redisConnectionFactory);
-			redisTemplate.afterPropertiesSet();
-			return new RedisSessionRepository(redisTemplate);
-		}
 
 	}
 

--- a/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/config/annotation/web/http/EnableRedisHttpSessionExpireSessionDestroyedTests.java
+++ b/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/config/annotation/web/http/EnableRedisHttpSessionExpireSessionDestroyedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,7 +113,7 @@ class EnableRedisHttpSessionExpireSessionDestroyedTests<S extends Session> exten
 	}
 
 	@Configuration
-	@EnableRedisHttpSession(maxInactiveIntervalInSeconds = 1)
+	@EnableRedisHttpSession(maxInactiveIntervalInSeconds = 1, enableIndexingAndEvents = true)
 	static class Config extends BaseConfig {
 
 		@Bean

--- a/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/taskexecutor/RedisListenerContainerTaskExecutorITests.java
+++ b/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/taskexecutor/RedisListenerContainerTaskExecutorITests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ class RedisListenerContainerTaskExecutorITests extends AbstractRedisITests {
 	}
 
 	@Configuration
-	@EnableRedisHttpSession(redisNamespace = "RedisListenerContainerTaskExecutorITests")
+	@EnableRedisHttpSession(redisNamespace = "RedisListenerContainerTaskExecutorITests", enableIndexingAndEvents = true)
 	static class Config extends BaseConfig {
 
 		@Bean

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/EnableRedisHttpSession.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/EnableRedisHttpSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.session.SessionRepository;
 import org.springframework.session.config.annotation.web.http.EnableSpringHttpSession;
 import org.springframework.session.data.redis.RedisFlushMode;
 import org.springframework.session.data.redis.RedisIndexedSessionRepository;
+import org.springframework.session.data.redis.RedisSessionRepository;
 import org.springframework.session.web.http.SessionRepositoryFilter;
 
 /**
@@ -54,7 +55,8 @@ import org.springframework.session.web.http.SessionRepositoryFilter;
  * }
  * </pre>
  *
- * More advanced configurations can extend {@link RedisHttpSessionConfiguration} instead.
+ * More advanced configurations can extend {@link RedisHttpSessionConfiguration} or
+ * {@link RedisIndexedHttpSessionConfiguration} instead.
  *
  * @author Rob Winch
  * @author Vedran Pavic
@@ -64,7 +66,7 @@ import org.springframework.session.web.http.SessionRepositoryFilter;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Documented
-@Import(RedisHttpSessionConfiguration.class)
+@Import(RedisHttpSessionConfigurationSelector.class)
 @Configuration(proxyBeanMethods = false)
 public @interface EnableRedisHttpSession {
 
@@ -114,18 +116,20 @@ public @interface EnableRedisHttpSession {
 	FlushMode flushMode() default FlushMode.ON_SAVE;
 
 	/**
-	 * The cron expression for expired session cleanup job. By default runs every minute.
-	 * @return the session cleanup cron expression
-	 * @since 2.0.0
-	 */
-	String cleanupCron() default RedisHttpSessionConfiguration.DEFAULT_CLEANUP_CRON;
-
-	/**
 	 * Save mode for the session. The default is {@link SaveMode#ON_SET_ATTRIBUTE}, which
 	 * only saves changes made to session.
 	 * @return the save mode
 	 * @since 2.2.0
 	 */
 	SaveMode saveMode() default SaveMode.ON_SET_ATTRIBUTE;
+
+	/**
+	 * Indicate whether the {@link SessionRepository} should publish session events and
+	 * support fetching sessions by index. If true, a
+	 * {@link RedisIndexedSessionRepository} will be used in place of
+	 * {@link RedisSessionRepository}. This will result in slower performance.
+	 * @return true if indexing and events should be enabled, false otherwise
+	 */
+	boolean enableIndexingAndEvents() default false;
 
 }

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfiguration.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,55 +16,35 @@
 
 package org.springframework.session.data.redis.config.annotation.web.http;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
-import org.apache.commons.logging.LogFactory;
-
 import org.springframework.beans.factory.BeanClassLoaderAware;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportAware;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
-import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.listener.ChannelTopic;
-import org.springframework.data.redis.listener.PatternTopic;
-import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.annotation.SchedulingConfigurer;
-import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.springframework.session.FlushMode;
-import org.springframework.session.IndexResolver;
 import org.springframework.session.MapSession;
 import org.springframework.session.SaveMode;
-import org.springframework.session.Session;
 import org.springframework.session.config.SessionRepositoryCustomizer;
 import org.springframework.session.config.annotation.web.http.SpringHttpSessionConfiguration;
 import org.springframework.session.data.redis.RedisFlushMode;
-import org.springframework.session.data.redis.RedisIndexedSessionRepository;
-import org.springframework.session.data.redis.config.ConfigureNotifyKeyspaceEventsAction;
-import org.springframework.session.data.redis.config.ConfigureRedisAction;
+import org.springframework.session.data.redis.RedisSessionRepository;
 import org.springframework.session.data.redis.config.annotation.SpringSessionRedisConnectionFactory;
 import org.springframework.session.web.http.SessionRepositoryFilter;
 import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.util.StringValueResolver;
 
@@ -83,84 +63,37 @@ import org.springframework.util.StringValueResolver;
 public class RedisHttpSessionConfiguration extends SpringHttpSessionConfiguration
 		implements BeanClassLoaderAware, EmbeddedValueResolverAware, ImportAware {
 
-	static final String DEFAULT_CLEANUP_CRON = "0 * * * * *";
-
 	private Integer maxInactiveIntervalInSeconds = MapSession.DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS;
 
-	private String redisNamespace = RedisIndexedSessionRepository.DEFAULT_NAMESPACE;
+	private String redisNamespace = RedisSessionRepository.DEFAULT_KEY_NAMESPACE;
 
 	private FlushMode flushMode = FlushMode.ON_SAVE;
 
 	private SaveMode saveMode = SaveMode.ON_SET_ATTRIBUTE;
 
-	private String cleanupCron = DEFAULT_CLEANUP_CRON;
-
-	private ConfigureRedisAction configureRedisAction = new ConfigureNotifyKeyspaceEventsAction();
-
 	private RedisConnectionFactory redisConnectionFactory;
-
-	private IndexResolver<Session> indexResolver;
 
 	private RedisSerializer<Object> defaultRedisSerializer;
 
-	private ApplicationEventPublisher applicationEventPublisher;
-
-	private Executor redisTaskExecutor;
-
-	private Executor redisSubscriptionExecutor;
-
-	private List<SessionRepositoryCustomizer<RedisIndexedSessionRepository>> sessionRepositoryCustomizers;
+	private List<SessionRepositoryCustomizer<RedisSessionRepository>> sessionRepositoryCustomizers;
 
 	private ClassLoader classLoader;
 
 	private StringValueResolver embeddedValueResolver;
 
 	@Bean
-	public RedisIndexedSessionRepository sessionRepository() {
-		RedisTemplate<Object, Object> redisTemplate = createRedisTemplate();
-		RedisIndexedSessionRepository sessionRepository = new RedisIndexedSessionRepository(redisTemplate);
-		sessionRepository.setApplicationEventPublisher(this.applicationEventPublisher);
-		if (this.indexResolver != null) {
-			sessionRepository.setIndexResolver(this.indexResolver);
-		}
-		if (this.defaultRedisSerializer != null) {
-			sessionRepository.setDefaultSerializer(this.defaultRedisSerializer);
-		}
-		sessionRepository.setDefaultMaxInactiveInterval(this.maxInactiveIntervalInSeconds);
+	public RedisSessionRepository sessionRepository() {
+		RedisTemplate<String, Object> redisTemplate = createRedisTemplate();
+		RedisSessionRepository sessionRepository = new RedisSessionRepository(redisTemplate);
+		sessionRepository.setDefaultMaxInactiveInterval(Duration.ofSeconds(this.maxInactiveIntervalInSeconds));
 		if (StringUtils.hasText(this.redisNamespace)) {
 			sessionRepository.setRedisKeyNamespace(this.redisNamespace);
 		}
 		sessionRepository.setFlushMode(this.flushMode);
 		sessionRepository.setSaveMode(this.saveMode);
-		int database = resolveDatabase();
-		sessionRepository.setDatabase(database);
 		this.sessionRepositoryCustomizers
 				.forEach((sessionRepositoryCustomizer) -> sessionRepositoryCustomizer.customize(sessionRepository));
 		return sessionRepository;
-	}
-
-	@Bean
-	public RedisMessageListenerContainer springSessionRedisMessageListenerContainer(
-			RedisIndexedSessionRepository sessionRepository) {
-		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
-		container.setConnectionFactory(this.redisConnectionFactory);
-		if (this.redisTaskExecutor != null) {
-			container.setTaskExecutor(this.redisTaskExecutor);
-		}
-		if (this.redisSubscriptionExecutor != null) {
-			container.setSubscriptionExecutor(this.redisSubscriptionExecutor);
-		}
-		container.addMessageListener(sessionRepository,
-				Arrays.asList(new ChannelTopic(sessionRepository.getSessionDeletedChannel()),
-						new ChannelTopic(sessionRepository.getSessionExpiredChannel())));
-		container.addMessageListener(sessionRepository,
-				Collections.singletonList(new PatternTopic(sessionRepository.getSessionCreatedChannelPrefix() + "*")));
-		return container;
-	}
-
-	@Bean
-	public InitializingBean enableRedisKeyspaceNotificationsInitializer() {
-		return new EnableRedisKeyspaceNotificationsInitializer(this.redisConnectionFactory, this.configureRedisAction);
 	}
 
 	public void setMaxInactiveIntervalInSeconds(int maxInactiveIntervalInSeconds) {
@@ -186,20 +119,6 @@ public class RedisHttpSessionConfiguration extends SpringHttpSessionConfiguratio
 		this.saveMode = saveMode;
 	}
 
-	public void setCleanupCron(String cleanupCron) {
-		this.cleanupCron = cleanupCron;
-	}
-
-	/**
-	 * Sets the action to perform for configuring Redis.
-	 * @param configureRedisAction the configureRedis to set. The default is
-	 * {@link ConfigureNotifyKeyspaceEventsAction}.
-	 */
-	@Autowired(required = false)
-	public void setConfigureRedisAction(ConfigureRedisAction configureRedisAction) {
-		this.configureRedisAction = configureRedisAction;
-	}
-
 	@Autowired
 	public void setRedisConnectionFactory(
 			@SpringSessionRedisConnectionFactory ObjectProvider<RedisConnectionFactory> springSessionRedisConnectionFactory,
@@ -217,31 +136,9 @@ public class RedisHttpSessionConfiguration extends SpringHttpSessionConfiguratio
 		this.defaultRedisSerializer = defaultRedisSerializer;
 	}
 
-	@Autowired
-	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
-		this.applicationEventPublisher = applicationEventPublisher;
-	}
-
-	@Autowired(required = false)
-	public void setIndexResolver(IndexResolver<Session> indexResolver) {
-		this.indexResolver = indexResolver;
-	}
-
-	@Autowired(required = false)
-	@Qualifier("springSessionRedisTaskExecutor")
-	public void setRedisTaskExecutor(Executor redisTaskExecutor) {
-		this.redisTaskExecutor = redisTaskExecutor;
-	}
-
-	@Autowired(required = false)
-	@Qualifier("springSessionRedisSubscriptionExecutor")
-	public void setRedisSubscriptionExecutor(Executor redisSubscriptionExecutor) {
-		this.redisSubscriptionExecutor = redisSubscriptionExecutor;
-	}
-
 	@Autowired(required = false)
 	public void setSessionRepositoryCustomizer(
-			ObjectProvider<SessionRepositoryCustomizer<RedisIndexedSessionRepository>> sessionRepositoryCustomizers) {
+			ObjectProvider<SessionRepositoryCustomizer<RedisSessionRepository>> sessionRepositoryCustomizers) {
 		this.sessionRepositoryCustomizers = sessionRepositoryCustomizers.orderedStream().collect(Collectors.toList());
 	}
 
@@ -273,14 +170,10 @@ public class RedisHttpSessionConfiguration extends SpringHttpSessionConfiguratio
 		}
 		this.flushMode = flushMode;
 		this.saveMode = attributes.getEnum("saveMode");
-		String cleanupCron = attributes.getString("cleanupCron");
-		if (StringUtils.hasText(cleanupCron)) {
-			this.cleanupCron = cleanupCron;
-		}
 	}
 
-	private RedisTemplate<Object, Object> createRedisTemplate() {
-		RedisTemplate<Object, Object> redisTemplate = new RedisTemplate<>();
+	private RedisTemplate<String, Object> createRedisTemplate() {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
 		redisTemplate.setKeySerializer(new StringRedisSerializer());
 		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
 		if (this.defaultRedisSerializer != null) {
@@ -290,79 +183,6 @@ public class RedisHttpSessionConfiguration extends SpringHttpSessionConfiguratio
 		redisTemplate.setBeanClassLoader(this.classLoader);
 		redisTemplate.afterPropertiesSet();
 		return redisTemplate;
-	}
-
-	private int resolveDatabase() {
-		if (ClassUtils.isPresent("io.lettuce.core.RedisClient", null)
-				&& this.redisConnectionFactory instanceof LettuceConnectionFactory) {
-			return ((LettuceConnectionFactory) this.redisConnectionFactory).getDatabase();
-		}
-		if (ClassUtils.isPresent("redis.clients.jedis.Jedis", null)
-				&& this.redisConnectionFactory instanceof JedisConnectionFactory) {
-			return ((JedisConnectionFactory) this.redisConnectionFactory).getDatabase();
-		}
-		return RedisIndexedSessionRepository.DEFAULT_DATABASE;
-	}
-
-	/**
-	 * Ensures that Redis is configured to send keyspace notifications. This is important
-	 * to ensure that expiration and deletion of sessions trigger SessionDestroyedEvents.
-	 * Without the SessionDestroyedEvent resources may not get cleaned up properly. For
-	 * example, the mapping of the Session to WebSocket connections may not get cleaned
-	 * up.
-	 */
-	static class EnableRedisKeyspaceNotificationsInitializer implements InitializingBean {
-
-		private final RedisConnectionFactory connectionFactory;
-
-		private ConfigureRedisAction configure;
-
-		EnableRedisKeyspaceNotificationsInitializer(RedisConnectionFactory connectionFactory,
-				ConfigureRedisAction configure) {
-			this.connectionFactory = connectionFactory;
-			this.configure = configure;
-		}
-
-		@Override
-		public void afterPropertiesSet() {
-			if (this.configure == ConfigureRedisAction.NO_OP) {
-				return;
-			}
-			RedisConnection connection = this.connectionFactory.getConnection();
-			try {
-				this.configure.configure(connection);
-			}
-			finally {
-				try {
-					connection.close();
-				}
-				catch (Exception ex) {
-					LogFactory.getLog(getClass()).error("Error closing RedisConnection", ex);
-				}
-			}
-		}
-
-	}
-
-	/**
-	 * Configuration of scheduled job for cleaning up expired sessions.
-	 */
-	@EnableScheduling
-	@Configuration(proxyBeanMethods = false)
-	class SessionCleanupConfiguration implements SchedulingConfigurer {
-
-		private final RedisIndexedSessionRepository sessionRepository;
-
-		SessionCleanupConfiguration(RedisIndexedSessionRepository sessionRepository) {
-			this.sessionRepository = sessionRepository;
-		}
-
-		@Override
-		public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
-			taskRegistrar.addCronTask(this.sessionRepository::cleanupExpiredSessions,
-					RedisHttpSessionConfiguration.this.cleanupCron);
-		}
-
 	}
 
 }

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationSelector.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpSessionConfigurationSelector.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.data.redis.config.annotation.web.http;
+
+import org.springframework.context.annotation.ImportSelector;
+import org.springframework.core.type.AnnotationMetadata;
+
+/**
+ * Dynamically determines which session repository configuration to include using the
+ * {@link EnableRedisHttpSession} annotation.
+ *
+ * @author Eleftheria Stein
+ * @since 3.0
+ */
+final class RedisHttpSessionConfigurationSelector implements ImportSelector {
+
+	@Override
+	public String[] selectImports(AnnotationMetadata importMetadata) {
+		if (!importMetadata.hasAnnotation(EnableRedisHttpSession.class.getName())) {
+			return new String[0];
+		}
+		EnableRedisHttpSession annotation = importMetadata.getAnnotations().get(EnableRedisHttpSession.class)
+				.synthesize();
+		if (annotation.enableIndexingAndEvents()) {
+			return new String[] { RedisIndexedHttpSessionConfiguration.class.getName() };
+		}
+		else {
+			return new String[] { RedisHttpSessionConfiguration.class.getName() };
+		}
+	}
+
+}

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisIndexedHttpSessionConfiguration.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/RedisIndexedHttpSessionConfiguration.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright 2014-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.session.data.redis.config.annotation.web.http;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.EmbeddedValueResolverAware;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportAware;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+import org.springframework.session.FlushMode;
+import org.springframework.session.IndexResolver;
+import org.springframework.session.MapSession;
+import org.springframework.session.SaveMode;
+import org.springframework.session.Session;
+import org.springframework.session.config.SessionRepositoryCustomizer;
+import org.springframework.session.config.annotation.web.http.SpringHttpSessionConfiguration;
+import org.springframework.session.data.redis.RedisFlushMode;
+import org.springframework.session.data.redis.RedisIndexedSessionRepository;
+import org.springframework.session.data.redis.config.ConfigureNotifyKeyspaceEventsAction;
+import org.springframework.session.data.redis.config.ConfigureRedisAction;
+import org.springframework.session.data.redis.config.annotation.SpringSessionRedisConnectionFactory;
+import org.springframework.session.web.http.SessionRepositoryFilter;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.util.StringValueResolver;
+
+/**
+ * Exposes the {@link SessionRepositoryFilter} as a bean named
+ * {@code springSessionRepositoryFilter}. In order to use this a single
+ * {@link RedisConnectionFactory} must be exposed as a Bean.
+ *
+ * @author Eleftheria Stein
+ * @since 3.0
+ */
+@Configuration(proxyBeanMethods = false)
+public class RedisIndexedHttpSessionConfiguration extends SpringHttpSessionConfiguration
+		implements BeanClassLoaderAware, EmbeddedValueResolverAware, ImportAware {
+
+	static final String DEFAULT_CLEANUP_CRON = "0 * * * * *";
+
+	private Integer maxInactiveIntervalInSeconds = MapSession.DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS;
+
+	private String redisNamespace = RedisIndexedSessionRepository.DEFAULT_NAMESPACE;
+
+	private FlushMode flushMode = FlushMode.ON_SAVE;
+
+	private SaveMode saveMode = SaveMode.ON_SET_ATTRIBUTE;
+
+	private String cleanupCron = DEFAULT_CLEANUP_CRON;
+
+	private ConfigureRedisAction configureRedisAction = new ConfigureNotifyKeyspaceEventsAction();
+
+	private RedisConnectionFactory redisConnectionFactory;
+
+	private IndexResolver<Session> indexResolver;
+
+	private RedisSerializer<Object> defaultRedisSerializer;
+
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	private Executor redisTaskExecutor;
+
+	private Executor redisSubscriptionExecutor;
+
+	private List<SessionRepositoryCustomizer<RedisIndexedSessionRepository>> sessionRepositoryCustomizers;
+
+	private ClassLoader classLoader;
+
+	private StringValueResolver embeddedValueResolver;
+
+	@Bean
+	public RedisIndexedSessionRepository sessionRepository() {
+		RedisTemplate<Object, Object> redisTemplate = createRedisTemplate();
+		RedisIndexedSessionRepository sessionRepository = new RedisIndexedSessionRepository(redisTemplate);
+		sessionRepository.setApplicationEventPublisher(this.applicationEventPublisher);
+		if (this.indexResolver != null) {
+			sessionRepository.setIndexResolver(this.indexResolver);
+		}
+		if (this.defaultRedisSerializer != null) {
+			sessionRepository.setDefaultSerializer(this.defaultRedisSerializer);
+		}
+		sessionRepository.setDefaultMaxInactiveInterval(this.maxInactiveIntervalInSeconds);
+		if (StringUtils.hasText(this.redisNamespace)) {
+			sessionRepository.setRedisKeyNamespace(this.redisNamespace);
+		}
+		sessionRepository.setFlushMode(this.flushMode);
+		sessionRepository.setSaveMode(this.saveMode);
+		int database = resolveDatabase();
+		sessionRepository.setDatabase(database);
+		this.sessionRepositoryCustomizers
+				.forEach((sessionRepositoryCustomizer) -> sessionRepositoryCustomizer.customize(sessionRepository));
+		return sessionRepository;
+	}
+
+	@Bean
+	public RedisMessageListenerContainer springSessionRedisMessageListenerContainer(
+			RedisIndexedSessionRepository sessionRepository) {
+		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+		container.setConnectionFactory(this.redisConnectionFactory);
+		if (this.redisTaskExecutor != null) {
+			container.setTaskExecutor(this.redisTaskExecutor);
+		}
+		if (this.redisSubscriptionExecutor != null) {
+			container.setSubscriptionExecutor(this.redisSubscriptionExecutor);
+		}
+		container.addMessageListener(sessionRepository,
+				Arrays.asList(new ChannelTopic(sessionRepository.getSessionDeletedChannel()),
+						new ChannelTopic(sessionRepository.getSessionExpiredChannel())));
+		container.addMessageListener(sessionRepository,
+				Collections.singletonList(new PatternTopic(sessionRepository.getSessionCreatedChannelPrefix() + "*")));
+		return container;
+	}
+
+	@Bean
+	public InitializingBean enableRedisKeyspaceNotificationsInitializer() {
+		return new EnableRedisKeyspaceNotificationsInitializer(this.redisConnectionFactory, this.configureRedisAction);
+	}
+
+	public void setMaxInactiveIntervalInSeconds(int maxInactiveIntervalInSeconds) {
+		this.maxInactiveIntervalInSeconds = maxInactiveIntervalInSeconds;
+	}
+
+	public void setRedisNamespace(String namespace) {
+		this.redisNamespace = namespace;
+	}
+
+	@Deprecated
+	public void setRedisFlushMode(RedisFlushMode redisFlushMode) {
+		Assert.notNull(redisFlushMode, "redisFlushMode cannot be null");
+		setFlushMode(redisFlushMode.getFlushMode());
+	}
+
+	public void setFlushMode(FlushMode flushMode) {
+		Assert.notNull(flushMode, "flushMode cannot be null");
+		this.flushMode = flushMode;
+	}
+
+	public void setSaveMode(SaveMode saveMode) {
+		this.saveMode = saveMode;
+	}
+
+	public void setCleanupCron(String cleanupCron) {
+		this.cleanupCron = cleanupCron;
+	}
+
+	/**
+	 * Sets the action to perform for configuring Redis.
+	 * @param configureRedisAction the configureRedis to set. The default is
+	 * {@link ConfigureNotifyKeyspaceEventsAction}.
+	 */
+	@Autowired(required = false)
+	public void setConfigureRedisAction(ConfigureRedisAction configureRedisAction) {
+		this.configureRedisAction = configureRedisAction;
+	}
+
+	@Autowired
+	public void setRedisConnectionFactory(
+			@SpringSessionRedisConnectionFactory ObjectProvider<RedisConnectionFactory> springSessionRedisConnectionFactory,
+			ObjectProvider<RedisConnectionFactory> redisConnectionFactory) {
+		RedisConnectionFactory redisConnectionFactoryToUse = springSessionRedisConnectionFactory.getIfAvailable();
+		if (redisConnectionFactoryToUse == null) {
+			redisConnectionFactoryToUse = redisConnectionFactory.getObject();
+		}
+		this.redisConnectionFactory = redisConnectionFactoryToUse;
+	}
+
+	@Autowired(required = false)
+	@Qualifier("springSessionDefaultRedisSerializer")
+	public void setDefaultRedisSerializer(RedisSerializer<Object> defaultRedisSerializer) {
+		this.defaultRedisSerializer = defaultRedisSerializer;
+	}
+
+	@Autowired
+	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+		this.applicationEventPublisher = applicationEventPublisher;
+	}
+
+	@Autowired(required = false)
+	public void setIndexResolver(IndexResolver<Session> indexResolver) {
+		this.indexResolver = indexResolver;
+	}
+
+	@Autowired(required = false)
+	@Qualifier("springSessionRedisTaskExecutor")
+	public void setRedisTaskExecutor(Executor redisTaskExecutor) {
+		this.redisTaskExecutor = redisTaskExecutor;
+	}
+
+	@Autowired(required = false)
+	@Qualifier("springSessionRedisSubscriptionExecutor")
+	public void setRedisSubscriptionExecutor(Executor redisSubscriptionExecutor) {
+		this.redisSubscriptionExecutor = redisSubscriptionExecutor;
+	}
+
+	@Autowired(required = false)
+	public void setSessionRepositoryCustomizer(
+			ObjectProvider<SessionRepositoryCustomizer<RedisIndexedSessionRepository>> sessionRepositoryCustomizers) {
+		this.sessionRepositoryCustomizers = sessionRepositoryCustomizers.orderedStream().collect(Collectors.toList());
+	}
+
+	@Override
+	public void setBeanClassLoader(ClassLoader classLoader) {
+		this.classLoader = classLoader;
+	}
+
+	@Override
+	public void setEmbeddedValueResolver(StringValueResolver resolver) {
+		this.embeddedValueResolver = resolver;
+	}
+
+	@Override
+	@SuppressWarnings("deprecation")
+	public void setImportMetadata(AnnotationMetadata importMetadata) {
+		Map<String, Object> attributeMap = importMetadata
+				.getAnnotationAttributes(EnableRedisHttpSession.class.getName());
+		AnnotationAttributes attributes = AnnotationAttributes.fromMap(attributeMap);
+		this.maxInactiveIntervalInSeconds = attributes.getNumber("maxInactiveIntervalInSeconds");
+		String redisNamespaceValue = attributes.getString("redisNamespace");
+		if (StringUtils.hasText(redisNamespaceValue)) {
+			this.redisNamespace = this.embeddedValueResolver.resolveStringValue(redisNamespaceValue);
+		}
+		FlushMode flushMode = attributes.getEnum("flushMode");
+		RedisFlushMode redisFlushMode = attributes.getEnum("redisFlushMode");
+		if (flushMode == FlushMode.ON_SAVE && redisFlushMode != RedisFlushMode.ON_SAVE) {
+			flushMode = redisFlushMode.getFlushMode();
+		}
+		this.flushMode = flushMode;
+		this.saveMode = attributes.getEnum("saveMode");
+	}
+
+	private RedisTemplate<Object, Object> createRedisTemplate() {
+		RedisTemplate<Object, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+		if (this.defaultRedisSerializer != null) {
+			redisTemplate.setDefaultSerializer(this.defaultRedisSerializer);
+		}
+		redisTemplate.setConnectionFactory(this.redisConnectionFactory);
+		redisTemplate.setBeanClassLoader(this.classLoader);
+		redisTemplate.afterPropertiesSet();
+		return redisTemplate;
+	}
+
+	private int resolveDatabase() {
+		if (ClassUtils.isPresent("io.lettuce.core.RedisClient", null)
+				&& this.redisConnectionFactory instanceof LettuceConnectionFactory) {
+			return ((LettuceConnectionFactory) this.redisConnectionFactory).getDatabase();
+		}
+		if (ClassUtils.isPresent("redis.clients.jedis.Jedis", null)
+				&& this.redisConnectionFactory instanceof JedisConnectionFactory) {
+			return ((JedisConnectionFactory) this.redisConnectionFactory).getDatabase();
+		}
+		return RedisIndexedSessionRepository.DEFAULT_DATABASE;
+	}
+
+	/**
+	 * Ensures that Redis is configured to send keyspace notifications. This is important
+	 * to ensure that expiration and deletion of sessions trigger SessionDestroyedEvents.
+	 * Without the SessionDestroyedEvent resources may not get cleaned up properly. For
+	 * example, the mapping of the Session to WebSocket connections may not get cleaned
+	 * up.
+	 */
+	static class EnableRedisKeyspaceNotificationsInitializer implements InitializingBean {
+
+		private final RedisConnectionFactory connectionFactory;
+
+		private ConfigureRedisAction configure;
+
+		EnableRedisKeyspaceNotificationsInitializer(RedisConnectionFactory connectionFactory,
+				ConfigureRedisAction configure) {
+			this.connectionFactory = connectionFactory;
+			this.configure = configure;
+		}
+
+		@Override
+		public void afterPropertiesSet() {
+			if (this.configure == ConfigureRedisAction.NO_OP) {
+				return;
+			}
+			RedisConnection connection = this.connectionFactory.getConnection();
+			try {
+				this.configure.configure(connection);
+			}
+			finally {
+				try {
+					connection.close();
+				}
+				catch (Exception ex) {
+					LogFactory.getLog(getClass()).error("Error closing RedisConnection", ex);
+				}
+			}
+		}
+
+	}
+
+	/**
+	 * Configuration of scheduled job for cleaning up expired sessions.
+	 */
+	@EnableScheduling
+	@Configuration(proxyBeanMethods = false)
+	class SessionCleanupConfiguration implements SchedulingConfigurer {
+
+		private final RedisIndexedSessionRepository sessionRepository;
+
+		SessionCleanupConfiguration(RedisIndexedSessionRepository sessionRepository) {
+			this.sessionRepository = sessionRepository;
+		}
+
+		@Override
+		public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+			taskRegistrar.addCronTask(this.sessionRepository::cleanupExpiredSessions,
+					RedisIndexedHttpSessionConfiguration.this.cleanupCron);
+		}
+
+	}
+
+}

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/EnableRedisKeyspaceNotificationsInitializerTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/EnableRedisKeyspaceNotificationsInitializerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,14 +49,14 @@ class EnableRedisKeyspaceNotificationsInitializerTests {
 	@Captor
 	ArgumentCaptor<String> options;
 
-	private RedisHttpSessionConfiguration.EnableRedisKeyspaceNotificationsInitializer initializer;
+	private RedisIndexedHttpSessionConfiguration.EnableRedisKeyspaceNotificationsInitializer initializer;
 
 	@BeforeEach
 	void setup() {
 		MockitoAnnotations.initMocks(this);
 		given(this.connectionFactory.getConnection()).willReturn(this.connection);
 
-		this.initializer = new RedisHttpSessionConfiguration.EnableRedisKeyspaceNotificationsInitializer(
+		this.initializer = new RedisIndexedHttpSessionConfiguration.EnableRedisKeyspaceNotificationsInitializer(
 				this.connectionFactory, new ConfigureNotifyKeyspaceEventsAction());
 	}
 

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisIndexedHttpSessionConfigurationMockTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisIndexedHttpSessionConfigurationMockTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.session.data.redis.config.ConfigureRedisAction;
-import org.springframework.session.data.redis.config.annotation.web.http.RedisHttpSessionConfiguration.EnableRedisKeyspaceNotificationsInitializer;
+import org.springframework.session.data.redis.config.annotation.web.http.RedisIndexedHttpSessionConfiguration.EnableRedisKeyspaceNotificationsInitializer;
 
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.mockito.BDDMockito.given;
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-class RedisHttpSessionConfigurationMockTests {
+class RedisIndexedHttpSessionConfigurationMockTests {
 
 	@Mock
 	RedisConnectionFactory factory;

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisIndexedHttpSessionConfigurationOverrideSessionTaskExecutor.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisIndexedHttpSessionConfigurationOverrideSessionTaskExecutor.java
@@ -38,19 +38,17 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
  * @author Vladimir Tsanev
- * @author Mark Paluch
  *
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @WebAppConfiguration
-class RedisHttpSessionConfigurationOverrideSessionTaskExecutors {
+class RedisIndexedHttpSessionConfigurationOverrideSessionTaskExecutor {
 
 	@Autowired
 	RedisMessageListenerContainer redisMessageListenerContainer;
@@ -58,32 +56,17 @@ class RedisHttpSessionConfigurationOverrideSessionTaskExecutors {
 	@Autowired
 	Executor springSessionRedisTaskExecutor;
 
-	@Autowired
-	Executor springSessionRedisSubscriptionExecutor;
-
 	@Test
-	void overrideSessionTaskExecutors() {
-		verify(this.springSessionRedisSubscriptionExecutor, times(1)).execute(any(Runnable.class));
-		verify(this.springSessionRedisTaskExecutor, never()).execute(any(Runnable.class));
+	void overrideSessionTaskExecutor() {
+		verify(this.springSessionRedisTaskExecutor, times(1)).execute(any(Runnable.class));
 	}
 
-	@EnableRedisHttpSession
+	@EnableRedisHttpSession(enableIndexingAndEvents = true)
 	@Configuration
 	static class Config {
 
 		@Bean
 		Executor springSessionRedisTaskExecutor() {
-			Executor executor = mock(Executor.class);
-			willAnswer((it) -> {
-				Runnable r = it.getArgument(0);
-				new Thread(r).start();
-				return null;
-			}).given(executor).execute(any());
-			return executor;
-		}
-
-		@Bean
-		Executor springSessionRedisSubscriptionExecutor() {
 			Executor executor = mock(Executor.class);
 			willAnswer((it) -> {
 				Runnable r = it.getArgument(0);

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisIndexedHttpSessionConfigurationOverrideSessionTaskExecutors.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisIndexedHttpSessionConfigurationOverrideSessionTaskExecutors.java
@@ -38,17 +38,19 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
  * @author Vladimir Tsanev
+ * @author Mark Paluch
  *
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @WebAppConfiguration
-class RedisHttpSessionConfigurationOverrideSessionTaskExecutor {
+class RedisIndexedHttpSessionConfigurationOverrideSessionTaskExecutors {
 
 	@Autowired
 	RedisMessageListenerContainer redisMessageListenerContainer;
@@ -56,17 +58,32 @@ class RedisHttpSessionConfigurationOverrideSessionTaskExecutor {
 	@Autowired
 	Executor springSessionRedisTaskExecutor;
 
+	@Autowired
+	Executor springSessionRedisSubscriptionExecutor;
+
 	@Test
-	void overrideSessionTaskExecutor() {
-		verify(this.springSessionRedisTaskExecutor, times(1)).execute(any(Runnable.class));
+	void overrideSessionTaskExecutors() {
+		verify(this.springSessionRedisSubscriptionExecutor, times(1)).execute(any(Runnable.class));
+		verify(this.springSessionRedisTaskExecutor, never()).execute(any(Runnable.class));
 	}
 
-	@EnableRedisHttpSession
+	@EnableRedisHttpSession(enableIndexingAndEvents = true)
 	@Configuration
 	static class Config {
 
 		@Bean
 		Executor springSessionRedisTaskExecutor() {
+			Executor executor = mock(Executor.class);
+			willAnswer((it) -> {
+				Runnable r = it.getArgument(0);
+				new Thread(r).start();
+				return null;
+			}).given(executor).execute(any());
+			return executor;
+		}
+
+		@Bean
+		Executor springSessionRedisSubscriptionExecutor() {
 			Executor executor = mock(Executor.class);
 			willAnswer((it) -> {
 				Runnable r = it.getArgument(0);

--- a/spring-session-docs/modules/ROOT/examples/resources/docs/http/HttpSessionListenerXmlTests-context.xml
+++ b/spring-session-docs/modules/ROOT/examples/resources/docs/http/HttpSessionListenerXmlTests-context.xml
@@ -14,7 +14,7 @@
 
 
 	<context:annotation-config/>
-	<bean class="org.springframework.session.data.redis.config.annotation.web.http.RedisHttpSessionConfiguration"/>
+	<bean class="org.springframework.session.data.redis.config.annotation.web.http.RedisIndexedHttpSessionConfiguration"/>
 
 	<bean class="docs.http.AbstractHttpSessionListenerTests"
 		factory-method="createMockRedisConnection"/>


### PR DESCRIPTION
This PR changes `@EnableRedisHttpSession` to use a `RedisSessionRepository` by default, instead of a `RedisIndexedSessionRepository`. 

Users may opt in to using a `RedisIndexedSessionRepository` by specifying `@EnableRedisHttpSession(enableIndexingAndEvents = true)`.

Once we decide on the final implementations, the reference docs and samples need to be updated.

