### PR TITLE
Fix SessionCreatedEvent handling in RedisIndexedSessionRepository

### DIFF
--- a/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryITests.java
+++ b/spring-session-data-redis/src/integration-test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryITests.java
@@ -111,10 +111,10 @@ class RedisIndexedSessionRepositoryITests extends AbstractRedisITests {
 		this.repository.save(toSave);
 
 		assertThat(this.registry.receivedEvent(toSave.getId())).isTrue();
-		assertThat(this.registry.<SessionCreatedEvent>getEvent(toSave.getId())).isInstanceOf(SessionCreatedEvent.class);
 		assertThat(this.redis.boundSetOps(usernameSessionKey).members()).contains(toSave.getId());
 
-		Session session = this.repository.findById(toSave.getId());
+		SessionCreatedEvent createdEvent = this.registry.getEvent(toSave.getId());
+		Session session = createdEvent.getSession();
 
 		assertThat(session.getId()).isEqualTo(toSave.getId());
 		assertThat(session.getAttributeNames()).isEqualTo(toSave.getAttributeNames());

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
@@ -466,11 +466,6 @@ public class RedisIndexedSessionRepository
 	@Override
 	public void save(RedisSession session) {
 		session.save();
-		if (session.isNew) {
-			String sessionCreatedKey = getSessionCreatedChannel(session.getId());
-			this.sessionRedisOperations.convertAndSend(sessionCreatedKey, session.delta);
-			session.isNew = false;
-		}
 	}
 
 	public void cleanUpExpiredSessions() {
@@ -511,33 +506,13 @@ public class RedisIndexedSessionRepository
 		if (entries.isEmpty()) {
 			return null;
 		}
-		MapSession loaded = loadSession(id, entries);
+		MapSession loaded = new RedisSessionMapper(id).apply(entries);
 		if (!allowExpired && loaded.isExpired()) {
 			return null;
 		}
 		RedisSession result = new RedisSession(loaded, false);
 		result.originalLastAccessTime = loaded.getLastAccessedTime();
 		return result;
-	}
-
-	private MapSession loadSession(String id, Map<String, Object> entries) {
-		MapSession loaded = new MapSession(id);
-		for (Map.Entry<String, Object> entry : entries.entrySet()) {
-			String key = entry.getKey();
-			if (RedisSessionMapper.CREATION_TIME_KEY.equals(key)) {
-				loaded.setCreationTime(Instant.ofEpochMilli((long) entry.getValue()));
-			}
-			else if (RedisSessionMapper.MAX_INACTIVE_INTERVAL_KEY.equals(key)) {
-				loaded.setMaxInactiveInterval(Duration.ofSeconds((int) entry.getValue()));
-			}
-			else if (RedisSessionMapper.LAST_ACCESSED_TIME_KEY.equals(key)) {
-				loaded.setLastAccessedTime(Instant.ofEpochMilli((long) entry.getValue()));
-			}
-			else if (key.startsWith(RedisSessionMapper.ATTRIBUTE_PREFIX)) {
-				loaded.setAttribute(key.substring(RedisSessionMapper.ATTRIBUTE_PREFIX.length()), entry.getValue());
-			}
-		}
-		return loaded;
 	}
 
 	@Override
@@ -574,9 +549,13 @@ public class RedisIndexedSessionRepository
 
 		if (ByteUtils.startsWith(messageChannel, this.sessionCreatedChannelPrefixBytes)) {
 			// TODO: is this thread safe?
+			String channel = new String(messageChannel);
+			String sessionId = channel.substring(channel.lastIndexOf(":") + 1);
 			@SuppressWarnings("unchecked")
-			Map<String, Object> loaded = (Map<String, Object>) this.defaultSerializer.deserialize(message.getBody());
-			handleCreated(loaded, new String(messageChannel));
+			Map<String, Object> entries = (Map<String, Object>) this.defaultSerializer.deserialize(message.getBody());
+			MapSession loaded = new RedisSessionMapper(sessionId).apply(entries);
+			RedisSession session = new RedisSession(loaded, false);
+			handleCreated(session);
 			return;
 		}
 
@@ -624,9 +603,7 @@ public class RedisIndexedSessionRepository
 		}
 	}
 
-	private void handleCreated(Map<String, Object> loaded, String channel) {
-		String id = channel.substring(channel.lastIndexOf(":") + 1);
-		Session session = loadSession(id, loaded);
+	private void handleCreated(RedisSession session) {
 		publishEvent(new SessionCreatedEvent(this, session));
 	}
 
@@ -880,9 +857,12 @@ public class RedisIndexedSessionRepository
 							.add(sessionId);
 				}
 			}
-
+			if (this.isNew) {
+				String sessionCreatedKey = getSessionCreatedChannel(getId());
+				RedisIndexedSessionRepository.this.sessionRedisOperations.convertAndSend(sessionCreatedKey, this.delta);
+				this.isNew = false;
+			}
 			this.delta = new HashMap<>(this.delta.size());
-
 			Long originalExpiration = (this.originalLastAccessTime != null)
 					? this.originalLastAccessTime.plus(getMaxInactiveInterval()).toEpochMilli() : null;
 			RedisIndexedSessionRepository.this.expirationPolicy.onExpirationUpdated(originalExpiration, this);

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
@@ -484,6 +484,9 @@ public class RedisIndexedSessionRepository
 		}
 		String principalKey = getPrincipalKey(indexValue);
 		Set<Object> sessionIds = this.sessionRedisOperations.boundSetOps(principalKey).members();
+		if (sessionIds == null) {
+			return Collections.emptyMap();
+		}
 		Map<String, RedisSession> sessions = new HashMap<>(sessionIds.size());
 		for (Object id : sessionIds) {
 			RedisSession session = findById((String) id);
@@ -503,7 +506,7 @@ public class RedisIndexedSessionRepository
 	 */
 	private RedisSession getSession(String id, boolean allowExpired) {
 		Map<String, Object> entries = getSessionBoundHashOperations(id).entries();
-		if (entries.isEmpty()) {
+		if ((entries == null) || entries.isEmpty()) {
 			return null;
 		}
 		MapSession loaded = new RedisSessionMapper(id).apply(entries);


### PR DESCRIPTION
While attempting to migrate `RedisIndexedSessionRepository` to `RedisSessionMapper` in order to reuse the session mapping logic, I ran into #1338. This problem has been somewhat hidden by the old mapping code being too lenient and accepting a map with no entries at all whereas `RedisSessionMapper` validates both map not being empty as well as presence of key session properties.

---

At present, `RedisIndexedSessionRepository` publishes a `SessionCreatedEvent` backed by an empty `MapSession` instance. This happens because session delta has been cleared before publishing a message to the session created channel.

Fixes gh-1338

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
