### PR TITLE
GH-3857: Allow redisSessionMapper to return null MapSession

### DIFF
--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisIndexedSessionRepository.java
@@ -334,7 +334,7 @@ public class RedisIndexedSessionRepository
 
 	private SessionIdGenerator sessionIdGenerator = UuidSessionIdGenerator.getInstance();
 
-	private BiFunction<String, Map<String, Object>, MapSession> redisSessionMapper = new RedisSessionMapper();
+	private BiFunction<String, Map<String, Object>, @Nullable MapSession> redisSessionMapper = new RedisSessionMapper();
 
 	/**
 	 * Creates a new instance. For an example, refer to the class level javadoc.
@@ -757,11 +757,15 @@ public class RedisIndexedSessionRepository
 
 	/**
 	 * Set the {@link BiFunction} used to map {@link MapSession} to a
-	 * {@link ReactiveRedisSessionRepository.RedisSession}.
+	 * {@link ReactiveRedisSessionRepository.RedisSession}. The mapper may return
+	 * {@code null} to indicate that the session could not be loaded (for example when the
+	 * Redis hash is incomplete); callers treat a {@code null} result the same as a
+	 * missing session.
 	 * @param redisSessionMapper the mapper to use, cannot be null
 	 * @since 3.2
 	 */
-	public void setRedisSessionMapper(BiFunction<String, Map<String, Object>, MapSession> redisSessionMapper) {
+	public void setRedisSessionMapper(
+			BiFunction<String, Map<String, Object>, @Nullable MapSession> redisSessionMapper) {
 		Assert.notNull(redisSessionMapper, "redisSessionMapper cannot be null");
 		this.redisSessionMapper = redisSessionMapper;
 	}

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisSessionMapper.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisSessionMapper.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.session.MapSession;
 import org.springframework.session.Session;
 import org.springframework.util.Assert;
@@ -29,12 +31,15 @@ import org.springframework.util.Assert;
 /**
  * A {@link Function} that converts a {@link Map} representing Redis hash to a
  * {@link MapSession}.
+ * <p>
+ * This implementation never returns {@code null}; custom mappers used via
+ * {@code setRedisSessionMapper} may return {@code null} to signal an unloadable session.
  *
  * @author Vedran Pavic
  * @author Marcus da Coregio
  * @since 2.2.0
  */
-public final class RedisSessionMapper implements BiFunction<String, Map<String, Object>, MapSession> {
+public final class RedisSessionMapper implements BiFunction<String, Map<String, Object>, @Nullable MapSession> {
 
 	/**
 	 * The key in the hash representing {@link Session#getCreationTime()}.

--- a/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisSessionRepository.java
+++ b/spring-session-data-redis/src/main/java/org/springframework/session/data/redis/RedisSessionRepository.java
@@ -63,7 +63,7 @@ public class RedisSessionRepository implements SessionRepository<RedisSessionRep
 
 	private SessionIdGenerator sessionIdGenerator = UuidSessionIdGenerator.getInstance();
 
-	private BiFunction<String, Map<String, Object>, MapSession> redisSessionMapper = new RedisSessionMapper();
+	private BiFunction<String, Map<String, Object>, @Nullable MapSession> redisSessionMapper = new RedisSessionMapper();
 
 	/**
 	 * Create a new {@link RedisSessionRepository} instance.
@@ -183,11 +183,15 @@ public class RedisSessionRepository implements SessionRepository<RedisSessionRep
 
 	/**
 	 * Set the {@link BiFunction} used to map {@link MapSession} to a
-	 * {@link ReactiveRedisSessionRepository.RedisSession}.
+	 * {@link ReactiveRedisSessionRepository.RedisSession}. The mapper may return
+	 * {@code null} to indicate that the session could not be loaded (for example when the
+	 * Redis hash is incomplete); callers treat a {@code null} result the same as a
+	 * missing session.
 	 * @param redisSessionMapper the mapper to use, cannot be null
 	 * @since 3.2
 	 */
-	public void setRedisSessionMapper(BiFunction<String, Map<String, Object>, MapSession> redisSessionMapper) {
+	public void setRedisSessionMapper(
+			BiFunction<String, Map<String, Object>, @Nullable MapSession> redisSessionMapper) {
 		Assert.notNull(redisSessionMapper, "redisSessionMapper cannot be null");
 		this.redisSessionMapper = redisSessionMapper;
 	}

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisIndexedSessionRepositoryTests.java
@@ -960,6 +960,20 @@ class RedisIndexedSessionRepositoryTests {
 		assertThat(newSessionId).isEqualTo("test");
 	}
 
+	@Test
+	void findByIdWhenRedisSessionMapperReturnsNullThenReturnsNull() {
+		String sessionId = "session-id";
+		given(this.redisOperations.<String, Object>boundHashOps(getKey(sessionId)))
+			.willReturn(this.boundHashOperations);
+		Map<String, Object> map = map(RedisSessionMapper.CREATION_TIME_KEY, Instant.EPOCH.toEpochMilli(),
+				RedisSessionMapper.MAX_INACTIVE_INTERVAL_KEY, 1, RedisSessionMapper.LAST_ACCESSED_TIME_KEY,
+				Instant.now().toEpochMilli());
+		given(this.boundHashOperations.entries()).willReturn(map);
+		this.redisRepository.setRedisSessionMapper((id, entries) -> null);
+
+		assertThat(this.redisRepository.findById(sessionId)).isNull();
+	}
+
 	private String getKey(String id) {
 		return "spring:session:sessions:" + id;
 	}

--- a/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisSessionRepositoryTests.java
+++ b/spring-session-data-redis/src/test/java/org/springframework/session/data/redis/RedisSessionRepositoryTests.java
@@ -399,6 +399,17 @@ class RedisSessionRepositoryTests {
 		assertThat(session.changeSessionId()).isEqualTo("test");
 	}
 
+	@Test
+	void findByIdWhenRedisSessionMapperReturnsNullThenReturnsNull() {
+		given(this.sessionHashOperations.entries(eq(TEST_SESSION_KEY)))
+			.willReturn(mapOf(RedisSessionMapper.CREATION_TIME_KEY, Instant.EPOCH.toEpochMilli(),
+					RedisSessionMapper.LAST_ACCESSED_TIME_KEY, Instant.now().toEpochMilli(),
+					RedisSessionMapper.MAX_INACTIVE_INTERVAL_KEY, MapSession.DEFAULT_MAX_INACTIVE_INTERVAL_SECONDS));
+		this.sessionRepository.setRedisSessionMapper((id, entries) -> null);
+
+		assertThat(this.sessionRepository.findById(TEST_SESSION_ID)).isNull();
+	}
+
 	private static String getSessionKey(String sessionId) {
 		return "spring:session:sessions:" + sessionId;
 	}


### PR DESCRIPTION
## Summary

`RedisIndexedSessionRepository` and `RedisSessionRepository` already treat a `null` result from `redisSessionMapper` as a missing/unloadable session, but the `BiFunction` return type was declared non-null. That breaks Kotlin nullability when registering custom mappers that return `null` (for example after cleaning up a corrupt Redis hash).

This change annotates the mapper return type as `@Nullable MapSession` on the field and setter (and aligns `RedisSessionMapper`'s `BiFunction` type for NullAway), matching existing runtime behavior.

Fixes #3857

## Changes

- Annotate `redisSessionMapper` field and `setRedisSessionMapper` with `@Nullable MapSession` return type in:
  - `RedisIndexedSessionRepository`
  - `RedisSessionRepository`
- Align `RedisSessionMapper` with `BiFunction<..., @Nullable MapSession>` so the default assignment compiles under NullAway (implementation still never returns null)
- Add unit tests that a mapper returning `null` yields `findById(...) == null`

## Test plan

- [x] `./gradlew :spring-session-data-redis:test --tests RedisIndexedSessionRepositoryTests --tests RedisSessionRepositoryTests` (Temurin 21)
- [x] DCO `Signed-off-by` on commit