### PR TITLE
#3097 Hook for extending session cookie on access

### DIFF
--- a/spring-session-core/src/main/java/org/springframework/session/web/http/HttpSessionIdResolver.java
+++ b/spring-session-core/src/main/java/org/springframework/session/web/http/HttpSessionIdResolver.java
@@ -52,6 +52,17 @@ public interface HttpSessionIdResolver {
 	void setSessionId(HttpServletRequest request, HttpServletResponse response, String sessionId);
 
 	/**
+	 * Instruct the client to extend the current session. This method is invoked when an
+	 * existing session is used and can inform a client about the validity of the session.
+	 * For example, it might update the expiration date of a cookie with the session id.
+	 * @param request the current request
+	 * @param response the current response
+	 * @param sessionId the session id
+	 */
+	default void extendSession(HttpServletRequest request, HttpServletResponse response, String sessionId) {
+	}
+
+	/**
 	 * Instruct the client to end the current session. This method is invoked when a
 	 * session is invalidated and should inform a client that the session id is no longer
 	 * valid. For example, it might remove a cookie with the session id in it or set an

--- a/spring-session-core/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
+++ b/spring-session-core/src/main/java/org/springframework/session/web/http/SessionRepositoryFilter.java
@@ -231,6 +231,9 @@ public class SessionRepositoryFilter<S extends Session> extends OncePerRequestFi
 				if (!isRequestedSessionIdValid() || !sessionId.equals(requestedSessionId)) {
 					SessionRepositoryFilter.this.httpSessionIdResolver.setSessionId(this, this.response, sessionId);
 				}
+				else {
+					SessionRepositoryFilter.this.httpSessionIdResolver.extendSession(this, this.response, sessionId);
+				}
 			}
 		}
 

--- a/spring-session-core/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
@@ -1048,6 +1048,29 @@ class SessionRepositoryFilterTests {
 	}
 
 	@Test
+	void doFilterAdapterOnExistingSession() throws Exception {
+		MapSession session = this.sessionRepository.createSession();
+		this.sessionRepository.save(session);
+		SessionRepository<MapSession> sessionRepository = spy(this.sessionRepository);
+		setSessionCookie(session.getId());
+		given(this.strategy.resolveSessionIds(any(HttpServletRequest.class)))
+			.willReturn(Arrays.asList(session.getId()));
+
+		this.filter = new SessionRepositoryFilter<>(sessionRepository);
+		this.filter.setHttpSessionIdResolver(this.strategy);
+
+		doFilter(new DoInFilter() {
+			@Override
+			public void doFilter(HttpServletRequest wrappedRequest, HttpServletResponse wrappedResponse) {
+				wrappedRequest.getSession();
+			}
+		});
+
+		verify(this.strategy).extendSession(any(HttpServletRequest.class), any(HttpServletResponse.class),
+				eq(session.getId()));
+	}
+
+	@Test
 	void doFilterAdapterOnInvalidate() throws Exception {
 		this.filter.setHttpSessionIdResolver(this.strategy);
 


### PR DESCRIPTION
This PR adds an additional hook to `HttpSessionIdResolver` that is called whenever an existing session is accessed. This would make it possible to store the session ID in a persistent cookie with an expiration date that is extended every time the session is accessed.

See https://github.com/spring-projects/spring-session/issues/3097.