### PR TITLE
Remove expired session from principal index

### DIFF
--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
@@ -518,13 +518,17 @@ public class RedisIndexedSessionRepository
 			long prevMin = roundDownMinute(System.currentTimeMillis());
 			String expirationsPrefix = this.namespace + "expirations:";
 
-			List<String> expirationKeys = this.sessionRedisOperations.keys(expirationsPrefix + "*").stream()
+			List<String> expirationKeys = this.sessionRedisOperations.keys(expirationsPrefix + "*")
+				.stream()
 				.filter(expirationKey -> Long.parseLong(expirationKey.substring(expirationsPrefix.length())) < prevMin)
 				.toList();
 
 			orphanedSessionIds.stream()
-				.filter(orphanedSessionId -> expirationKeys.stream().noneMatch(expirationKey -> this.sessionRedisOperations.boundSetOps(expirationKey).isMember(orphanedSessionId)))
-				.forEach(orphanedSessionId -> this.sessionRedisOperations.boundSetOps(principalKey).remove(orphanedSessionId));
+				.filter(orphanedSessionId -> expirationKeys.stream()
+					.noneMatch(expirationKey -> this.sessionRedisOperations.boundSetOps(expirationKey)
+						.isMember(orphanedSessionId)))
+				.forEach(orphanedSessionId -> this.sessionRedisOperations.boundSetOps(principalKey)
+					.remove(orphanedSessionId));
 		}
 
 		return sessions;

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryTests.java
@@ -424,7 +424,8 @@ class RedisIndexedSessionRepositoryTests {
 				RedisSessionMapper.MAX_INACTIVE_INTERVAL_KEY, 1, RedisSessionMapper.LAST_ACCESSED_TIME_KEY,
 				Instant.now().minus(5, ChronoUnit.MINUTES).toEpochMilli());
 		given(this.boundHashOperations.entries()).willReturn(map);
-		given(this.redisOperations.keys("spring:session:expirations:*")).willReturn(Set.of("spring:session:expirations:1616594540000"));
+		given(this.redisOperations.keys("spring:session:expirations:*"))
+			.willReturn(Set.of("spring:session:expirations:1616594540000"));
 
 		this.redisRepository.findByIndexNameAndIndexValue(FindByIndexNameSessionRepository.PRINCIPAL_NAME_INDEX_NAME,
 				"principal");


### PR DESCRIPTION
Despite RedisIndexedSessionRepository's efforts to automatically remove expired sessions from its principal index, it is possible for expired sessions to remain in that index due to misses from at least these causes:
- application failure due to no event redelivery (see https://docs.spring.io/spring-data/redis/reference/redis/redis-repositories/expirations.html)
  > Redis Pub/Sub messages are not persistent. If a key expires while the application is down, the expiry event is not processed, which may lead to secondary indexes containing references to the expired object.
- application only gets events from one redis node in a cluster (see https://github.com/spring-projects/spring-data-redis/issues/1111)

The findByIndexNameAndIndexValue method in RedisIndexedSessionRepository reads every session in the principal index including the expired ones, only returning the live ones. As expired sessions stack up, it slows down the findByIndexNameAndIndexValue method. Even though RedisIndexedSessionRepository encounters expired sessions, it doesn't take the opportunity to delete them from the principal index. The effect is that expired sessions are read over and over, never getting cleaned up. This was observed negatively affecting Spring Authorization Server's token endpoint due to its reliance on findByIndexNameAndIndexValue via SessionRegistry's getAllSessions method (see https://github.com/spring-projects/spring-authorization-server/blob/29a8321ab2d65f2f479311c28dd72b3809353722/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeAuthenticationProvider.java#L323).

 This commit improves RedisIndexedSessionRepository to delete the expired session from the principal index when findByIndexNameAndIndexValue sees that a session is expired. This mitigates the impact of expired sessions in that they will only be read once by findByIndexNameAndIndexValue before being removed out of the index.

 Mitigates #2230.