### PR TITLE
Treat a SerializationException retrieving a session as though there w…

### DIFF
--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import org.springframework.data.redis.core.BoundValueOperations;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.SerializationException;
 import org.springframework.session.FindByIndexNameSessionRepository;
 import org.springframework.session.FlushMode;
 import org.springframework.session.MapSession;
@@ -392,6 +393,15 @@ class RedisIndexedSessionRepositoryTests {
 		given(this.boundHashOperations.entries()).willReturn(map);
 
 		assertThat(this.redisRepository.findById(expiredId)).isNull();
+	}
+
+	@Test
+	void getSessionIncompatible() {
+		String incompatibleId = "incompatible";
+
+		given(this.redisOperations.boundHashOps(getKey(incompatibleId))).willReturn(this.boundHashOperations);
+		given(this.boundHashOperations.entries()).willThrow(new SerializationException("arbitrary exception"));
+		assertThat(this.redisRepository.findById(incompatibleId)).isNull();
 	}
 
 	@Test


### PR DESCRIPTION
…ere no session.

This makes zero-downtime / seamless upgrades possible in more cases.  Currently, upgrading spring-security across versions that change SpringSecurityCoreVersion.SERIAL_VERSION_ID requires manual deletion of cached sessions.

See also https://github.com/spring-projects/spring-security/issues/9204 and https://github.com/spring-projects/spring-security/issues/3737