### PR TITLE
Document community extensions for MongoDB and Hazelcast

### DIFF
--- a/spring-session-docs/modules/ROOT/pages/index.adoc
+++ b/spring-session-docs/modules/ROOT/pages/index.adoc
@@ -100,6 +100,12 @@ Spring Session is Open Source software released under the https://www.apache.org
 | Spring Session Caffeine
 | https://github.com/gotson/spring-session-caffeine
 
+| Spring Session MongoDB
+| https://github.com/mongodb/mongo-spring-session
+
+| Spring Session Hazelcast
+| https://github.com/hazelcast-guides/spring-session-hazelcast
+
 |===
 
 [[minimum-requirements]]


### PR DESCRIPTION
### Description
This PR updates the Reference Documentation (`index.adoc`) to include the missing Community Extensions for **MongoDB** and **Hazelcast**.

Previously, these extensions were not listed in the "Community Extensions" table. I have added links pointing to the currently active repositories maintained by the respective vendors:
- **MongoDB:** `mongodb/mongo-spring-session`
- **Hazelcast:** `hazelcast/hazelcast-spring-session`

### Related Issue
Closes gh-3604