### PR TITLE
Fix session cookie writes for string responses

### DIFF
--- a/spring-session-core/src/main/java/org/springframework/session/web/http/OnCommittedResponseWrapper.java
+++ b/spring-session-core/src/main/java/org/springframework/session/web/http/OnCommittedResponseWrapper.java
@@ -43,6 +43,8 @@ abstract class OnCommittedResponseWrapper extends HttpServletResponseWrapper {
 	 */
 	private long contentLength;
 
+	private boolean contentLengthSet;
+
 	/**
 	 * The size of data written to the response body. The field will only be updated when
 	 * {@link #disableOnCommitted} is false.
@@ -107,7 +109,8 @@ abstract class OnCommittedResponseWrapper extends HttpServletResponseWrapper {
 
 	private void setContentLength(long len) {
 		this.contentLength = len;
-		checkContentLength(0);
+		this.contentLengthSet = true;
+		checkContentLength(0, false);
 	}
 
 	/**
@@ -259,8 +262,13 @@ abstract class OnCommittedResponseWrapper extends HttpServletResponseWrapper {
 	 * @param contentLengthToWrite the size of the content that is about to be written.
 	 */
 	private void checkContentLength(long contentLengthToWrite) {
+		checkContentLength(contentLengthToWrite, true);
+	}
+
+	private void checkContentLength(long contentLengthToWrite, boolean bodyWriteOccurred) {
 		this.contentWritten += contentLengthToWrite;
-		boolean isBodyFullyWritten = this.contentLength > 0 && this.contentWritten >= this.contentLength;
+		boolean isBodyFullyWritten = this.contentLengthSet && this.contentWritten >= this.contentLength
+				&& (this.contentLength > 0 || bodyWriteOccurred);
 		int bufferSize = getBufferSize();
 		boolean requiresFlush = bufferSize > 0 && this.contentWritten >= bufferSize;
 		if (isBodyFullyWritten || requiresFlush) {

--- a/spring-session-core/src/test/java/org/springframework/session/web/http/OnCommittedResponseWrapperTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/web/http/OnCommittedResponseWrapperTests.java
@@ -632,6 +632,33 @@ class OnCommittedResponseWrapperTests {
 	}
 
 	@Test
+	void explicitZeroContentLengthPrintWriterWriteStringCommits() throws IOException {
+		this.response.setContentLength(0);
+
+		this.response.getWriter().write("ok");
+
+		assertThat(this.committed).isTrue();
+	}
+
+	@Test
+	void explicitZeroContentLengthPrintWriterWriteEmptyStringCommits() throws IOException {
+		this.response.setContentLength(0);
+
+		this.response.getWriter().write("");
+
+		assertThat(this.committed).isTrue();
+	}
+
+	@Test
+	void explicitZeroContentLengthOutputStreamWriteEmptyByteArrayCommits() throws IOException {
+		this.response.setContentLength(0);
+
+		this.response.getOutputStream().write(new byte[0]);
+
+		assertThat(this.committed).isTrue();
+	}
+
+	@Test
 	void printWriterWriteStringDoesNotCommit() throws IOException {
 		String body = "something";
 

--- a/spring-session-core/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
+++ b/spring-session-core/src/test/java/org/springframework/session/web/http/SessionRepositoryFilterTests.java
@@ -17,6 +17,7 @@
 package org.springframework.session.web.http;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -969,6 +970,36 @@ class SessionRepositoryFilterTests {
 				String id = wrappedRequest.getSession().getId();
 				wrappedResponse.getWriter().close();
 				assertThat(SessionRepositoryFilterTests.this.sessionRepository.findById(id)).isNotNull();
+			}
+		});
+	}
+
+	@Test
+	void doFilterOutputWriteWithExplicitZeroContentLengthCommitsSession() throws Exception {
+		doFilter(new DoInFilter() {
+			@Override
+			public void doFilter(HttpServletRequest wrappedRequest, HttpServletResponse wrappedResponse)
+					throws IOException {
+				String id = wrappedRequest.getSession().getId();
+				wrappedResponse.setContentLength(0);
+				wrappedResponse.getOutputStream().write("ok".getBytes(StandardCharsets.UTF_8));
+				assertThat(SessionRepositoryFilterTests.this.sessionRepository.findById(id)).isNotNull();
+				assertThat(SessionRepositoryFilterTests.this.response.getCookie("SESSION")).isNotNull();
+			}
+		});
+	}
+
+	@Test
+	void doFilterOutputWriteEmptyBodyWithExplicitZeroContentLengthCommitsSession() throws Exception {
+		doFilter(new DoInFilter() {
+			@Override
+			public void doFilter(HttpServletRequest wrappedRequest, HttpServletResponse wrappedResponse)
+					throws IOException {
+				String id = wrappedRequest.getSession().getId();
+				wrappedResponse.setContentLength(0);
+				wrappedResponse.getOutputStream().write(new byte[0]);
+				assertThat(SessionRepositoryFilterTests.this.sessionRepository.findById(id)).isNotNull();
+				assertThat(SessionRepositoryFilterTests.this.response.getCookie("SESSION")).isNotNull();
 			}
 		});
 	}

--- a/spring-session-samples/spring-session-sample-boot-jdbc/src/integration-test/java/sample/BootTests.java
+++ b/spring-session-samples/spring-session-sample-boot-jdbc/src/integration-test/java/sample/BootTests.java
@@ -32,6 +32,11 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.htmlunit.webdriver.MockMvcHtmlUnitDriverBuilder;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 /**
  * @author Eddú Meléndez
  * @author Vedran Pavic
@@ -80,6 +85,15 @@ class BootTests {
 		HomePage home = login.form().login(HomePage.class);
 		login = home.logout();
 		login.assertAt();
+	}
+
+	@Test
+	void stringResponseSetsSessionCookie() throws Exception {
+		this.mockMvc.perform(get("/string"))
+			.andExpect(status().isOk())
+			.andExpect(content().string("ok"))
+			.andExpect(cookie().exists("SESSION"))
+			.andExpect(cookie().doesNotExist("JSESSIONID"));
 	}
 
 }

--- a/spring-session-samples/spring-session-sample-boot-jdbc/src/main/java/sample/IndexController.java
+++ b/spring-session-samples/spring-session-sample-boot-jdbc/src/main/java/sample/IndexController.java
@@ -16,7 +16,10 @@
 
 package sample;
 
+import jakarta.servlet.http.HttpSession;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
@@ -31,6 +34,13 @@ public class IndexController {
 	@RequestMapping("/")
 	public String index() {
 		return "index";
+	}
+
+	@GetMapping("/string")
+	@ResponseBody
+	public String string(HttpSession session) {
+		session.setAttribute("sample", "value");
+		return "ok";
 	}
 
 }

--- a/spring-session-samples/spring-session-sample-boot-jdbc/src/main/java/sample/config/SecurityConfig.java
+++ b/spring-session-samples/spring-session-sample-boot-jdbc/src/main/java/sample/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
 		return http
 			.authorizeHttpRequests((authorize) -> authorize
 				.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+				.requestMatchers("/string").permitAll()
 				.anyRequest().authenticated()
 			)
 			.formLogin((formLogin) -> formLogin

--- a/spring-session-samples/spring-session-sample-boot-redis/src/integration-test/java/sample/BootTests.java
+++ b/spring-session-samples/spring-session-sample-boot-redis/src/integration-test/java/sample/BootTests.java
@@ -36,6 +36,11 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.htmlunit.webdriver.MockMvcHtmlUnitDriverBuilder;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 /**
  * @author Eddú Meléndez
  * @author Vedran Pavic
@@ -83,6 +88,15 @@ class BootTests {
 		HomePage home = login.form().login(HomePage.class);
 		home.logout();
 		login.assertAt();
+	}
+
+	@Test
+	void stringResponseSetsSessionCookie() throws Exception {
+		this.mockMvc.perform(get("/string"))
+			.andExpect(status().isOk())
+			.andExpect(content().string("ok"))
+			.andExpect(cookie().exists("SESSION"))
+			.andExpect(cookie().doesNotExist("JSESSIONID"));
 	}
 
 	@TestConfiguration

--- a/spring-session-samples/spring-session-sample-boot-redis/src/main/java/sample/config/IndexController.java
+++ b/spring-session-samples/spring-session-sample-boot-redis/src/main/java/sample/config/IndexController.java
@@ -16,8 +16,10 @@
 
 package sample.config;
 
+import jakarta.servlet.http.HttpSession;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
  * An index controller.
@@ -30,6 +32,13 @@ public class IndexController {
 	@GetMapping("/")
 	String index() {
 		return "index";
+	}
+
+	@GetMapping("/string")
+	@ResponseBody
+	String string(HttpSession session) {
+		session.setAttribute("sample", "value");
+		return "ok";
 	}
 
 }

--- a/spring-session-samples/spring-session-sample-boot-redis/src/main/java/sample/config/SecurityConfig.java
+++ b/spring-session-samples/spring-session-sample-boot-redis/src/main/java/sample/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
 		return http
 			.authorizeHttpRequests((authorize) -> authorize
 				.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+				.requestMatchers("/string").permitAll()
 				.anyRequest().authenticated()
 			)
 			.formLogin((formLogin) -> formLogin


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Session. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

## Summary
- fix `OnCommittedResponseWrapper` so Spring Session commits once an explicitly zero content-length response performs a body write
- add core regressions for string and empty-body cases that previously missed the early session commit path
- include JDBC and Redis sample checks as proof-of-concept verification that a plain `String` response writes the `SESSION` cookie

Fixes #3755

## Notes
- the main fix is isolated to `spring-session-core`
- the sample changes are included only as additional verification of the reported behavior
- if you would prefer to keep the PR scoped to the core fix and regressions, I can drop the sample changes

## Testing
- [x] `.\gradlew.bat :spring-session-core:test --tests "org.springframework.session.web.http.OnCommittedResponseWrapperTests" --tests "org.springframework.session.web.http.SessionRepositoryFilterTests"`
- [x] `.\gradlew.bat :spring-session-core:build`
- [x] `.\gradlew.bat :spring-session-sample-boot-jdbc:integrationTest --tests "sample.BootTests.stringResponseSetsSessionCookie"`
- [x] `.\gradlew.bat :spring-session-sample-boot-redis:integrationTest --tests "sample.BootTests.stringResponseSetsSessionCookie"`
