### PR TITLE
Upgrade Logback to 1.4.1

### DIFF
--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -13,7 +13,7 @@ dependencyManagement {
 	dependencies {
 		dependency 'com.hazelcast:hazelcast:5.1.3'
 		dependency 'org.aspectj:aspectjweaver:1.9.9.1'
-		dependency 'ch.qos.logback:logback-core:1.2.11'
+		dependency 'ch.qos.logback:logback-core:1.4.1'
 		dependency 'com.google.code.findbugs:jsr305:3.0.2'
 		dependency 'com.h2database:h2:2.1.214'
 		dependency 'com.ibm.db2:jcc:11.5.7.0'


### PR DESCRIPTION
This addresses the [CI build failures](https://github.com/spring-projects/spring-session/actions/workflows/continuous-integration-workflow.yml?query=branch%3Amain) that are caused by Spring Boot picking up SLF4J 2.0 and Logback 1.4.