### PR TITLE
SortedSetRedisSessionExpirationStore should touch the expires key

### DIFF
--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/SortedSetRedisSessionExpirationStore.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/SortedSetRedisSessionExpirationStore.java
@@ -75,8 +75,8 @@ public class SortedSetRedisSessionExpirationStore implements RedisSessionExpirat
 
 	/**
 	 * Retrieves the sessions that are expected to be expired and invoke
-	 * {@link #touch(String)} on each of the session keys, resolved via
-	 * {@link #getSessionKey(String)}.
+	 * {@link #touch(String)} on each of the expired keys, resolved via
+	 * {@link #getExpiredKey(String)}.
 	 */
 	@Override
 	public void cleanupExpiredSessions() {
@@ -86,8 +86,8 @@ public class SortedSetRedisSessionExpirationStore implements RedisSessionExpirat
 			return;
 		}
 		for (Object sessionId : sessionIds) {
-			String sessionKey = getSessionKey((String) sessionId);
-			touch(sessionKey);
+			String expiredKey = getExpiredKey((String) sessionId);
+			touch(expiredKey);
 		}
 	}
 
@@ -105,8 +105,8 @@ public class SortedSetRedisSessionExpirationStore implements RedisSessionExpirat
 		this.redisOps.hasKey(sessionKey);
 	}
 
-	private String getSessionKey(String sessionId) {
-		return this.namespace + ":sessions:" + sessionId;
+	private String getExpiredKey(String sessionId) {
+		return this.namespace + ":sessions:expires:" + sessionId;
 	}
 
 	/**

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/SortedSetRedisSessionExpirationStoreTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/SortedSetRedisSessionExpirationStoreTests.java
@@ -78,9 +78,9 @@ class SortedSetRedisSessionExpirationStoreTests {
 			.reverseRangeByScore(anyString(), anyDouble(), anyDouble(), anyLong(), anyLong()))
 			.willReturn(Set.of("1", "2", "3"));
 		this.expirationStore.cleanupExpiredSessions();
-		verify(this.redisTemplate).hasKey("spring:session:sessions:1");
-		verify(this.redisTemplate).hasKey("spring:session:sessions:2");
-		verify(this.redisTemplate).hasKey("spring:session:sessions:3");
+		verify(this.redisTemplate).hasKey("spring:session:sessions:expires:1");
+		verify(this.redisTemplate).hasKey("spring:session:sessions:expires:2");
+		verify(this.redisTemplate).hasKey("spring:session:sessions:expires:3");
 	}
 
 }


### PR DESCRIPTION
`SortedSetRedisSessionExpirationStore#cleanupExpiredSessions` touches the session key (`<namespace>:sessions:<id>`) instead of the expires shadow key (`<namespace>:sessions:expires:<id>`).

`RedisIndexedSessionRepository#onMessage` only handles keyspace events whose key starts with the `sessions:expires:` prefix. Because the store touches the session key, expiration does not produce an event that matches that prefix, so `SessionDeletedEvent` and `SessionExpiredEvent` are not published for sessions tracked by this store. The principal index cleanup and the removal from the expiration sorted set run from that same `onMessage` handler, so they do not happen either.

This affects `RedisIndexedSessionRepository` when it is configured with `SortedSetRedisSessionExpirationStore`. `MinuteBasedRedisSessionExpirationStore` and the reactive `SortedSetReactiveRedisSessionExpirationStore` both touch the expires key and are not affected.

### Change

`cleanupExpiredSessions` now touches `<namespace>:sessions:expires:<id>`, which matches the prefix that `onMessage` listens on and is consistent with the other two stores. The existing private helper was renamed from `getSessionKey` to `getExpiredKey` to reflect the key it builds and to match the naming used in `RedisIndexedSessionRepository` and `ReactiveRedisIndexedSessionRepository`.

### Testing

- Updated `SortedSetRedisSessionExpirationStoreTests#cleanupExpiredSessionsThenTouchExpiredSessions` to assert that the expires key is touched. It fails before the change and passes after.
- `./gradlew :spring-session-data-redis:test` passes.
- `./gradlew :spring-session-data-redis:integrationTest --tests "*SortedSetRedisSessionExpirationStoreITests"` passes.
- checkstyle and Spring Java Format checks pass for the changed files.

Closes gh-3468

cc @rwinch
