### PR TITLE
Annotate DefaultCookieSerializer.setCookiePath as @Nullable

### DIFF
--- a/spring-session-core/src/main/java/org/springframework/session/web/http/DefaultCookieSerializer.java
+++ b/spring-session-core/src/main/java/org/springframework/session/web/http/DefaultCookieSerializer.java
@@ -296,7 +296,7 @@ public class DefaultCookieSerializer implements CookieSerializer {
 	 * @param cookiePath the path of the Cookie. If null, the default of the context path
 	 * will be used.
 	 */
-	public void setCookiePath(String cookiePath) {
+	public void setCookiePath(@Nullable String cookiePath) {
 		this.cookiePath = cookiePath;
 	}
 


### PR DESCRIPTION
## Summary
`DefaultCookieSerializer.setCookiePath(String)` was missing `@Nullable` even though the field is `@Nullable` and the javadoc documents null as valid. Aligns with `setSameSite(@Nullable String)`.

Fixes #3883

## Test plan
- [x] `./gradlew :spring-session-core:test --tests DefaultCookieSerializerTests` (existing coverage of `setCookiePath(null)`)
