### PR TITLE
Doc cautions about index repo with Redis Cluster

### DIFF
--- a/spring-session-docs/modules/ROOT/pages/configuration/redis.adoc
+++ b/spring-session-docs/modules/ROOT/pages/configuration/redis.adoc
@@ -122,6 +122,9 @@ For example, it may create indexes based on session attributes like user ID or l
 These indexes allow for efficient querying of sessions based on specific criteria, enhancing performance and enabling advanced session management features.
 In addition to that, `RedisIndexedSessionRepository` also supports session expiration and deletion.
 
+CAUTION: Using `RedisIndexedSessionRepository` with Redis Cluster is discouraged due to https://github.com/spring-projects/spring-data-redis/issues/1111[only being subscribed to events from one random redis node in the cluster],
+causing a memory leak in the index and a slowdown in calls to `findByPrincipalName`. Using `RedisIndexedSessionRepository` in tandem with a redis that does not have multiple shards avoids this problem.
+
 === Configuring the `RedisSessionRepository`
 
 ==== Using Spring Boot Properties


### PR DESCRIPTION
Due to https://github.com/spring-projects/spring-data-redis/issues/1111, applications can suffer from missing important Keyspace events as described at https://github.com/spring-projects/spring-session/issues/2230.

This adds a caution to the docs to help others avoid running into this problem and suggests an alternative.

Mitigates #2230.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
