### PR TITLE
Disable Hazelcast network join auto-detection in tests

### DIFF
--- a/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/HazelcastITestUtils.java
+++ b/spring-session-hazelcast/src/integration-test/java/org/springframework/session/hazelcast/HazelcastITestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ final class HazelcastITestUtils {
 		Config config = new Config();
 		NetworkConfig networkConfig = config.getNetworkConfig();
 		networkConfig.setPort(0);
-		networkConfig.getJoin().getMulticastConfig().setEnabled(false);
+		networkConfig.getJoin().getAutoDetectionConfig().setEnabled(false);
 		AttributeConfig attributeConfig = new AttributeConfig()
 				.setName(HazelcastIndexedSessionRepository.PRINCIPAL_NAME_ATTRIBUTE)
 				.setExtractorClassName(PrincipalNameExtractor.class.getName());

--- a/spring-session-hazelcast/src/integration-test/resources/hazelcast-server.xml
+++ b/spring-session-hazelcast/src/integration-test/resources/hazelcast-server.xml
@@ -5,7 +5,7 @@
 
 	<network>
 		<join>
-			<multicast enabled="false"/>
+			<auto-detection enabled="false"/>
 		</join>
 	</network>
 

--- a/spring-session-samples/spring-session-sample-boot-hazelcast/src/main/java/sample/config/SessionConfig.java
+++ b/spring-session-samples/spring-session-sample-boot-hazelcast/src/main/java/sample/config/SessionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class SessionConfig {
 		Config config = new Config();
 		NetworkConfig networkConfig = config.getNetworkConfig();
 		networkConfig.setPort(0);
-		networkConfig.getJoin().getMulticastConfig().setEnabled(false);
+		networkConfig.getJoin().getAutoDetectionConfig().setEnabled(false);
 		AttributeConfig attributeConfig = new AttributeConfig()
 				.setName(HazelcastIndexedSessionRepository.PRINCIPAL_NAME_ATTRIBUTE)
 				.setExtractorClassName(PrincipalNameExtractor.class.getName());

--- a/spring-session-samples/spring-session-sample-javaconfig-hazelcast/src/main/java/sample/SessionConfig.java
+++ b/spring-session-samples/spring-session-sample-javaconfig-hazelcast/src/main/java/sample/SessionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ public class SessionConfig {
 		Config config = new Config();
 		NetworkConfig networkConfig = config.getNetworkConfig();
 		networkConfig.setPort(0);
-		networkConfig.getJoin().getMulticastConfig().setEnabled(false);
+		networkConfig.getJoin().getAutoDetectionConfig().setEnabled(false);
 		AttributeConfig attributeConfig = new AttributeConfig()
 				.setName(HazelcastIndexedSessionRepository.PRINCIPAL_NAME_ATTRIBUTE)
 				.setExtractorClassName(PrincipalNameExtractor.class.getName());

--- a/spring-session-samples/spring-session-sample-misc-hazelcast/src/main/java/sample/Initializer.java
+++ b/spring-session-samples/spring-session-sample-misc-hazelcast/src/main/java/sample/Initializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ public class Initializer implements ServletContextListener {
 		Config config = new Config();
 		NetworkConfig networkConfig = config.getNetworkConfig();
 		networkConfig.setPort(0);
-		networkConfig.getJoin().getMulticastConfig().setEnabled(false);
+		networkConfig.getJoin().getAutoDetectionConfig().setEnabled(false);
 		config.getMapConfig(SESSION_MAP_NAME).setTimeToLiveSeconds(MapSession.DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS);
 		return Hazelcast.newHazelcastInstance(config);
 	}


### PR DESCRIPTION
At present, Hazelcast configurations used in tests disable multicast join but leave network join auto-detection enabled. This can cause issues with parallel test execution on machines that have bigger number of CPU cores/threads.

This commit updates Hazelcast configurations used in tests to disable network join auto-detection and thus ensure no network join method ends up being enabled.

---

Before making these changes, a number of Hazelcast tests regularly fail on my desktop (Ryzen 5 5600X with 6 cores/12 threads). 

Update:
I would hold off merging this for now because I plan to also try and see if other supported branches are affected by the same issue.