### PR TITLE
Fixup JdbcIndexedSessionRepository - multiple sessions for ID

### DIFF
--- a/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcIndexedSessionRepository.java
+++ b/spring-session-jdbc/src/main/java/org/springframework/session/jdbc/JdbcIndexedSessionRepository.java
@@ -486,6 +486,9 @@ public class JdbcIndexedSessionRepository implements
 			if (sessions.isEmpty()) {
 				return null;
 			}
+			if (sessions.size() > 1) {
+				logger.warn("Found " + sessions.size() + " sessions for id " + id + ". Returning the first one.");
+			}
 			return sessions.get(0);
 		});
 
@@ -982,13 +985,13 @@ public class JdbcIndexedSessionRepository implements
 					delegate.setLastAccessedTime(Instant.ofEpochMilli(rs.getLong("LAST_ACCESS_TIME")));
 					delegate.setMaxInactiveInterval(Duration.ofSeconds(rs.getInt("MAX_INACTIVE_INTERVAL")));
 					session = new JdbcSession(delegate, primaryKey, false);
+					sessions.add(session);
 				}
 				String attributeName = rs.getString("ATTRIBUTE_NAME");
 				if (attributeName != null) {
 					byte[] bytes = getLobHandler().getBlobAsBytes(rs, "ATTRIBUTE_BYTES");
 					session.delegate.setAttribute(attributeName, lazily(() -> deserialize(bytes)));
 				}
-				sessions.add(session);
 			}
 			return sessions;
 		}


### PR DESCRIPTION
SessionResultSetExtractor#extractData should not return a list containing multiple entries for the same JdbcSession This is confusing when debugging the code.

Add a warning when >1 session is found for the same ID. This is an indicator that data is corrupt; most of the schemas prevent at the database level by adding a unique constraint to the primary ID column. If the code encounters this scenario; it should fail fast, however this might be a breaking change. A WARN level logging helps developers initially spot this situation and remedy.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
