### PR TITLE
feat: implement RedisSessionRepository and RedisIndexedSessionReposit…

### DIFF
--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
@@ -334,7 +334,7 @@ public class RedisIndexedSessionRepository
 
 	private SessionIdGenerator sessionIdGenerator = UuidSessionIdGenerator.getInstance();
 
-	private BiFunction<String, Map<String, Object>, MapSession> redisSessionMapper = new RedisSessionMapper();
+	private BiFunction<String, Map<String, Object>, @Nullable MapSession> redisSessionMapper = new RedisSessionMapper();
 
 	/**
 	 * Creates a new instance. For an example, refer to the class level javadoc.
@@ -761,7 +761,7 @@ public class RedisIndexedSessionRepository
 	 * @param redisSessionMapper the mapper to use, cannot be null
 	 * @since 3.2
 	 */
-	public void setRedisSessionMapper(BiFunction<String, Map<String, Object>, MapSession> redisSessionMapper) {
+	public void setRedisSessionMapper(BiFunction<String, Map<String, Object>, @Nullable MapSession> redisSessionMapper) {
 		Assert.notNull(redisSessionMapper, "redisSessionMapper cannot be null");
 		this.redisSessionMapper = redisSessionMapper;
 	}

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisSessionRepository.java
@@ -63,7 +63,7 @@ public class RedisSessionRepository implements SessionRepository<RedisSessionRep
 
 	private SessionIdGenerator sessionIdGenerator = UuidSessionIdGenerator.getInstance();
 
-	private BiFunction<String, Map<String, Object>, MapSession> redisSessionMapper = new RedisSessionMapper();
+	private BiFunction<String, Map<String, Object>, @Nullable MapSession> redisSessionMapper = new RedisSessionMapper();
 
 	/**
 	 * Create a new {@link RedisSessionRepository} instance.
@@ -187,7 +187,7 @@ public class RedisSessionRepository implements SessionRepository<RedisSessionRep
 	 * @param redisSessionMapper the mapper to use, cannot be null
 	 * @since 3.2
 	 */
-	public void setRedisSessionMapper(BiFunction<String, Map<String, Object>, MapSession> redisSessionMapper) {
+	public void setRedisSessionMapper(BiFunction<String, Map<String, Object>, @Nullable MapSession> redisSessionMapper) {
 		Assert.notNull(redisSessionMapper, "redisSessionMapper cannot be null");
 		this.redisSessionMapper = redisSessionMapper;
 	}

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryTests.java
@@ -960,6 +960,20 @@ class RedisIndexedSessionRepositoryTests {
 		assertThat(newSessionId).isEqualTo("test");
 	}
 
+	@Test
+	void findByIdWhenRedisSessionMapperReturnsNullThenReturnsNull() {
+		String sessionId = "session-id";
+		given(this.redisOperations.<String, Object>boundHashOps(getKey(sessionId)))
+			.willReturn(this.boundHashOperations);
+		Map<String, Object> map = map(RedisSessionMapper.CREATION_TIME_KEY, Instant.EPOCH.toEpochMilli(),
+				RedisSessionMapper.MAX_INACTIVE_INTERVAL_KEY, 1, RedisSessionMapper.LAST_ACCESSED_TIME_KEY,
+				Instant.now().toEpochMilli());
+		given(this.boundHashOperations.entries()).willReturn(map);
+		this.redisRepository.setRedisSessionMapper((id, entries) -> null);
+
+		assertThat(this.redisRepository.findById(sessionId)).isNull();
+	}
+
 	private String getKey(String id) {
 		return "spring:session:sessions:" + id;
 	}

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisSessionRepositoryTests.java
@@ -399,6 +399,17 @@ class RedisSessionRepositoryTests {
 		assertThat(session.changeSessionId()).isEqualTo("test");
 	}
 
+	@Test
+	void findByIdWhenRedisSessionMapperReturnsNullThenReturnsNull() {
+		given(this.sessionHashOperations.entries(eq(TEST_SESSION_KEY)))
+			.willReturn(mapOf(RedisSessionMapper.CREATION_TIME_KEY, Instant.EPOCH.toEpochMilli(),
+					RedisSessionMapper.LAST_ACCESSED_TIME_KEY, Instant.now().toEpochMilli(),
+					RedisSessionMapper.MAX_INACTIVE_INTERVAL_KEY, MapSession.DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS));
+		this.sessionRepository.setRedisSessionMapper((id, entries) -> null);
+
+		assertThat(this.sessionRepository.findById(TEST_SESSION_ID)).isNull();
+	}
+
 	private static String getSessionKey(String sessionId) {
 		return "spring:session:sessions:" + sessionId;
 	}


### PR DESCRIPTION
This change annotates the BiFunction return type of redisSessionMapper as nullable.

The implementation already supports null values in getSession(), but the public API
currently exposes a non-null return type, preventing Kotlin users from supplying
custom mappers that return null.

This change restores Kotlin interoperability while preserving the existing behavior.