### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/antora-generate.yml
+++ b/.github/workflows/antora-generate.yml
@@ -24,7 +24,7 @@ jobs:
         run: ./gradlew :spring-session-docs:generateAntora
       - name: Extract Branch Name
         id: extract_branch_name
-        run: echo "##[set-output name=generated_branch_name;]$(echo ${GITHUB_REPOSITORY}/${GITHUB_REF##*/})"
+        run: echo "generated_branch_name=$(echo ${GITHUB_REPOSITORY}/${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
       - name: Push generated antora files to the spring-generated-docs
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Resolve  #2231 

Update `antora-generate.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find .github/workflows -name '*.yml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: echo "##[set-output name=generated_branch_name;]$(echo ${GITHUB_REPOSITORY}/${GITHUB_REF##*/})"
```

**TO-BE**

```yml
run: echo "generated_branch_name=$(echo ${GITHUB_REPOSITORY}/${GITHUB_REF##*/})" >> $GITHUB_OUTPUT
```
