### PR TITLE
ci: fix GitHub Actions Deprecating save-state and set-output commands

### DIFF
--- a/.github/workflows/algolia-index.yml
+++ b/.github/workflows/algolia-index.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Update Index
         run: ${GITHUB_WORKSPACE}/.github/actions/algolia-docsearch-scraper.sh "${{ secrets.ALGOLIA_APPLICATION_ID }}" "${{ secrets.ALGOLIA_WRITE_API_KEY }}" "${GITHUB_WORKSPACE}/.github/actions/algolia-config.json"

--- a/.github/workflows/antora-generate.yml
+++ b/.github/workflows/antora-generate.yml
@@ -24,7 +24,7 @@ jobs:
         run: ./gradlew :spring-session-docs:generateAntora
       - name: Extract Branch Name
         id: extract_branch_name
-        run: echo "##[set-output name=generated_branch_name;]$(echo ${GITHUB_REPOSITORY}/${GITHUB_REF##*/})"
+        run: echo "generated_branch_name=${GITHUB_REPOSITORY}/${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
       - name: Push generated antora files to the spring-generated-docs
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:

--- a/.github/workflows/antora-generate.yml
+++ b/.github/workflows/antora-generate.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -23,17 +23,18 @@ jobs:
         jdk: [17]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.jdk }}
+          distribution: 'adopt'
       - name: Setup gradle user name
         run: |
           mkdir -p ~/.gradle
           echo 'systemProp.user.name=spring-builds+github' >> ~/.gradle/gradle.properties
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
@@ -49,11 +50,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'spring-projects/spring-session'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
+          distribution: 'adopt'
       - name: Setup gradle user name
         run: |
           mkdir -p ~/.gradle
@@ -77,11 +79,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'spring-projects/spring-session'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
+          distribution: 'adopt'
       - name: Setup gradle user name
         run: |
           mkdir -p ~/.gradle

--- a/.github/workflows/deploy-reference.yml
+++ b/.github/workflows/deploy-reference.yml
@@ -12,9 +12,9 @@ jobs:
     name: deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -6,5 +6,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/pr-build-workflow.yml
+++ b/.github/workflows/pr-build-workflow.yml
@@ -12,13 +12,14 @@ jobs:
         jdk: [17]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.jdk }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.jdk }}
+          distribution: 'adopt'
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->
The save-state, set-output command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
