### PR TITLE
Use text blocks for SQL statements

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation 'com.apollographql.apollo:apollo-runtime:2.4.5'
     implementation 'com.github.ben-manes:gradle-versions-plugin:0.38.0'
     implementation 'com.github.spullara.mustache.java:compiler:0.9.10'
-    implementation 'io.spring.javaformat:spring-javaformat-gradle-plugin:0.0.15'
+    implementation 'io.spring.javaformat:spring-javaformat-gradle-plugin:0.0.34'
     implementation 'io.spring.nohttp:nohttp-gradle:0.0.9'
     implementation 'net.sourceforge.htmlunit:htmlunit:2.37.0'
     implementation 'org.hidetake:gradle-ssh-plugin:2.10.1'

--- a/spring-session-data-mongodb/src/main/java/org/springframework/session/data/mongo/JacksonMongoSessionConverter.java
+++ b/spring-session-data-mongodb/src/main/java/org/springframework/session/data/mongo/JacksonMongoSessionConverter.java
@@ -174,12 +174,12 @@ public class JacksonMongoSessionConverter extends AbstractMongoSessionConverter 
 		public String translate(String propertyName) {
 
 			switch (propertyName) {
-			case "id":
-				return "_id";
-			case "_id":
-				return "id";
-			default:
-				return propertyName;
+				case "id":
+					return "_id";
+				case "_id":
+					return "id";
+				default:
+					return propertyName;
 			}
 		}
 

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/Db2JdbcIndexedSessionRepositoryCustomizer.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/Db2JdbcIndexedSessionRepositoryCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,19 +28,18 @@ import org.springframework.session.config.SessionRepositoryCustomizer;
 public class Db2JdbcIndexedSessionRepositoryCustomizer
 		implements SessionRepositoryCustomizer<JdbcIndexedSessionRepository> {
 
-	// @formatter:off
-	private static final String CREATE_SESSION_ATTRIBUTE_QUERY = ""
-			+ "MERGE INTO %TABLE_NAME%_ATTRIBUTES SA "
-			+ "USING ( "
-			+ "    VALUES (?, ?, ?) "
-			+ ") A (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES) "
-			+ "ON (SA.SESSION_PRIMARY_ID = A.SESSION_PRIMARY_ID and SA.ATTRIBUTE_NAME = A.ATTRIBUTE_NAME) "
-			+ "WHEN MATCHED THEN "
-			+ "    UPDATE SET ATTRIBUTE_BYTES = A.ATTRIBUTE_BYTES "
-			+ "WHEN NOT MATCHED THEN "
-			+ "    INSERT (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES) "
-			+ "    VALUES (A.SESSION_PRIMARY_ID, A.ATTRIBUTE_NAME, A.ATTRIBUTE_BYTES)";
-	// @formatter:on
+	private static final String CREATE_SESSION_ATTRIBUTE_QUERY = """
+			MERGE INTO %TABLE_NAME%_ATTRIBUTES SA
+			USING (
+				VALUES (?, ?, ?)
+			) A (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES)
+			ON (SA.SESSION_PRIMARY_ID = A.SESSION_PRIMARY_ID and SA.ATTRIBUTE_NAME = A.ATTRIBUTE_NAME)
+			WHEN MATCHED THEN
+				UPDATE SET ATTRIBUTE_BYTES = A.ATTRIBUTE_BYTES
+			WHEN NOT MATCHED THEN
+				INSERT (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES)
+				VALUES (A.SESSION_PRIMARY_ID, A.ATTRIBUTE_NAME, A.ATTRIBUTE_BYTES)
+			""";
 
 	@Override
 	public void customize(JdbcIndexedSessionRepository sessionRepository) {

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcIndexedSessionRepository.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcIndexedSessionRepository.java
@@ -140,68 +140,59 @@ public class JdbcIndexedSessionRepository
 
 	private static final String SPRING_SECURITY_CONTEXT = "SPRING_SECURITY_CONTEXT";
 
-	// @formatter:off
-	private static final String CREATE_SESSION_QUERY = ""
-			+ "INSERT INTO %TABLE_NAME% (PRIMARY_ID, SESSION_ID, CREATION_TIME, LAST_ACCESS_TIME, MAX_INACTIVE_INTERVAL, EXPIRY_TIME, PRINCIPAL_NAME) "
-			+ "VALUES (?, ?, ?, ?, ?, ?, ?)";
-	// @formatter:on
+	private static final String CREATE_SESSION_QUERY = """
+			INSERT INTO %TABLE_NAME% (PRIMARY_ID, SESSION_ID, CREATION_TIME, LAST_ACCESS_TIME, MAX_INACTIVE_INTERVAL, EXPIRY_TIME, PRINCIPAL_NAME)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+			""";
 
-	// @formatter:off
-	private static final String CREATE_SESSION_ATTRIBUTE_QUERY = ""
-			+ "INSERT INTO %TABLE_NAME%_ATTRIBUTES (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES) "
-			+ "VALUES (?, ?, ?)";
-	// @formatter:on
+	private static final String CREATE_SESSION_ATTRIBUTE_QUERY = """
+			INSERT INTO %TABLE_NAME%_ATTRIBUTES (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES)
+			VALUES (?, ?, ?)
+			""";
 
-	// @formatter:off
-	private static final String GET_SESSION_QUERY = ""
-			+ "SELECT S.PRIMARY_ID, S.SESSION_ID, S.CREATION_TIME, S.LAST_ACCESS_TIME, S.MAX_INACTIVE_INTERVAL, SA.ATTRIBUTE_NAME, SA.ATTRIBUTE_BYTES "
-			+ "FROM %TABLE_NAME% S "
-			+ "LEFT JOIN %TABLE_NAME%_ATTRIBUTES SA ON S.PRIMARY_ID = SA.SESSION_PRIMARY_ID "
-			+ "WHERE S.SESSION_ID = ?";
-	// @formatter:on
+	private static final String GET_SESSION_QUERY = """
+			SELECT S.PRIMARY_ID, S.SESSION_ID, S.CREATION_TIME, S.LAST_ACCESS_TIME, S.MAX_INACTIVE_INTERVAL, SA.ATTRIBUTE_NAME, SA.ATTRIBUTE_BYTES
+			FROM %TABLE_NAME% S
+			LEFT JOIN %TABLE_NAME%_ATTRIBUTES SA ON S.PRIMARY_ID = SA.SESSION_PRIMARY_ID
+			WHERE S.SESSION_ID = ?
+			""";
 
-	// @formatter:off
-	private static final String UPDATE_SESSION_QUERY = ""
-			+ "UPDATE %TABLE_NAME% "
-			+ "SET SESSION_ID = ?, LAST_ACCESS_TIME = ?, MAX_INACTIVE_INTERVAL = ?, EXPIRY_TIME = ?, PRINCIPAL_NAME = ? "
-			+ "WHERE PRIMARY_ID = ?";
-	// @formatter:on
+	private static final String UPDATE_SESSION_QUERY = """
+			UPDATE %TABLE_NAME%
+			SET SESSION_ID = ?, LAST_ACCESS_TIME = ?, MAX_INACTIVE_INTERVAL = ?, EXPIRY_TIME = ?, PRINCIPAL_NAME = ?
+			WHERE PRIMARY_ID = ?
+			""";
 
-	// @formatter:off
-	private static final String UPDATE_SESSION_ATTRIBUTE_QUERY = ""
-			+ "UPDATE %TABLE_NAME%_ATTRIBUTES "
-			+ "SET ATTRIBUTE_BYTES = ? "
-			+ "WHERE SESSION_PRIMARY_ID = ? "
-			+ "AND ATTRIBUTE_NAME = ?";
-	// @formatter:on
+	private static final String UPDATE_SESSION_ATTRIBUTE_QUERY = """
+			UPDATE %TABLE_NAME%_ATTRIBUTES
+			SET ATTRIBUTE_BYTES = ?
+			WHERE SESSION_PRIMARY_ID = ?
+			AND ATTRIBUTE_NAME = ?
+			""";
 
-	// @formatter:off
-	private static final String DELETE_SESSION_ATTRIBUTE_QUERY = ""
-			+ "DELETE FROM %TABLE_NAME%_ATTRIBUTES "
-			+ "WHERE SESSION_PRIMARY_ID = ? "
-			+ "AND ATTRIBUTE_NAME = ?";
-	// @formatter:on
+	private static final String DELETE_SESSION_ATTRIBUTE_QUERY = """
+			DELETE FROM %TABLE_NAME%_ATTRIBUTES
+			WHERE SESSION_PRIMARY_ID = ?
+			AND ATTRIBUTE_NAME = ?
+			""";
 
-	// @formatter:off
-	private static final String DELETE_SESSION_QUERY = ""
-			+ "DELETE FROM %TABLE_NAME% "
-			+ "WHERE SESSION_ID = ? "
-			+ "AND MAX_INACTIVE_INTERVAL >= 0";
-	// @formatter:on
+	private static final String DELETE_SESSION_QUERY = """
+			DELETE FROM %TABLE_NAME%
+			WHERE SESSION_ID = ?
+			AND MAX_INACTIVE_INTERVAL >= 0
+			""";
 
-	// @formatter:off
-	private static final String LIST_SESSIONS_BY_PRINCIPAL_NAME_QUERY = ""
-			+ "SELECT S.PRIMARY_ID, S.SESSION_ID, S.CREATION_TIME, S.LAST_ACCESS_TIME, S.MAX_INACTIVE_INTERVAL, SA.ATTRIBUTE_NAME, SA.ATTRIBUTE_BYTES "
-			+ "FROM %TABLE_NAME% S "
-			+ "LEFT JOIN %TABLE_NAME%_ATTRIBUTES SA ON S.PRIMARY_ID = SA.SESSION_PRIMARY_ID "
-			+ "WHERE S.PRINCIPAL_NAME = ?";
-	// @formatter:on
+	private static final String LIST_SESSIONS_BY_PRINCIPAL_NAME_QUERY = """
+			SELECT S.PRIMARY_ID, S.SESSION_ID, S.CREATION_TIME, S.LAST_ACCESS_TIME, S.MAX_INACTIVE_INTERVAL, SA.ATTRIBUTE_NAME, SA.ATTRIBUTE_BYTES
+			FROM %TABLE_NAME% S
+			LEFT JOIN %TABLE_NAME%_ATTRIBUTES SA ON S.PRIMARY_ID = SA.SESSION_PRIMARY_ID
+			WHERE S.PRINCIPAL_NAME = ?
+			""";
 
-	// @formatter:off
-	private static final String DELETE_SESSIONS_BY_EXPIRY_TIME_QUERY = ""
-			+ "DELETE FROM %TABLE_NAME% "
-			+ "WHERE EXPIRY_TIME < ?";
-	// @formatter:on
+	private static final String DELETE_SESSIONS_BY_EXPIRY_TIME_QUERY = """
+			DELETE FROM %TABLE_NAME%
+			WHERE EXPIRY_TIME < ?
+			""";
 
 	private static final Log logger = LogFactory.getLog(JdbcIndexedSessionRepository.class);
 

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/MySqlJdbcIndexedSessionRepositoryCustomizer.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/MySqlJdbcIndexedSessionRepositoryCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,12 +28,11 @@ import org.springframework.session.config.SessionRepositoryCustomizer;
 public class MySqlJdbcIndexedSessionRepositoryCustomizer
 		implements SessionRepositoryCustomizer<JdbcIndexedSessionRepository> {
 
-	// @formatter:off
-	private static final String CREATE_SESSION_ATTRIBUTE_QUERY = ""
-			+ "INSERT INTO %TABLE_NAME%_ATTRIBUTES (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES) "
-			+ "VALUES (?, ?, ?) "
-			+ "ON DUPLICATE KEY UPDATE ATTRIBUTE_BYTES = VALUES(ATTRIBUTE_BYTES)";
-	// @formatter:on
+	private static final String CREATE_SESSION_ATTRIBUTE_QUERY = """
+			INSERT INTO %TABLE_NAME%_ATTRIBUTES (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES)
+			VALUES (?, ?, ?)
+			ON DUPLICATE KEY UPDATE ATTRIBUTE_BYTES = VALUES(ATTRIBUTE_BYTES)
+			""";
 
 	@Override
 	public void customize(JdbcIndexedSessionRepository sessionRepository) {

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/OracleJdbcIndexedSessionRepositoryCustomizer.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/OracleJdbcIndexedSessionRepositoryCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,20 +28,19 @@ import org.springframework.session.config.SessionRepositoryCustomizer;
 public class OracleJdbcIndexedSessionRepositoryCustomizer
 		implements SessionRepositoryCustomizer<JdbcIndexedSessionRepository> {
 
-	// @formatter:off
-	private static final String CREATE_SESSION_ATTRIBUTE_QUERY = ""
-			+ "MERGE INTO %TABLE_NAME%_ATTRIBUTES SA "
-			+ "USING ( "
-			+ "    SELECT ? AS SESSION_PRIMARY_ID, ? AS ATTRIBUTE_NAME, ? AS ATTRIBUTE_BYTES "
-			+ "    FROM DUAL "
-			+ ") A "
-			+ "ON (SA.SESSION_PRIMARY_ID = A.SESSION_PRIMARY_ID and SA.ATTRIBUTE_NAME = A.ATTRIBUTE_NAME) "
-			+ "WHEN MATCHED THEN "
-			+ "    UPDATE SET ATTRIBUTE_BYTES = A.ATTRIBUTE_BYTES "
-			+ "WHEN NOT MATCHED THEN "
-			+ "    INSERT (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES) "
-			+ "    VALUES (A.SESSION_PRIMARY_ID, A.ATTRIBUTE_NAME, A.ATTRIBUTE_BYTES)";
-	// @formatter:on
+	private static final String CREATE_SESSION_ATTRIBUTE_QUERY = """
+			MERGE INTO %TABLE_NAME%_ATTRIBUTES SA
+			USING (
+				SELECT ? AS SESSION_PRIMARY_ID, ? AS ATTRIBUTE_NAME, ? AS ATTRIBUTE_BYTES
+				FROM DUAL
+			) A
+			ON (SA.SESSION_PRIMARY_ID = A.SESSION_PRIMARY_ID and SA.ATTRIBUTE_NAME = A.ATTRIBUTE_NAME)
+			WHEN MATCHED THEN
+				UPDATE SET ATTRIBUTE_BYTES = A.ATTRIBUTE_BYTES
+			WHEN NOT MATCHED THEN
+				INSERT (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES)
+				VALUES (A.SESSION_PRIMARY_ID, A.ATTRIBUTE_NAME, A.ATTRIBUTE_BYTES)
+			""";
 
 	@Override
 	public void customize(JdbcIndexedSessionRepository sessionRepository) {

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/PostgreSqlJdbcIndexedSessionRepositoryCustomizer.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/PostgreSqlJdbcIndexedSessionRepositoryCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,13 +28,12 @@ import org.springframework.session.config.SessionRepositoryCustomizer;
 public class PostgreSqlJdbcIndexedSessionRepositoryCustomizer
 		implements SessionRepositoryCustomizer<JdbcIndexedSessionRepository> {
 
-	// @formatter:off
-	private static final String CREATE_SESSION_ATTRIBUTE_QUERY = ""
-			+ "INSERT INTO %TABLE_NAME%_ATTRIBUTES (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES) "
-			+ "VALUES (?, ?, ?) "
-			+ "ON CONFLICT (SESSION_PRIMARY_ID, ATTRIBUTE_NAME) "
-			+ "DO UPDATE SET ATTRIBUTE_BYTES = EXCLUDED.ATTRIBUTE_BYTES";
-	// @formatter:on
+	private static final String CREATE_SESSION_ATTRIBUTE_QUERY = """
+			INSERT INTO %TABLE_NAME%_ATTRIBUTES (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES)
+			VALUES (?, ?, ?)
+			ON CONFLICT (SESSION_PRIMARY_ID, ATTRIBUTE_NAME)
+			DO UPDATE SET ATTRIBUTE_BYTES = EXCLUDED.ATTRIBUTE_BYTES
+			""";
 
 	@Override
 	public void customize(JdbcIndexedSessionRepository sessionRepository) {

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/SqlServerJdbcIndexedSessionRepositoryCustomizer.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/SqlServerJdbcIndexedSessionRepositoryCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,19 +28,18 @@ import org.springframework.session.config.SessionRepositoryCustomizer;
 public class SqlServerJdbcIndexedSessionRepositoryCustomizer
 		implements SessionRepositoryCustomizer<JdbcIndexedSessionRepository> {
 
-	// @formatter:off
-	private static final String CREATE_SESSION_ATTRIBUTE_QUERY = ""
-			+ "MERGE INTO %TABLE_NAME%_ATTRIBUTES SA "
-			+ "USING ( "
-			+ "    VALUES (?, ?, ?) "
-			+ ") A (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES) "
-			+ "ON (SA.SESSION_PRIMARY_ID = A.SESSION_PRIMARY_ID and SA.ATTRIBUTE_NAME = A.ATTRIBUTE_NAME) "
-			+ "WHEN MATCHED THEN "
-			+ "    UPDATE SET ATTRIBUTE_BYTES = A.ATTRIBUTE_BYTES "
-			+ "WHEN NOT MATCHED THEN "
-			+ "    INSERT (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES) "
-			+ "    VALUES (A.SESSION_PRIMARY_ID, A.ATTRIBUTE_NAME, A.ATTRIBUTE_BYTES);";
-	// @formatter:on
+	private static final String CREATE_SESSION_ATTRIBUTE_QUERY = """
+			MERGE INTO %TABLE_NAME%_ATTRIBUTES SA
+			USING (
+				VALUES (?, ?, ?)
+			) A (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES)
+			ON (SA.SESSION_PRIMARY_ID = A.SESSION_PRIMARY_ID and SA.ATTRIBUTE_NAME = A.ATTRIBUTE_NAME)
+			WHEN MATCHED THEN
+				UPDATE SET ATTRIBUTE_BYTES = A.ATTRIBUTE_BYTES
+			WHEN NOT MATCHED THEN
+				INSERT (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES)
+				VALUES (A.SESSION_PRIMARY_ID, A.ATTRIBUTE_NAME, A.ATTRIBUTE_BYTES);
+			""";
 
 	@Override
 	public void customize(JdbcIndexedSessionRepository sessionRepository) {

--- a/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcIndexedSessionRepositoryTests.java
+++ b/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcIndexedSessionRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeastOnce;
@@ -350,7 +351,7 @@ class JdbcIndexedSessionRepositoryTests {
 		this.repository.save(session);
 
 		assertThat(session.isNew()).isFalse();
-		verify(this.jdbcOperations, times(1)).update(startsWith("UPDATE SPRING_SESSION_ATTRIBUTES SET"),
+		verify(this.jdbcOperations, times(1)).update(matches("^UPDATE SPRING_SESSION_ATTRIBUTES\\s*SET.*"),
 				isA(PreparedStatementSetter.class));
 		verifyNoMoreInteractions(this.jdbcOperations);
 	}
@@ -367,7 +368,7 @@ class JdbcIndexedSessionRepositoryTests {
 		this.repository.save(session);
 
 		assertThat(session.isNew()).isFalse();
-		verify(this.jdbcOperations, times(1)).batchUpdate(startsWith("UPDATE SPRING_SESSION_ATTRIBUTES SET"),
+		verify(this.jdbcOperations, times(1)).batchUpdate(matches("^UPDATE SPRING_SESSION_ATTRIBUTES\\s*SET.*"),
 				isA(BatchPreparedStatementSetter.class));
 		verifyNoMoreInteractions(this.jdbcOperations);
 	}
@@ -382,7 +383,7 @@ class JdbcIndexedSessionRepositoryTests {
 		this.repository.save(session);
 
 		assertThat(session.isNew()).isFalse();
-		verify(this.jdbcOperations, times(1)).update(startsWith("DELETE FROM SPRING_SESSION_ATTRIBUTES WHERE"),
+		verify(this.jdbcOperations, times(1)).update(matches("^DELETE FROM SPRING_SESSION_ATTRIBUTES\\s*WHERE.*"),
 				isA(PreparedStatementSetter.class));
 		verifyNoMoreInteractions(this.jdbcOperations);
 	}
@@ -410,7 +411,7 @@ class JdbcIndexedSessionRepositoryTests {
 		this.repository.save(session);
 
 		assertThat(session.isNew()).isFalse();
-		verify(this.jdbcOperations, times(1)).batchUpdate(startsWith("DELETE FROM SPRING_SESSION_ATTRIBUTES WHERE"),
+		verify(this.jdbcOperations, times(1)).batchUpdate(matches("^DELETE FROM SPRING_SESSION_ATTRIBUTES\\s*WHERE.*"),
 				isA(BatchPreparedStatementSetter.class));
 		verifyNoMoreInteractions(this.jdbcOperations);
 	}
@@ -452,7 +453,7 @@ class JdbcIndexedSessionRepositoryTests {
 		this.repository.save(session);
 
 		assertThat(session.isNew()).isFalse();
-		verify(this.jdbcOperations).update(startsWith("DELETE FROM SPRING_SESSION_ATTRIBUTES WHERE"),
+		verify(this.jdbcOperations).update(matches("^DELETE FROM SPRING_SESSION_ATTRIBUTES\\s*WHERE.*"),
 				isA(PreparedStatementSetter.class));
 		verifyNoMoreInteractions(this.jdbcOperations);
 	}
@@ -468,7 +469,7 @@ class JdbcIndexedSessionRepositoryTests {
 		this.repository.save(session);
 
 		assertThat(session.isNew()).isFalse();
-		verify(this.jdbcOperations).update(startsWith("UPDATE SPRING_SESSION_ATTRIBUTES SET"),
+		verify(this.jdbcOperations).update(matches("^UPDATE SPRING_SESSION_ATTRIBUTES\\s*SET.*"),
 				isA(PreparedStatementSetter.class));
 		verifyNoMoreInteractions(this.jdbcOperations);
 	}
@@ -481,7 +482,7 @@ class JdbcIndexedSessionRepositoryTests {
 		this.repository.save(session);
 
 		assertThat(session.isNew()).isFalse();
-		verify(this.jdbcOperations, times(1)).update(startsWith("UPDATE SPRING_SESSION SET"),
+		verify(this.jdbcOperations, times(1)).update(matches("^UPDATE SPRING_SESSION\\s*SET.*"),
 				isA(PreparedStatementSetter.class));
 		verifyNoMoreInteractions(this.jdbcOperations);
 	}
@@ -632,7 +633,7 @@ class JdbcIndexedSessionRepositoryTests {
 		session.getAttribute("attribute2");
 		session.setAttribute("attribute3", "value4");
 		this.repository.save(session);
-		verify(this.jdbcOperations).update(startsWith("UPDATE SPRING_SESSION_ATTRIBUTES SET"),
+		verify(this.jdbcOperations).update(matches("^UPDATE SPRING_SESSION_ATTRIBUTES\\s*SET.*"),
 				isA(PreparedStatementSetter.class));
 		verifyNoMoreInteractions(this.jdbcOperations);
 	}
@@ -650,7 +651,8 @@ class JdbcIndexedSessionRepositoryTests {
 		this.repository.save(session);
 		ArgumentCaptor<BatchPreparedStatementSetter> captor = ArgumentCaptor
 				.forClass(BatchPreparedStatementSetter.class);
-		verify(this.jdbcOperations).batchUpdate(startsWith("UPDATE SPRING_SESSION_ATTRIBUTES SET"), captor.capture());
+		verify(this.jdbcOperations).batchUpdate(matches("^UPDATE SPRING_SESSION_ATTRIBUTES\\s*SET.*"),
+				captor.capture());
 		assertThat(captor.getValue().getBatchSize()).isEqualTo(2);
 		verifyNoMoreInteractions(this.jdbcOperations);
 	}
@@ -682,7 +684,8 @@ class JdbcIndexedSessionRepositoryTests {
 		this.repository.save(session);
 		ArgumentCaptor<BatchPreparedStatementSetter> captor = ArgumentCaptor
 				.forClass(BatchPreparedStatementSetter.class);
-		verify(this.jdbcOperations).batchUpdate(startsWith("UPDATE SPRING_SESSION_ATTRIBUTES SET"), captor.capture());
+		verify(this.jdbcOperations).batchUpdate(matches("^UPDATE SPRING_SESSION_ATTRIBUTES\\s*SET.*"),
+				captor.capture());
 		assertThat(captor.getValue().getBatchSize()).isEqualTo(3);
 		verifyNoMoreInteractions(this.jdbcOperations);
 	}
@@ -705,7 +708,7 @@ class JdbcIndexedSessionRepositoryTests {
 		cached.setAttribute("attribute1", "value1");
 		JdbcSession session = this.repository.new JdbcSession(cached, "primaryKey", false);
 		session.removeAttribute("attribute1");
-		verify(this.jdbcOperations).update(startsWith("DELETE FROM SPRING_SESSION_ATTRIBUTES WHERE"),
+		verify(this.jdbcOperations).update(matches("^DELETE FROM SPRING_SESSION_ATTRIBUTES\\s*WHERE.*"),
 				isA(PreparedStatementSetter.class));
 		verifyNoMoreInteractions(this.jdbcOperations);
 	}
@@ -715,7 +718,8 @@ class JdbcIndexedSessionRepositoryTests {
 		this.repository.setFlushMode(FlushMode.IMMEDIATE);
 		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
 		session.setMaxInactiveInterval(Duration.ofSeconds(1));
-		verify(this.jdbcOperations).update(startsWith("UPDATE SPRING_SESSION SET"), isA(PreparedStatementSetter.class));
+		verify(this.jdbcOperations).update(matches("^UPDATE SPRING_SESSION\\s*SET.*"),
+				isA(PreparedStatementSetter.class));
 		verifyNoMoreInteractions(this.jdbcOperations);
 	}
 
@@ -724,7 +728,8 @@ class JdbcIndexedSessionRepositoryTests {
 		this.repository.setFlushMode(FlushMode.IMMEDIATE);
 		JdbcSession session = this.repository.new JdbcSession(new MapSession(), "primaryKey", false);
 		session.setLastAccessedTime(Instant.now());
-		verify(this.jdbcOperations).update(startsWith("UPDATE SPRING_SESSION SET"), isA(PreparedStatementSetter.class));
+		verify(this.jdbcOperations).update(matches("^UPDATE SPRING_SESSION\\s*SET.*"),
+				isA(PreparedStatementSetter.class));
 		verifyNoMoreInteractions(this.jdbcOperations);
 	}
 


### PR DESCRIPTION
With Java 17 now being the baseline, strings containing SQL statements can be managed more conveniently using text blocks.

Note: these changes require upgrade of Spring JavaFormat in order for the formatter to be able to deal with text blocks.