### PR TITLE
Update reference site link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -63,7 +63,7 @@ Compile and test; build all jars, distribution zips, and docs
 
 You can find the documentation, samples, and guides for using Spring Session on the https://projects.spring.io/spring-session/[Spring Session project site].
 
-For more in depth information, visit the https://docs.spring.io/spring-session/docs/current/reference/html5/[Spring Session Reference].
+For more in depth information, visit the https://docs.spring.io/spring-session/reference/[Spring Session Reference].
 
 == Code of Conduct
 


### PR DESCRIPTION
https://docs.spring.io/spring-session/docs/current/reference/html5/ goes to a 404 page

Use https://docs.spring.io/spring-session/reference/ instead which is the current documentation site.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
