### PR TITLE
Fix "Find by Username" sample

### DIFF
--- a/spring-session-samples/spring-session-sample-boot-findbyusername/src/main/resources/application.properties
+++ b/spring-session-samples/spring-session-sample-boot-findbyusername/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.security.user.password=password
+spring.session.redis.repository-type=indexed


### PR DESCRIPTION
Spring Boot's auto-configuration support for Spring Session now uses `RedisSessionRepository` as the default Redis session repository, so applications that rely on indexed session repository need to opt into the previous default. One such example is our _Find by Username_ sample.

This commit fixes _Find by Username_ sample by opting into the indexed repository type using newly introduced `spring.session.redis.repository-type` property.