### PR TITLE
Fix #3622: Ensure SameSite is Lax when null is provided to DefaultCookieSerializer

### DIFF
--- a/spring-session-core/src/main/java/org/springframework/session/web/http/DefaultCookieSerializer.java
+++ b/spring-session-core/src/main/java/org/springframework/session/web/http/DefaultCookieSerializer.java
@@ -40,6 +40,7 @@ import org.apache.commons.logging.LogFactory;
  * @author Rob Winch
  * @author Vedran Pavic
  * @author Eddú Meléndez
+ * @author Khyojae
  * @since 1.1
  */
 public class DefaultCookieSerializer implements CookieSerializer {
@@ -410,6 +411,10 @@ public class DefaultCookieSerializer implements CookieSerializer {
 	 * @since 2.1.0
 	 */
 	public void setSameSite(String sameSite) {
+		if (sameSite == null) {
+			this.sameSite = "Lax";
+			return;
+		}
 		this.sameSite = sameSite;
 	}
 

--- a/spring-session-core/src/test/java/org/springframework/session/web/http/DefaultCookieSerializerTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/web/http/DefaultCookieSerializerTests.java
@@ -45,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * @author Rob Winch
  * @author Vedran Pavic
  * @author Eddú Meléndez
+ * @author Khyojae
  */
 class DefaultCookieSerializerTests {
 
@@ -459,6 +460,22 @@ class DefaultCookieSerializerTests {
 		this.serializer.writeCookieValue(cookieValue(this.sessionId));
 		assertThat(getCookie().getSameSite()).isNull();
 	}
+
+
+
+
+	@Test
+	void writeCookieShouldUseDefaultSameSiteWhenNotSet() {
+		DefaultCookieSerializer serializer = new DefaultCookieSerializer();
+		serializer.setSameSite(null);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		serializer.writeCookieValue(new CookieValue(request, response, "test-id"));
+
+		assertThat(response.getHeader("Set-Cookie")).contains("SameSite=Lax");
+	}
+
 
 	void setCookieName(String cookieName) {
 		this.cookieName = cookieName;


### PR DESCRIPTION
Resolves #3622

This PR ensures that `DefaultCookieSerializer` falls back to the default "Lax" SameSite attribute when `null` is explicitly provided. This prevents the SameSite attribute from being omitted in certain auto-configuration scenarios in Spring Boot 3.3+.

I've also added a regression test to verify this behavior.