### PR TITLE
Only start a new transaction if there's a delta for session updates w…

### DIFF
--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcIndexedSessionRepository.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcIndexedSessionRepository.java
@@ -907,7 +907,7 @@ public class JdbcIndexedSessionRepository implements
 				});
 			}
 			else {
-				List<Runnable> deltaActions = new ArrayList<>();
+				List<Runnable> deltaActions = JdbcSession.this.changed ? new ArrayList<>(4) : new ArrayList<>();
 				if (JdbcSession.this.changed) {
 					deltaActions.add(() -> {
 						Map<String, String> indexes = JdbcIndexedSessionRepository.this.indexResolver


### PR DESCRIPTION
…ith JDBC based repository

Avoids eagerly acquiring a connection or any other eager initialization that may happen alongside a transaction starting if there's no actual update to be made.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

Solves #3329 
