### PR TITLE
Simplify expired session cleanup jobs

### DIFF
--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/EnableRedisIndexedHttpSession.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/EnableRedisIndexedHttpSession.java
@@ -108,6 +108,6 @@ public @interface EnableRedisIndexedHttpSession {
 	 * The cron expression for expired session cleanup job. By default runs every minute.
 	 * @return the session cleanup cron expression
 	 */
-	String cleanupCron() default RedisIndexedHttpSessionConfiguration.DEFAULT_CLEANUP_CRON;
+	String cleanupCron() default RedisIndexedSessionRepository.DEFAULT_CLEANUP_CRON;
 
 }

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisIndexedHttpSessionConfigurationTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisIndexedHttpSessionConfigurationTests.java
@@ -117,10 +117,8 @@ class RedisIndexedHttpSessionConfigurationTests {
 	void customCleanupCronAnnotation() {
 		registerAndRefresh(RedisConfig.class, CustomCleanupCronExpressionAnnotationConfiguration.class);
 
-		RedisIndexedHttpSessionConfiguration configuration = this.context
-				.getBean(RedisIndexedHttpSessionConfiguration.class);
-		assertThat(configuration).isNotNull();
-		assertThat(ReflectionTestUtils.getField(configuration, "cleanupCron")).isEqualTo(CLEANUP_CRON_EXPRESSION);
+		RedisIndexedSessionRepository sessionRepository = this.context.getBean(RedisIndexedSessionRepository.class);
+		assertThat(sessionRepository).extracting("cleanupCron").isEqualTo(CLEANUP_CRON_EXPRESSION);
 	}
 
 	@Test

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/EnableJdbcHttpSession.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/EnableJdbcHttpSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,7 +98,7 @@ public @interface EnableJdbcHttpSession {
 	 * @return the session cleanup cron expression
 	 * @since 2.0.0
 	 */
-	String cleanupCron() default JdbcHttpSessionConfiguration.DEFAULT_CLEANUP_CRON;
+	String cleanupCron() default JdbcIndexedSessionRepository.DEFAULT_CLEANUP_CRON;
 
 	/**
 	 * Flush mode for the sessions. The default is {@code ON_SAVE} which only updates the

--- a/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcIndexedSessionRepositoryTests.java
+++ b/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/JdbcIndexedSessionRepositoryTests.java
@@ -38,6 +38,7 @@ import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.support.lob.DefaultLobHandler;
 import org.springframework.jdbc.support.lob.TemporaryLobCreator;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.AuthorityUtils;
@@ -241,6 +242,25 @@ class JdbcIndexedSessionRepositoryTests {
 	void setSaveModeNull() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setSaveMode(null))
 				.withMessage("saveMode must not be null");
+	}
+
+	@Test
+	void setCleanupCronNull() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setCleanupCron(null))
+				.withMessage("cleanupCron must not be null");
+	}
+
+	@Test
+	void setCleanupCronInvalid() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setCleanupCron("test"))
+				.withMessage("cleanupCron must be valid");
+	}
+
+	@Test
+	void setCleanupCronDisabled() {
+		this.repository.setCleanupCron(Scheduled.CRON_DISABLED);
+		this.repository.afterPropertiesSet();
+		assertThat(this.repository).extracting("taskScheduler").isNull();
 	}
 
 	@Test

--- a/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfigurationTests.java
+++ b/spring-session-jdbc/src/test/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfigurationTests.java
@@ -136,18 +136,16 @@ class JdbcHttpSessionConfigurationTests {
 	void customCleanupCronAnnotation() {
 		registerAndRefresh(DataSourceConfiguration.class, CustomCleanupCronExpressionAnnotationConfiguration.class);
 
-		JdbcHttpSessionConfiguration configuration = this.context.getBean(JdbcHttpSessionConfiguration.class);
-		assertThat(configuration).isNotNull();
-		assertThat(ReflectionTestUtils.getField(configuration, "cleanupCron")).isEqualTo(CLEANUP_CRON_EXPRESSION);
+		JdbcIndexedSessionRepository repository = this.context.getBean(JdbcIndexedSessionRepository.class);
+		assertThat(repository).extracting("cleanupCron").isEqualTo(CLEANUP_CRON_EXPRESSION);
 	}
 
 	@Test
 	void customCleanupCronSetter() {
 		registerAndRefresh(DataSourceConfiguration.class, CustomCleanupCronExpressionSetterConfiguration.class);
 
-		JdbcHttpSessionConfiguration configuration = this.context.getBean(JdbcHttpSessionConfiguration.class);
-		assertThat(configuration).isNotNull();
-		assertThat(ReflectionTestUtils.getField(configuration, "cleanupCron")).isEqualTo(CLEANUP_CRON_EXPRESSION);
+		JdbcIndexedSessionRepository repository = this.context.getBean(JdbcIndexedSessionRepository.class);
+		assertThat(repository).extracting("cleanupCron").isEqualTo(CLEANUP_CRON_EXPRESSION);
 	}
 
 	@Test


### PR DESCRIPTION
At present, `RedisIndexedHttpSessionConfiguration` and `JdbcHttpSessionConfiguration` include `@EnableScheduling` annotated inner configuration classes that configure expired session cleanup jobs. This approach silently opts in users into general purpose task scheduling support provided by Spring Framework, which isn't something a library should do. Ideally, session cleanup jobs should only require a single thread dedicated to their execution and also one that doesn't compete for resources with general purpose task scheduling.

This PR updates `RedisIndexedSessionRepository` and `JdbcIndexedSessionRepository` to have them manage their own `ThreadPoolTaskScheduler` for purposes of running expired session cleanup jobs.

Closes gh-2136