### PR TITLE
Avoid inheritance in configuration classes

### DIFF
--- a/spring-session-data-mongodb/src/main/java/org/springframework/session/data/mongo/config/annotation/web/http/MongoHttpSessionConfiguration.java
+++ b/spring-session-data-mongodb/src/main/java/org/springframework/session/data/mongo/config/annotation/web/http/MongoHttpSessionConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportAware;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.serializer.support.DeserializingConverter;
@@ -52,8 +53,8 @@ import org.springframework.util.StringValueResolver;
  * @since 1.2
  */
 @Configuration(proxyBeanMethods = false)
-public class MongoHttpSessionConfiguration extends SpringHttpSessionConfiguration
-		implements BeanClassLoaderAware, EmbeddedValueResolverAware, ImportAware {
+@Import(SpringHttpSessionConfiguration.class)
+public class MongoHttpSessionConfiguration implements BeanClassLoaderAware, EmbeddedValueResolverAware, ImportAware {
 
 	private AbstractMongoSessionConverter mongoSessionConverter;
 

--- a/spring-session-data-mongodb/src/main/java/org/springframework/session/data/mongo/config/annotation/web/reactive/ReactiveMongoWebSessionConfiguration.java
+++ b/spring-session-data-mongodb/src/main/java/org/springframework/session/data/mongo/config/annotation/web/reactive/ReactiveMongoWebSessionConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportAware;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.serializer.support.DeserializingConverter;
@@ -49,10 +50,11 @@ import org.springframework.util.StringValueResolver;
  * {@link ReactiveMongoOperations}.
  *
  * @author Greg Turnquist
- * @author Vedran Pavić
+ * @author Vedran Pavic
  */
 @Configuration(proxyBeanMethods = false)
-public class ReactiveMongoWebSessionConfiguration extends SpringWebSessionConfiguration
+@Import(SpringWebSessionConfiguration.class)
+public class ReactiveMongoWebSessionConfiguration
 		implements BeanClassLoaderAware, EmbeddedValueResolverAware, ImportAware {
 
 	private AbstractMongoSessionConverter mongoSessionConverter;

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/AbstractRedisHttpSessionConfiguration.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/http/AbstractRedisHttpSessionConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.RedisSerializer;
@@ -51,8 +52,9 @@ import org.springframework.util.Assert;
  * @see SpringSessionRedisConnectionFactory
  */
 @Configuration(proxyBeanMethods = false)
+@Import(SpringHttpSessionConfiguration.class)
 public abstract class AbstractRedisHttpSessionConfiguration<T extends SessionRepository<? extends Session>>
-		extends SpringHttpSessionConfiguration implements BeanClassLoaderAware {
+		implements BeanClassLoaderAware {
 
 	private Duration maxInactiveInterval = MapSession.DEFAULT_MAX_INACTIVE_INTERVAL;
 

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/server/RedisWebSessionConfiguration.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/config/annotation/web/server/RedisWebSessionConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportAware;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
@@ -57,8 +58,8 @@ import org.springframework.web.server.session.WebSessionManager;
  * @see EnableRedisWebSession
  */
 @Configuration(proxyBeanMethods = false)
-public class RedisWebSessionConfiguration extends SpringWebSessionConfiguration
-		implements BeanClassLoaderAware, EmbeddedValueResolverAware, ImportAware {
+@Import(SpringWebSessionConfiguration.class)
+public class RedisWebSessionConfiguration implements BeanClassLoaderAware, EmbeddedValueResolverAware, ImportAware {
 
 	private Duration maxInactiveInterval = MapSession.DEFAULT_MAX_INACTIVE_INTERVAL;
 

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/server/RedisWebSessionConfigurationTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/config/annotation/web/server/RedisWebSessionConfigurationTests.java
@@ -191,7 +191,7 @@ class RedisWebSessionConfigurationTests {
 	void multipleConnectionFactoryRedisConfig() {
 		assertThatExceptionOfType(BeanCreationException.class)
 				.isThrownBy(() -> registerAndRefresh(RedisConfig.class, MultipleConnectionFactoryRedisConfig.class))
-				.withCauseInstanceOf(NoUniqueBeanDefinitionException.class).havingCause()
+				.havingRootCause().isInstanceOf(NoUniqueBeanDefinitionException.class)
 				.withMessageContaining("expected single matching bean but found 2");
 	}
 

--- a/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfiguration.java
+++ b/spring-session-hazelcast/src/main/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportAware;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
@@ -55,7 +56,8 @@ import org.springframework.util.StringUtils;
  * @see EnableHazelcastHttpSession
  */
 @Configuration(proxyBeanMethods = false)
-public class HazelcastHttpSessionConfiguration extends SpringHttpSessionConfiguration implements ImportAware {
+@Import(SpringHttpSessionConfiguration.class)
+public class HazelcastHttpSessionConfiguration implements ImportAware {
 
 	private Duration maxInactiveInterval = MapSession.DEFAULT_MAX_INACTIVE_INTERVAL;
 

--- a/spring-session-hazelcast/src/test/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfigurationTests.java
+++ b/spring-session-hazelcast/src/test/java/org/springframework/session/hazelcast/config/annotation/web/http/HazelcastHttpSessionConfigurationTests.java
@@ -71,9 +71,8 @@ class HazelcastHttpSessionConfigurationTests {
 	@Test
 	void noHazelcastInstanceConfiguration() {
 		assertThatExceptionOfType(BeanCreationException.class)
-				.isThrownBy(() -> registerAndRefresh(NoHazelcastInstanceConfiguration.class))
-				.withCauseInstanceOf(NoSuchBeanDefinitionException.class).havingCause()
-				.withMessageContaining("HazelcastInstance");
+				.isThrownBy(() -> registerAndRefresh(NoHazelcastInstanceConfiguration.class)).havingRootCause()
+				.isInstanceOf(NoSuchBeanDefinitionException.class).withMessageContaining("HazelcastInstance");
 	}
 
 	@Test
@@ -206,8 +205,8 @@ class HazelcastHttpSessionConfigurationTests {
 	@Test
 	void multipleHazelcastInstanceConfiguration() {
 		assertThatExceptionOfType(BeanCreationException.class)
-				.isThrownBy(() -> registerAndRefresh(MultipleHazelcastInstanceConfiguration.class))
-				.withCauseInstanceOf(NoUniqueBeanDefinitionException.class).havingCause()
+				.isThrownBy(() -> registerAndRefresh(MultipleHazelcastInstanceConfiguration.class)).havingRootCause()
+				.isInstanceOf(NoUniqueBeanDefinitionException.class)
 				.withMessageContaining("expected single matching bean but found 2");
 	}
 

--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfiguration.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/config/annotation/web/http/JdbcHttpSessionConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.EmbeddedValueResolverAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportAware;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.convert.ConversionService;
@@ -75,8 +76,8 @@ import org.springframework.util.StringValueResolver;
  * @see EnableJdbcHttpSession
  */
 @Configuration(proxyBeanMethods = false)
-public class JdbcHttpSessionConfiguration extends SpringHttpSessionConfiguration
-		implements BeanClassLoaderAware, EmbeddedValueResolverAware, ImportAware {
+@Import(SpringHttpSessionConfiguration.class)
+public class JdbcHttpSessionConfiguration implements BeanClassLoaderAware, EmbeddedValueResolverAware, ImportAware {
 
 	private Duration maxInactiveInterval = MapSession.DEFAULT_MAX_INACTIVE_INTERVAL;
 


### PR DESCRIPTION
This PR restructures configuration classes to avoid inheritance, where possible. This should provide more flexibility when composing custom configurations.

Closes #1415