### PR TITLE
Add Revved up by Develocity badge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,6 +4,8 @@ image:https://badges.gitter.im/spring-projects/spring-session.svg[link="https://
 
 image:https://github.com/spring-projects/spring-session/workflows/CI/badge.svg?branch=main["Build Status", link="https://github.com/spring-projects/spring-session/actions?query=workflow%3ACI"]
 
+image:https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A["Revved up by Develocity", link="https://ge.spring.io/scans?search.rootProjectNames=spring-session-build"]
+
 Spring Session provides an API and implementations for managing a user's session information, while also making it trivial to support clustered sessions without being tied to an application container specific solution.
 It also provides transparent integration with:
 


### PR DESCRIPTION
This pull request adds a badge to the project to indicate that it uses the Develocity instance hosted at https://ge.spring.io/.

Other Spring projects, such as [Spring Boot](https://github.com/spring-projects/spring-boot?tab=readme-ov-file#spring-boot---) and [Spring Framework](https://github.com/spring-projects/spring-framework?tab=readme-ov-file#-spring-framework--), already have the badge present in their README. 