### PR TITLE
Fix max inactive interval setters backwards compatibility

### DIFF
--- a/spring-session-data-mongodb/src/main/java/org/springframework/session/data/mongo/MongoIndexedSessionRepository.java
+++ b/spring-session-data-mongodb/src/main/java/org/springframework/session/data/mongo/MongoIndexedSessionRepository.java
@@ -193,6 +193,19 @@ public class MongoIndexedSessionRepository
 		this.defaultMaxInactiveInterval = defaultMaxInactiveInterval;
 	}
 
+	/**
+	 * Set the maximum inactive interval in seconds between requests before newly created
+	 * sessions will be invalidated. A negative time indicates that the session will never
+	 * time out. The default is 1800 (30 minutes).
+	 * @param defaultMaxInactiveInterval the default maxInactiveInterval in seconds
+	 * @deprecated since 3.0.0, in favor of
+	 * {@link #setDefaultMaxInactiveInterval(Duration)}
+	 */
+	@Deprecated(since = "3.0.0")
+	public void setMaxInactiveIntervalInSeconds(Integer defaultMaxInactiveInterval) {
+		setDefaultMaxInactiveInterval(Duration.ofSeconds(defaultMaxInactiveInterval));
+	}
+
 	public void setCollectionName(final String collectionName) {
 		this.collectionName = collectionName;
 	}

--- a/spring-session-data-mongodb/src/main/java/org/springframework/session/data/mongo/ReactiveMongoSessionRepository.java
+++ b/spring-session-data-mongodb/src/main/java/org/springframework/session/data/mongo/ReactiveMongoSessionRepository.java
@@ -187,6 +187,19 @@ public class ReactiveMongoSessionRepository
 		this.defaultMaxInactiveInterval = defaultMaxInactiveInterval;
 	}
 
+	/**
+	 * Set the maximum inactive interval in seconds between requests before newly created
+	 * sessions will be invalidated. A negative time indicates that the session will never
+	 * time out. The default is 1800 (30 minutes).
+	 * @param defaultMaxInactiveInterval the default maxInactiveInterval in seconds
+	 * @deprecated since 3.0.0, in favor of
+	 * {@link #setDefaultMaxInactiveInterval(Duration)}
+	 */
+	@Deprecated(since = "3.0.0")
+	public void setMaxInactiveIntervalInSeconds(Integer defaultMaxInactiveInterval) {
+		setDefaultMaxInactiveInterval(Duration.ofSeconds(defaultMaxInactiveInterval));
+	}
+
 	public String getCollectionName() {
 		return this.collectionName;
 	}

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/ReactiveRedisSessionRepository.java
@@ -86,6 +86,19 @@ public class ReactiveRedisSessionRepository
 	}
 
 	/**
+	 * Set the maximum inactive interval in seconds between requests before newly created
+	 * sessions will be invalidated. A negative time indicates that the session will never
+	 * time out. The default is 1800 (30 minutes).
+	 * @param defaultMaxInactiveInterval the default maxInactiveInterval in seconds
+	 * @deprecated since 3.0.0, in favor of
+	 * {@link #setDefaultMaxInactiveInterval(Duration)}
+	 */
+	@Deprecated(since = "3.0.0")
+	public void setDefaultMaxInactiveInterval(int defaultMaxInactiveInterval) {
+		setDefaultMaxInactiveInterval(Duration.ofSeconds(defaultMaxInactiveInterval));
+	}
+
+	/**
 	 * Set the save mode.
 	 * @param saveMode the save mode
 	 */

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
@@ -380,6 +380,19 @@ public class RedisIndexedSessionRepository
 	}
 
 	/**
+	 * Set the maximum inactive interval in seconds between requests before newly created
+	 * sessions will be invalidated. A negative time indicates that the session will never
+	 * time out. The default is 1800 (30 minutes).
+	 * @param defaultMaxInactiveInterval the default maxInactiveInterval in seconds
+	 * @deprecated since 3.0.0, in favor of
+	 * {@link #setDefaultMaxInactiveInterval(Duration)}
+	 */
+	@Deprecated(since = "3.0.0")
+	public void setDefaultMaxInactiveInterval(int defaultMaxInactiveInterval) {
+		setDefaultMaxInactiveInterval(Duration.ofSeconds(defaultMaxInactiveInterval));
+	}
+
+	/**
 	 * Set the {@link IndexResolver} to use.
 	 * @param indexResolver the index resolver
 	 */

--- a/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/HazelcastIndexedSessionRepository.java
+++ b/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/HazelcastIndexedSessionRepository.java
@@ -195,6 +195,19 @@ public class HazelcastIndexedSessionRepository
 	}
 
 	/**
+	 * Set the maximum inactive interval in seconds between requests before newly created
+	 * sessions will be invalidated. A negative time indicates that the session will never
+	 * time out. The default is 1800 (30 minutes).
+	 * @param defaultMaxInactiveInterval the default maxInactiveInterval in seconds
+	 * @deprecated since 3.0.0, in favor of
+	 * {@link #setDefaultMaxInactiveInterval(Duration)}
+	 */
+	@Deprecated(since = "3.0.0")
+	public void setDefaultMaxInactiveInterval(Integer defaultMaxInactiveInterval) {
+		setDefaultMaxInactiveInterval(Duration.ofSeconds(defaultMaxInactiveInterval));
+	}
+
+	/**
 	 * Set the {@link IndexResolver} to use.
 	 * @param indexResolver the index resolver
 	 */

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcIndexedSessionRepository.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcIndexedSessionRepository.java
@@ -391,6 +391,19 @@ public class JdbcIndexedSessionRepository implements
 	}
 
 	/**
+	 * Set the maximum inactive interval in seconds between requests before newly created
+	 * sessions will be invalidated. A negative time indicates that the session will never
+	 * time out. The default is 1800 (30 minutes).
+	 * @param defaultMaxInactiveInterval the default maxInactiveInterval in seconds
+	 * @deprecated since 3.0.0, in favor of
+	 * {@link #setDefaultMaxInactiveInterval(Duration)}
+	 */
+	@Deprecated(since = "3.0.0")
+	public void setDefaultMaxInactiveInterval(Integer defaultMaxInactiveInterval) {
+		setDefaultMaxInactiveInterval(Duration.ofSeconds(defaultMaxInactiveInterval));
+	}
+
+	/**
 	 * Set the {@link IndexResolver} to use.
 	 * @param indexResolver the index resolver
 	 */


### PR DESCRIPTION
This commit restores integer based max inactive interval setters across all session repositories, that were migrated to `java.time` in 6d74cf5f.

This change caused problems building our Spring Boot based samples, as Spring Boot auto-configuration has move to session repository customizer based approach and is therefore using max inactive interval setters directly on session repository implementations.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
