### PR TITLE
Fix Spring Security configuration in tests

### DIFF
--- a/spring-session-data-mongodb/src/integration-test/java/org/springframework/session/data/mongo/integration/MongoDbDeleteJacksonSessionVerificationTest.java
+++ b/spring-session-data-mongodb/src/integration-test/java/org/springframework/session/data/mongo/integration/MongoDbDeleteJacksonSessionVerificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,6 +137,7 @@ public class MongoDbDeleteJacksonSessionVerificationTest {
 
 	}
 
+	@Configuration(proxyBeanMethods = false)
 	@EnableWebFluxSecurity
 	static class SecurityConfig {
 

--- a/spring-session-data-mongodb/src/integration-test/java/org/springframework/session/data/mongo/integration/MongoDbLogoutVerificationTest.java
+++ b/spring-session-data-mongodb/src/integration-test/java/org/springframework/session/data/mongo/integration/MongoDbLogoutVerificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,6 +135,7 @@ public class MongoDbLogoutVerificationTest {
 
 	}
 
+	@Configuration(proxyBeanMethods = false)
 	@EnableWebFluxSecurity
 	static class SecurityConfig {
 

--- a/spring-session-docs/modules/ROOT/examples/java/docs/security/RememberMeSecurityConfiguration.java
+++ b/spring-session-docs/modules/ROOT/examples/java/docs/security/RememberMeSecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package docs.security;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -32,6 +33,7 @@ import org.springframework.session.security.web.authentication.SpringSessionReme
 /**
  * @author rwinch
  */
+@Configuration(proxyBeanMethods = false)
 @EnableWebSecurity
 @EnableSpringHttpSession
 public class RememberMeSecurityConfiguration extends WebSecurityConfigurerAdapter {

--- a/spring-session-samples/spring-session-sample-javaconfig-hazelcast/src/main/java/sample/SecurityConfig.java
+++ b/spring-session-samples/spring-session-sample-javaconfig-hazelcast/src/main/java/sample/SecurityConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package sample;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.userdetails.User;
@@ -24,6 +25,7 @@ import org.springframework.security.core.userdetails.User;
 /**
  * @author Rob Winch
  */
+@Configuration(proxyBeanMethods = false)
 @EnableWebSecurity
 public class SecurityConfig {
 

--- a/spring-session-samples/spring-session-sample-javaconfig-rest/src/main/java/sample/SecurityConfig.java
+++ b/spring-session-samples/spring-session-sample-javaconfig-rest/src/main/java/sample/SecurityConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package sample;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -25,6 +26,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.web.savedrequest.NullRequestCache;
 
+@Configuration(proxyBeanMethods = false)
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 

--- a/spring-session-samples/spring-session-sample-javaconfig-security/src/main/java/sample/SecurityConfig.java
+++ b/spring-session-samples/spring-session-sample-javaconfig-security/src/main/java/sample/SecurityConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package sample;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.userdetails.User;
@@ -24,6 +25,7 @@ import org.springframework.security.core.userdetails.User;
 /**
  * @author Rob Winch
  */
+@Configuration(proxyBeanMethods = false)
 @EnableWebSecurity
 public class SecurityConfig {
 


### PR DESCRIPTION
As of spring-projects/spring-security#11653, Spring Security's `@Enable*Security` annotations are not meta annotated with `@Configuration` which breaks some of our tests.

This commit adds missing `@Configuration` annotations where needed.

Closes gh-2118