### PR TITLE
Build against RC snapshots of core dependencies

### DIFF
--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -4,7 +4,7 @@ dependencyManagement {
 		mavenBom 'com.fasterxml.jackson:jackson-bom:2.13.4'
 		mavenBom 'org.junit:junit-bom:5.9.0'
 		mavenBom 'org.mockito:mockito-bom:4.8.0'
-		mavenBom 'org.springframework:spring-framework-bom:6.0.0-M6'
+		mavenBom 'org.springframework:spring-framework-bom:6.0.0-SNAPSHOT'
 		mavenBom 'org.springframework.data:spring-data-bom:2022.0.0-M6'
 		mavenBom 'org.springframework.security:spring-security-bom:6.0.0-M7'
 		mavenBom 'org.testcontainers:testcontainers-bom:1.17.3'

--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -1,6 +1,6 @@
 dependencyManagement {
 	imports {
-		mavenBom 'io.projectreactor:reactor-bom:2022.0.0-M6'
+		mavenBom 'io.projectreactor:reactor-bom:2022.0.0-SNAPSHOT'
 		mavenBom 'com.fasterxml.jackson:jackson-bom:2.13.4'
 		mavenBom 'org.junit:junit-bom:5.9.0'
 		mavenBom 'org.mockito:mockito-bom:4.8.0'

--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -6,7 +6,7 @@ dependencyManagement {
 		mavenBom 'org.mockito:mockito-bom:4.8.0'
 		mavenBom 'org.springframework:spring-framework-bom:6.0.0-SNAPSHOT'
 		mavenBom 'org.springframework.data:spring-data-bom:2022.0.0-SNAPSHOT'
-		mavenBom 'org.springframework.security:spring-security-bom:6.0.0-M7'
+		mavenBom 'org.springframework.security:spring-security-bom:6.0.0-SNAPSHOT'
 		mavenBom 'org.testcontainers:testcontainers-bom:1.17.3'
 	}
 

--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -5,7 +5,7 @@ dependencyManagement {
 		mavenBom 'org.junit:junit-bom:5.9.0'
 		mavenBom 'org.mockito:mockito-bom:4.8.0'
 		mavenBom 'org.springframework:spring-framework-bom:6.0.0-SNAPSHOT'
-		mavenBom 'org.springframework.data:spring-data-bom:2022.0.0-M6'
+		mavenBom 'org.springframework.data:spring-data-bom:2022.0.0-SNAPSHOT'
 		mavenBom 'org.springframework.security:spring-security-bom:6.0.0-M7'
 		mavenBom 'org.testcontainers:testcontainers-bom:1.17.3'
 	}

--- a/spring-session-core/src/test/java/org/springframework/session/aot/hint/server/WebSessionSecurityRuntimeHintsTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/aot/hint/server/WebSessionSecurityRuntimeHintsTests.java
@@ -54,7 +54,7 @@ class WebSessionSecurityRuntimeHintsTests {
 			classUtilsMock.when(() -> ClassUtils.isPresent(eq("org.springframework.web.server.WebSession"), any()))
 					.thenReturn(false);
 			this.webSessionSecurityRuntimeHints.registerHints(this.hints, getClass().getClassLoader());
-			assertThat(this.hints.serialization().javaSerialization()).isEmpty();
+			assertThat(this.hints.serialization().javaSerializationHints()).isEmpty();
 		}
 	}
 
@@ -66,7 +66,7 @@ class WebSessionSecurityRuntimeHintsTests {
 							.isPresent(eq("org.springframework.security.web.server.csrf.DefaultCsrfToken"), any()))
 					.thenReturn(false);
 			this.webSessionSecurityRuntimeHints.registerHints(this.hints, getClass().getClassLoader());
-			assertThat(this.hints.serialization().javaSerialization()).isEmpty();
+			assertThat(this.hints.serialization().javaSerializationHints()).isEmpty();
 		}
 	}
 

--- a/spring-session-core/src/test/java/org/springframework/session/aot/hint/servlet/HttpSessionSecurityRuntimeHintsTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/aot/hint/servlet/HttpSessionSecurityRuntimeHintsTests.java
@@ -65,7 +65,7 @@ class HttpSessionSecurityRuntimeHintsTests {
 			classUtilsMock.when(() -> ClassUtils.isPresent(eq("jakarta.servlet.http.HttpSession"), any()))
 					.thenReturn(false);
 			this.httpSessionSecurityRuntimeHints.registerHints(this.hints, getClass().getClassLoader());
-			assertThat(this.hints.serialization().javaSerialization()).isEmpty();
+			assertThat(this.hints.serialization().javaSerializationHints()).isEmpty();
 		}
 	}
 
@@ -76,7 +76,7 @@ class HttpSessionSecurityRuntimeHintsTests {
 					() -> ClassUtils.isPresent(eq("org.springframework.security.web.csrf.DefaultCsrfToken"), any()))
 					.thenReturn(false);
 			this.httpSessionSecurityRuntimeHints.registerHints(this.hints, getClass().getClassLoader());
-			assertThat(this.hints.serialization().javaSerialization()).isEmpty();
+			assertThat(this.hints.serialization().javaSerializationHints()).isEmpty();
 		}
 	}
 


### PR DESCRIPTION
This PR upgrades core dependencies to build against the following RC snapshots:
- Spring Framework 6.0.0-RC1 snapshots
- Spring Data 2022.0.0-RC1 snapshots
- Spring Security 6.0.0-RC1 snapshots
- Project Reactor 2022.0.0-RC1 snapshots