### PR TITLE
Ensure configuration classes can be used with @Import

### DIFF
--- a/spring-session-data-mongodb/src/test/java/org/springframework/session/data/mongo/config/annotation/web/http/MongoHttpSessionConfigurationTest.java
+++ b/spring-session-data-mongodb/src/test/java/org/springframework/session/data/mongo/config/annotation/web/http/MongoHttpSessionConfigurationTest.java
@@ -194,6 +194,13 @@ public class MongoHttpSessionConfigurationTest {
 				indexResolver);
 	}
 
+	@Test
+	void importConfigAndCustomize() {
+		registerAndRefresh(ImportConfigAndCustomizeConfiguration.class);
+		MongoIndexedSessionRepository sessionRepository = this.context.getBean(MongoIndexedSessionRepository.class);
+		assertThat(sessionRepository).extracting("maxInactiveIntervalInSeconds").isEqualTo(0);
+	}
+
 	private void registerAndRefresh(Class<?>... annotatedClasses) {
 
 		this.context.register(annotatedClasses);
@@ -329,6 +336,17 @@ public class MongoHttpSessionConfigurationTest {
 		@SuppressWarnings("unchecked")
 		IndexResolver<MongoSession> indexResolver() {
 			return mock(IndexResolver.class);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Import(MongoHttpSessionConfiguration.class)
+	static class ImportConfigAndCustomizeConfiguration extends BaseConfiguration {
+
+		@Bean
+		SessionRepositoryCustomizer<MongoIndexedSessionRepository> sessionRepositoryCustomizer() {
+			return (sessionRepository) -> sessionRepository.setMaxInactiveIntervalInSeconds(0);
 		}
 
 	}

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/server/RedisWebSessionConfiguration.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/server/RedisWebSessionConfiguration.java
@@ -140,6 +140,9 @@ public class RedisWebSessionConfiguration extends SpringWebSessionConfiguration
 		Map<String, Object> attributeMap = importMetadata
 				.getAnnotationAttributes(EnableRedisWebSession.class.getName());
 		AnnotationAttributes attributes = AnnotationAttributes.fromMap(attributeMap);
+		if (attributes == null) {
+			return;
+		}
 		this.maxInactiveIntervalInSeconds = attributes.getNumber("maxInactiveIntervalInSeconds");
 		String redisNamespaceValue = attributes.getString("redisNamespace");
 		if (StringUtils.hasText(redisNamespaceValue)) {

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpsSessionConfigurationTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisHttpsSessionConfigurationTests.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.annotation.Order;
@@ -198,6 +199,13 @@ class RedisHttpsSessionConfigurationTests {
 				Duration.ofSeconds(MAX_INACTIVE_INTERVAL_IN_SECONDS));
 	}
 
+	@Test
+	void importConfigAndCustomize() {
+		registerAndRefresh(RedisConfig.class, ImportConfigAndCustomizeConfiguration.class);
+		RedisSessionRepository sessionRepository = this.context.getBean(RedisSessionRepository.class);
+		assertThat(sessionRepository).extracting("defaultMaxInactiveInterval").isEqualTo(Duration.ZERO);
+	}
+
 	private void registerAndRefresh(Class<?>... annotatedClasses) {
 		this.context.register(annotatedClasses);
 		this.context.refresh();
@@ -358,6 +366,17 @@ class RedisHttpsSessionConfigurationTests {
 		SessionRepositoryCustomizer<RedisSessionRepository> sessionRepositoryCustomizerTwo() {
 			return (sessionRepository) -> sessionRepository
 					.setDefaultMaxInactiveInterval(Duration.ofSeconds(MAX_INACTIVE_INTERVAL_IN_SECONDS));
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Import(RedisHttpSessionConfiguration.class)
+	static class ImportConfigAndCustomizeConfiguration {
+
+		@Bean
+		SessionRepositoryCustomizer<RedisSessionRepository> sessionRepositoryCustomizer() {
+			return (sessionRepository) -> sessionRepository.setDefaultMaxInactiveInterval(Duration.ZERO);
 		}
 
 	}

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisIndexedHttpSessionConfigurationTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/http/RedisIndexedHttpSessionConfigurationTests.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.annotation.Order;
@@ -231,6 +232,13 @@ class RedisIndexedHttpSessionConfigurationTests {
 				MAX_INACTIVE_INTERVAL_IN_SECONDS);
 	}
 
+	@Test
+	void importConfigAndCustomize() {
+		registerAndRefresh(RedisConfig.class, ImportConfigAndCustomizeConfiguration.class);
+		RedisIndexedSessionRepository sessionRepository = this.context.getBean(RedisIndexedSessionRepository.class);
+		assertThat(sessionRepository).extracting("defaultMaxInactiveInterval").isEqualTo(0);
+	}
+
 	private void registerAndRefresh(Class<?>... annotatedClasses) {
 		this.context.register(annotatedClasses);
 		this.context.refresh();
@@ -420,6 +428,17 @@ class RedisIndexedHttpSessionConfigurationTests {
 		SessionRepositoryCustomizer<RedisIndexedSessionRepository> sessionRepositoryCustomizerTwo() {
 			return (sessionRepository) -> sessionRepository
 					.setDefaultMaxInactiveInterval(MAX_INACTIVE_INTERVAL_IN_SECONDS);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Import(RedisIndexedHttpSessionConfiguration.class)
+	static class ImportConfigAndCustomizeConfiguration {
+
+		@Bean
+		SessionRepositoryCustomizer<RedisIndexedSessionRepository> sessionRepositoryCustomizer() {
+			return (sessionRepository) -> sessionRepository.setDefaultMaxInactiveInterval(0);
 		}
 
 	}

--- a/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfiguration.java
+++ b/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfiguration.java
@@ -125,6 +125,9 @@ public class HazelcastHttpSessionConfiguration extends SpringHttpSessionConfigur
 		Map<String, Object> attributeMap = importMetadata
 				.getAnnotationAttributes(EnableHazelcastHttpSession.class.getName());
 		AnnotationAttributes attributes = AnnotationAttributes.fromMap(attributeMap);
+		if (attributes == null) {
+			return;
+		}
 		this.maxInactiveIntervalInSeconds = attributes.getNumber("maxInactiveIntervalInSeconds");
 		String sessionMapNameValue = attributes.getString("sessionMapName");
 		if (StringUtils.hasText(sessionMapNameValue)) {

--- a/spring-session-hazelcast/src/test/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfigurationTests.java
+++ b/spring-session-hazelcast/src/test/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfigurationTests.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.annotation.Order;
 import org.springframework.session.FlushMode;
@@ -228,6 +229,14 @@ class HazelcastHttpSessionConfigurationTests {
 				.getBean(HazelcastIndexedSessionRepository.class);
 		assertThat(sessionRepository).hasFieldOrPropertyWithValue("defaultMaxInactiveInterval",
 				MAX_INACTIVE_INTERVAL_IN_SECONDS);
+	}
+
+	@Test
+	void importConfigAndCustomize() {
+		registerAndRefresh(ImportConfigAndCustomizeConfiguration.class);
+		HazelcastIndexedSessionRepository sessionRepository = this.context
+				.getBean(HazelcastIndexedSessionRepository.class);
+		assertThat(sessionRepository).extracting("defaultMaxInactiveInterval").isEqualTo(0);
 	}
 
 	private void registerAndRefresh(Class<?>... annotatedClasses) {
@@ -442,6 +451,17 @@ class HazelcastHttpSessionConfigurationTests {
 		SessionRepositoryCustomizer<HazelcastIndexedSessionRepository> sessionRepositoryCustomizerTwo() {
 			return (sessionRepository) -> sessionRepository
 					.setDefaultMaxInactiveInterval(MAX_INACTIVE_INTERVAL_IN_SECONDS);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Import(HazelcastHttpSessionConfiguration.class)
+	static class ImportConfigAndCustomizeConfiguration extends BaseConfiguration {
+
+		@Bean
+		SessionRepositoryCustomizer<HazelcastIndexedSessionRepository> sessionRepositoryCustomizer() {
+			return (sessionRepository) -> sessionRepository.setDefaultMaxInactiveInterval(0);
 		}
 
 	}

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfiguration.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfiguration.java
@@ -243,6 +243,9 @@ public class JdbcHttpSessionConfiguration extends SpringHttpSessionConfiguration
 		Map<String, Object> attributeMap = importMetadata
 				.getAnnotationAttributes(EnableJdbcHttpSession.class.getName());
 		AnnotationAttributes attributes = AnnotationAttributes.fromMap(attributeMap);
+		if (attributes == null) {
+			return;
+		}
 		this.maxInactiveIntervalInSeconds = attributes.getNumber("maxInactiveIntervalInSeconds");
 		String tableNameValue = attributes.getString("tableName");
 		if (StringUtils.hasText(tableNameValue)) {


### PR DESCRIPTION
This commit adds tests that verify that all Spring Session configuration classes can be used with `@Import`, and fixes JDBC and Hazelcast `HttpSession` configurations and Redis `WebSession` configuration.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
