### PR TITLE
Update Redis example documentation

### DIFF
--- a/spring-session-docs/modules/ROOT/pages/guides/boot-redis.adoc
+++ b/spring-session-docs/modules/ROOT/pages/guides/boot-redis.adoc
@@ -75,9 +75,9 @@ For example, you can include the following in your application.properties:
 ====
 .src/main/resources/application.properties
 ----
-spring.redis.host=localhost # Redis server host.
-spring.redis.password= # Login password of the redis server.
-spring.redis.port=6379 # Redis server port.
+spring.data.redis.host=localhost # Redis server host.
+spring.data.redis.password= # Login password of the redis server.
+spring.data.redis.port=6379 # Redis server port.
 ----
 ====
 


### PR DESCRIPTION
With the release of Spring-Boot 3.x, the application properties for Redis changed from `spring.redis` to `spring.data.redis`. This change will update the documentation to be consistent with the latest changes in Spring-Boot.

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#redis-properties
