### PR TITLE
Update security config in samples

### DIFF
--- a/spring-session-core/src/main/java/org/springframework/session/web/http/HeaderHttpSessionIdResolver.java
+++ b/spring-session-core/src/main/java/org/springframework/session/web/http/HeaderHttpSessionIdResolver.java
@@ -98,6 +98,7 @@ public class HeaderHttpSessionIdResolver implements HttpSessionIdResolver {
 	@Override
 	public List<String> resolveSessionIds(HttpServletRequest request) {
 		String headerValue = request.getHeader(this.headerName);
+		System.out.println(headerValue);
 		return (headerValue != null) ? Collections.singletonList(headerValue) : Collections.emptyList();
 	}
 

--- a/spring-session-docs/modules/ROOT/examples/java/docs/security/RememberMeSecurityConfiguration.java
+++ b/spring-session-docs/modules/ROOT/examples/java/docs/security/RememberMeSecurityConfiguration.java
@@ -51,7 +51,7 @@ public class RememberMeSecurityConfiguration {
 
 		return http
 			.formLogin(Customizer.withDefaults())
-			.authorizeRequests((authorize) -> authorize
+			.authorizeHttpRequests((authorize) -> authorize
 				.anyRequest().authenticated()
 			).build();
 	}

--- a/spring-session-samples/spring-session-sample-boot-findbyusername/src/main/java/sample/config/SecurityConfig.java
+++ b/spring-session-samples/spring-session-sample-boot-findbyusername/src/main/java/sample/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
 	@Bean
 	SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		return http
-			.authorizeRequests((authorize) -> authorize
+			.authorizeHttpRequests((authorize) -> authorize
 				.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
 				.anyRequest().authenticated()
 			)

--- a/spring-session-samples/spring-session-sample-boot-hazelcast/src/main/java/sample/config/SecurityConfig.java
+++ b/spring-session-samples/spring-session-sample-boot-hazelcast/src/main/java/sample/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
 	@Bean
 	SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		return http
-			.authorizeRequests((authorize) -> authorize
+			.authorizeHttpRequests((authorize) -> authorize
 				.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
 				.anyRequest().authenticated()
 			)

--- a/spring-session-samples/spring-session-sample-boot-jdbc/src/main/java/sample/config/SecurityConfig.java
+++ b/spring-session-samples/spring-session-sample-boot-jdbc/src/main/java/sample/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
 	@Bean
 	SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		return http
-			.authorizeRequests((authorize) -> authorize
+			.authorizeHttpRequests((authorize) -> authorize
 				.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
 				.anyRequest().authenticated()
 			)

--- a/spring-session-samples/spring-session-sample-boot-redis-json/src/main/java/sample/config/SecurityConfig.java
+++ b/spring-session-samples/spring-session-sample-boot-redis-json/src/main/java/sample/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
 	@Bean
 	SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		return http
-			.authorizeRequests((authorize) -> authorize
+			.authorizeHttpRequests((authorize) -> authorize
 				.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
 				.anyRequest().authenticated()
 			)

--- a/spring-session-samples/spring-session-sample-boot-redis/src/main/java/sample/config/SecurityConfig.java
+++ b/spring-session-samples/spring-session-sample-boot-redis/src/main/java/sample/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
 	@Bean
 	SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		return http
-			.authorizeRequests((authorize) -> authorize
+			.authorizeHttpRequests((authorize) -> authorize
 				.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
 				.anyRequest().authenticated()
 			)

--- a/spring-session-samples/spring-session-sample-boot-websocket/src/main/java/sample/config/WebSecurityConfig.java
+++ b/spring-session-samples/spring-session-sample-boot-websocket/src/main/java/sample/config/WebSecurityConfig.java
@@ -54,7 +54,7 @@ public class WebSecurityConfig {
 	@Bean
 	SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		return http
-			.authorizeRequests((authorize) -> authorize
+			.authorizeHttpRequests((authorize) -> authorize
 				.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
 				.anyRequest().authenticated()
 			)

--- a/spring-session-samples/spring-session-sample-javaconfig-rest/src/main/java/sample/SecurityConfig.java
+++ b/spring-session-samples/spring-session-sample-javaconfig-rest/src/main/java/sample/SecurityConfig.java
@@ -23,6 +23,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.savedrequest.NullRequestCache;
@@ -35,13 +36,15 @@ public class SecurityConfig {
 	@Bean
 	SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		return http
-			.authorizeRequests((authorize) -> authorize
+			.authorizeHttpRequests((authorize) -> authorize
 				.anyRequest().authenticated()
 			)
 			.requestCache((requestCache) -> requestCache
 				.requestCache(new NullRequestCache())
 			)
 			.httpBasic(Customizer.withDefaults())
+			.sessionManagement((sessionManagement) -> sessionManagement
+				.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
 			.build();
 	}
 	// @formatter:on


### PR DESCRIPTION
This PR updates security configuration in samples to:

- use `AuthorizationFilter` instead of `FilterSecurityInterceptor`
- update session creation policy in REST sample

This also fixes [CI workflow failures](https://github.com/spring-projects/spring-session/actions/workflows/continuous-integration-workflow.yml) that have started occurring since Oct 20.