### PR TITLE
Removed unnecessary parentheses around lambda value in SafeRedisSessionMapper example

### DIFF
--- a/spring-session-docs/modules/ROOT/pages/configuration/redis.adoc
+++ b/spring-session-docs/modules/ROOT/pages/configuration/redis.adoc
@@ -301,7 +301,7 @@ public class SessionConfig {
 
     @Bean
     SessionRepositoryCustomizer<RedisSessionRepository> redisSessionRepositoryCustomizer() {
-        return (redisSessionRepository) -> redisSessionRepository
+        return redisSessionRepository -> redisSessionRepository
                 .setRedisSessionMapper(new SafeRedisSessionMapper(redisSessionRepository));
     }
 


### PR DESCRIPTION
There was unnecessary parentheses around lambda value which is removed in this PR. It was the checkstyle rule `UnnecessaryParentheses` which notified me about this.