### PR TITLE
Add Common Java and Spring Security Serialization AOT Hints

### DIFF
--- a/spring-session-core/src/main/java/org/springframework/session/aot/hint/CommonSessionRuntimeHints.java
+++ b/spring-session-core/src/main/java/org/springframework/session/aot/hint/CommonSessionRuntimeHints.java
@@ -16,13 +16,21 @@
 
 package org.springframework.session.aot.hint;
 
+import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.TreeSet;
 
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.aot.hint.TypeReference;
+import org.springframework.session.MapSession;
 
 /**
  * A {@link RuntimeHintsRegistrar} for common session hints.
@@ -33,16 +41,19 @@ class CommonSessionRuntimeHints implements RuntimeHintsRegistrar {
 
 	@Override
 	public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
-		Arrays
-			.asList(TypeReference.of(String.class), TypeReference.of(ArrayList.class), TypeReference.of(TreeSet.class),
-					TypeReference.of(Number.class), TypeReference.of(Long.class), TypeReference.of(Integer.class),
-					TypeReference.of(StackTraceElement.class), TypeReference.of(Throwable.class),
-					TypeReference.of(Exception.class), TypeReference.of(RuntimeException.class),
-					TypeReference.of("java.util.Collections$UnmodifiableCollection"),
-					TypeReference.of("java.util.Collections$UnmodifiableList"),
-					TypeReference.of("java.util.Collections$EmptyList"),
-					TypeReference.of("java.util.Collections$UnmodifiableRandomAccessList"),
-					TypeReference.of("java.util.Collections$UnmodifiableSet"))
+		Arrays.asList(TypeReference.of(String.class), TypeReference.of(Number.class), TypeReference.of(Long.class),
+				TypeReference.of(Integer.class), TypeReference.of(URL.class), TypeReference.of(Instant.class),
+				TypeReference.of(Duration.class), TypeReference.of("java.time.Ser"),
+				TypeReference.of(StackTraceElement.class), TypeReference.of(Throwable.class),
+				TypeReference.of(Exception.class), TypeReference.of(RuntimeException.class),
+				TypeReference.of(ArrayList.class), TypeReference.of(TreeSet.class), TypeReference.of(HashMap.class),
+				TypeReference.of(LinkedHashMap.class), TypeReference.of(HashSet.class),
+				TypeReference.of(LinkedHashSet.class), TypeReference.of("java.util.Collections$UnmodifiableCollection"),
+				TypeReference.of("java.util.Collections$UnmodifiableList"),
+				TypeReference.of("java.util.Collections$EmptyList"),
+				TypeReference.of("java.util.Collections$UnmodifiableRandomAccessList"),
+				TypeReference.of("java.util.Collections$UnmodifiableSet"),
+				TypeReference.of("java.util.Collections$UnmodifiableMap"), TypeReference.of(MapSession.class))
 			.forEach(hints.serialization()::registerType);
 	}
 

--- a/spring-session-core/src/main/java/org/springframework/session/aot/hint/CommonSessionRuntimeHints.java
+++ b/spring-session-core/src/main/java/org/springframework/session/aot/hint/CommonSessionRuntimeHints.java
@@ -54,7 +54,7 @@ class CommonSessionRuntimeHints implements RuntimeHintsRegistrar {
 				TypeReference.of("java.util.Collections$UnmodifiableRandomAccessList"),
 				TypeReference.of("java.util.Collections$UnmodifiableSet"),
 				TypeReference.of("java.util.Collections$UnmodifiableMap"), TypeReference.of(MapSession.class))
-			.forEach(hints.serialization()::registerType);
+			.forEach(hints.reflection()::registerType);
 	}
 
 }

--- a/spring-session-core/src/main/java/org/springframework/session/aot/hint/CommonSessionSecurityRuntimeHints.java
+++ b/spring-session-core/src/main/java/org/springframework/session/aot/hint/CommonSessionSecurityRuntimeHints.java
@@ -74,13 +74,35 @@ class CommonSessionSecurityRuntimeHints implements RuntimeHintsRegistrar {
 	}
 
 	private void registerOAuth2ClientHintsIfNeeded(RuntimeHints hints) {
-		Arrays.asList(
+		Arrays.asList(TypeReference.of("org.springframework.security.oauth2.core.AbstractOAuth2Token"),
+				TypeReference.of("org.springframework.security.oauth2.core.OAuth2AccessToken"),
+				TypeReference.of("org.springframework.security.oauth2.core.OAuth2AccessToken$TokenType"),
+				TypeReference.of("org.springframework.security.oauth2.core.AuthenticationMethod"),
+				TypeReference.of("org.springframework.security.oauth2.core.ClientAuthenticationMethod"),
+				TypeReference.of("org.springframework.security.oauth2.core.AuthorizationGrantType"),
+				TypeReference.of("org.springframework.security.oauth2.core.OAuth2RefreshToken"),
+				TypeReference.of("org.springframework.security.oauth2.core.OAuth2AuthenticationException"),
+				TypeReference.of("org.springframework.security.oauth2.core.user.OAuth2UserAuthority"),
+				TypeReference.of("org.springframework.security.oauth2.core.user.DefaultOAuth2User"),
+				TypeReference.of("org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority"),
+				TypeReference.of("org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser"),
+				TypeReference.of("org.springframework.security.oauth2.core.oidc.OidcIdToken"),
+				TypeReference.of("org.springframework.security.oauth2.core.oidc.OidcUserInfo"),
+				TypeReference.of("org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest"),
+				TypeReference.of("org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponseType"),
 				TypeReference.of("org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken"),
+				TypeReference.of("org.springframework.security.oauth2.client.OAuth2AuthorizedClient"),
 				TypeReference
 					.of("org.springframework.security.oauth2.client.authentication.OAuth2LoginAuthenticationToken"),
 				TypeReference
 					.of("org.springframework.security.oauth2.client.authentication.OAuth2AuthorizationCodeAuthenticationToken"),
-				TypeReference.of("org.springframework.security.oauth2.core.OAuth2AuthenticationException"))
+				TypeReference.of("org.springframework.security.oauth2.client.registration.ClientRegistration"),
+				TypeReference
+					.of("org.springframework.security.oauth2.client.registration.ClientRegistration$ProviderDetails"),
+				TypeReference
+					.of("org.springframework.security.oauth2.client.registration.ClientRegistration$ProviderDetails$UserInfoEndpoint"),
+				TypeReference.of("net.minidev.json.JSONObject"),
+				TypeReference.of("com.nimbusds.oauth2.sdk.util.OrderedJSONObject"))
 			.forEach((type) -> hints.serialization()
 				.registerType(type, (hint) -> hint.onReachableType(TypeReference
 					.of("org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken"))));

--- a/spring-session-core/src/main/java/org/springframework/session/aot/hint/CommonSessionSecurityRuntimeHints.java
+++ b/spring-session-core/src/main/java/org/springframework/session/aot/hint/CommonSessionSecurityRuntimeHints.java
@@ -57,7 +57,7 @@ class CommonSessionSecurityRuntimeHints implements RuntimeHintsRegistrar {
 				TypeReference
 					.of("org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationException"),
 				TypeReference.of("org.springframework.security.core.userdetails.User$AuthorityComparator"))
-			.forEach((type) -> hints.serialization()
+			.forEach((type) -> hints.reflection()
 				.registerType(type, (hint) -> hint.onReachableType(
 						TypeReference.of("org.springframework.security.core.context.SecurityContextImpl"))));
 	}
@@ -68,7 +68,7 @@ class CommonSessionSecurityRuntimeHints implements RuntimeHintsRegistrar {
 				TypeReference
 					.of("org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken"),
 				TypeReference.of("org.springframework.security.oauth2.core.OAuth2AuthenticationException"))
-			.forEach((type) -> hints.serialization()
+			.forEach((type) -> hints.reflection()
 				.registerType(type, (hint) -> hint.onReachableType(TypeReference
 					.of("org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken"))));
 	}
@@ -103,7 +103,7 @@ class CommonSessionSecurityRuntimeHints implements RuntimeHintsRegistrar {
 					.of("org.springframework.security.oauth2.client.registration.ClientRegistration$ProviderDetails$UserInfoEndpoint"),
 				TypeReference.of("net.minidev.json.JSONObject"),
 				TypeReference.of("com.nimbusds.oauth2.sdk.util.OrderedJSONObject"))
-			.forEach((type) -> hints.serialization()
+			.forEach((type) -> hints.reflection()
 				.registerType(type, (hint) -> hint.onReachableType(TypeReference
 					.of("org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken"))));
 	}

--- a/spring-session-core/src/main/java/org/springframework/session/aot/hint/server/WebSessionSecurityRuntimeHints.java
+++ b/spring-session-core/src/main/java/org/springframework/session/aot/hint/server/WebSessionSecurityRuntimeHints.java
@@ -34,7 +34,7 @@ class WebSessionSecurityRuntimeHints implements RuntimeHintsRegistrar {
 			.isPresent("org.springframework.security.web.server.csrf.DefaultCsrfToken", classLoader)) {
 			return;
 		}
-		hints.serialization().registerType(DefaultCsrfToken.class);
+		hints.reflection().registerType(DefaultCsrfToken.class);
 	}
 
 }

--- a/spring-session-core/src/main/java/org/springframework/session/aot/hint/servlet/HttpSessionSecurityRuntimeHints.java
+++ b/spring-session-core/src/main/java/org/springframework/session/aot/hint/servlet/HttpSessionSecurityRuntimeHints.java
@@ -47,7 +47,7 @@ class HttpSessionSecurityRuntimeHints implements RuntimeHintsRegistrar {
 					TypeReference.of(DefaultSavedRequest.class), TypeReference.of(DefaultCsrfToken.class),
 					TypeReference.of(WebAuthenticationDetails.class), TypeReference.of(SavedCookie.class),
 					TypeReference.of("java.lang.String$CaseInsensitiveComparator"))
-			.forEach(hints.serialization()::registerType);
+			.forEach(hints.reflection()::registerType);
 	}
 
 }

--- a/spring-session-core/src/test/java/org/springframework/session/aot/hint/CommonSessionRuntimeHintsTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/aot/hint/CommonSessionRuntimeHintsTests.java
@@ -47,7 +47,7 @@ class CommonSessionRuntimeHintsTests {
 	@MethodSource("getSerializationHintTypes")
 	void commonSessionTypesHasHints(TypeReference typeReference) {
 		this.commonSessionRuntimeHints.registerHints(this.hints, getClass().getClassLoader());
-		assertThat(RuntimeHintsPredicates.serialization().onType(typeReference)).accepts(this.hints);
+		assertThat(RuntimeHintsPredicates.reflection().onType(typeReference)).accepts(this.hints);
 	}
 
 	@Test

--- a/spring-session-core/src/test/java/org/springframework/session/aot/hint/CommonSessionSecurityRuntimeHintsTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/aot/hint/CommonSessionSecurityRuntimeHintsTests.java
@@ -45,7 +45,7 @@ class CommonSessionSecurityRuntimeHintsTests {
 	@MethodSource("getSerializationHintTypes")
 	void commonSecurityTypesHasHints(TypeReference typeReference) {
 		this.commonSessionSecurityRuntimeHints.registerHints(this.hints, getClass().getClassLoader());
-		assertThat(RuntimeHintsPredicates.serialization().onType(typeReference)).accepts(this.hints);
+		assertThat(RuntimeHintsPredicates.reflection().onType(typeReference)).accepts(this.hints);
 	}
 
 	@Test

--- a/spring-session-core/src/test/java/org/springframework/session/aot/hint/server/WebSessionSecurityRuntimeHintsTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/aot/hint/server/WebSessionSecurityRuntimeHintsTests.java
@@ -45,7 +45,7 @@ class WebSessionSecurityRuntimeHintsTests {
 	@Test
 	void defaultCsrfTokenHasHints() {
 		this.webSessionSecurityRuntimeHints.registerHints(this.hints, getClass().getClassLoader());
-		assertThat(RuntimeHintsPredicates.serialization().onType(DefaultCsrfToken.class)).accepts(this.hints);
+		assertThat(RuntimeHintsPredicates.reflection().onType(DefaultCsrfToken.class)).accepts(this.hints);
 	}
 
 	@Test
@@ -54,7 +54,7 @@ class WebSessionSecurityRuntimeHintsTests {
 			classUtilsMock.when(() -> ClassUtils.isPresent(eq("org.springframework.web.server.WebSession"), any()))
 				.thenReturn(false);
 			this.webSessionSecurityRuntimeHints.registerHints(this.hints, getClass().getClassLoader());
-			assertThat(this.hints.serialization().javaSerializationHints()).isEmpty();
+			assertThat(this.hints.reflection().typeHints()).isEmpty();
 		}
 	}
 
@@ -66,7 +66,7 @@ class WebSessionSecurityRuntimeHintsTests {
 						any()))
 				.thenReturn(false);
 			this.webSessionSecurityRuntimeHints.registerHints(this.hints, getClass().getClassLoader());
-			assertThat(this.hints.serialization().javaSerializationHints()).isEmpty();
+			assertThat(this.hints.reflection().typeHints()).isEmpty();
 		}
 	}
 

--- a/spring-session-core/src/test/java/org/springframework/session/aot/hint/servlet/HttpSessionSecurityRuntimeHintsTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/aot/hint/servlet/HttpSessionSecurityRuntimeHintsTests.java
@@ -56,7 +56,7 @@ class HttpSessionSecurityRuntimeHintsTests {
 	@MethodSource("getSerializationHintTypes")
 	void httpSessionHasHints(TypeReference typeReference) {
 		this.httpSessionSecurityRuntimeHints.registerHints(this.hints, getClass().getClassLoader());
-		assertThat(RuntimeHintsPredicates.serialization().onType(typeReference)).accepts(this.hints);
+		assertThat(RuntimeHintsPredicates.reflection().onType(typeReference)).accepts(this.hints);
 	}
 
 	@Test
@@ -65,7 +65,7 @@ class HttpSessionSecurityRuntimeHintsTests {
 			classUtilsMock.when(() -> ClassUtils.isPresent(eq("jakarta.servlet.http.HttpSession"), any()))
 				.thenReturn(false);
 			this.httpSessionSecurityRuntimeHints.registerHints(this.hints, getClass().getClassLoader());
-			assertThat(this.hints.serialization().javaSerializationHints()).isEmpty();
+			assertThat(this.hints.reflection().typeHints()).isEmpty();
 		}
 	}
 
@@ -76,7 +76,7 @@ class HttpSessionSecurityRuntimeHintsTests {
 				.when(() -> ClassUtils.isPresent(eq("org.springframework.security.web.csrf.DefaultCsrfToken"), any()))
 				.thenReturn(false);
 			this.httpSessionSecurityRuntimeHints.registerHints(this.hints, getClass().getClassLoader());
-			assertThat(this.hints.serialization().javaSerializationHints()).isEmpty();
+			assertThat(this.hints.reflection().typeHints()).isEmpty();
 		}
 	}
 


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

Add missing aot hints.
The used application (for which the hints where missing) is a Spring cloud-gateway with spring-session-hazelcast.
See https://github.com/it-at-m/refarch/tree/main/refarch-gateway
and https://github.com/it-at-m/refarch/pull/28 (for an working branch with changes as serialization-config).

### Reference

Issue closes #3103 